### PR TITLE
Revamp scoreboard layout

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -8,36 +8,29 @@
     <div id="scoreboard" class="scoreboard">
       <div class="team">
         <div class="team-name" id="home">Home</div>
-        <div id="scoreHome" class="score">0</div>
+        <div class="score-row">
+          <div id="scoreHome" class="score">0</div>
+          <span id="homeFootball" class="football-icon">🏈</span>
+        </div>
       </div>
-      <div class="time-possession">
+      <div class="time-quarter">
         <div><strong>QTR:</strong> <span id="quarter">1</span></div>
-        <div><strong>Poss:</strong> <span id="possessionIndicator">Home</span></div>
       </div>
       <div class="team">
         <div class="team-name" id="away">Away</div>
-        <div id="scoreAway" class="score">0</div>
+        <div class="score-row">
+          <span id="awayFootball" class="football-icon">🏈</span>
+          <div id="scoreAway" class="score">0</div>
+        </div>
       </div>
     </div>
 
-    <label>Possession:
-      <span id="possession">Loading...</span>
-    </label>
-
-    <label>Select Player:
-      <select id="playerDropdown"></select>
-    </label>
-
-    <div class="info-row">
+    <div class="game-info">
       <span><strong>Down:</strong> <span id="down">...</span></span>
       <span><strong>Distance:</strong> <span id="distance">...</span></span>
-    </div>
-    <div class="info-row">
       <span><strong>Ball On:</strong> <span id="ballOn">...</span></span>
     </div>
 
-    <button onclick="runPlay()">▶️ Run Play</button>
-    <button onclick="nextDrive()">🔁 Next Drive</button>
     <div class="field-wrapper">
       <div id="field3D">
         <!-- Yard lines -->
@@ -65,7 +58,14 @@
         <canvas id="arcCanvas" width="1200" height="180" style="position: absolute; top: 0; left: 0; z-index: 1;"></canvas>
         <div id="catchPoint" style="position: absolute;  font-size: 22px;  color: black;  opacity: 0;  z-index: 4;  pointer-events: none;  transition: opacity 0.5s ease;"></div>
       </div>
-    </div>    
+    </div>
+
+    <label>Select Player:
+      <select id="playerDropdown"></select>
+    </label>
+
+    <button onclick="runPlay()">▶️ Run Play</button>
+    <button onclick="nextDrive()">🔁 Next Drive</button>
 
     <div id="result" class="result-box"></div>
 

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -244,13 +244,13 @@
           document.getElementById("down").innerText = state.Down;
           document.getElementById("distance").innerText = state.Distance;
           document.getElementById("ballOn").innerText = formatBallOn(state.BallOn);
-          document.getElementById("possession").innerText = state.Possession;
           document.getElementById("home").innerText = state.Home;
           document.getElementById("away").innerText = state.Away;
-          document.getElementById("scoreHome").innerText = state.HomeScore
+          document.getElementById("scoreHome").innerText = state.HomeScore;
           document.getElementById("scoreAway").innerText = state.AwayScore;
-          document.getElementById("quarter").innerText = state.Qtr
-          document.getElementById("possessionIndicator").innerText = state.Possession;
+          document.getElementById("quarter").innerText = state.Qtr;
+          document.getElementById("homeFootball").style.visibility = state.Possession === "Home" ? "visible" : "hidden";
+          document.getElementById("awayFootball").style.visibility = state.Possession === "Away" ? "visible" : "hidden";
       }
 
       function updateFrontendStats(player, yards, td) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -170,8 +170,31 @@
         font-size: 28px;
         font-weight: bold;
       }
-      .scoreboard .time-possession {
+      .scoreboard .time-quarter {
         font-size: 14px;
+        text-align: center;
+      }
+      .score-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        justify-content: center;
+      }
+      .football-icon {
+        font-size: 20px;
+        visibility: hidden;
+      }
+      .game-info {
+        display: flex;
+        justify-content: space-between;
+        margin: 10px 0 20px 0;
+        padding: 8px 10px;
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 0 6px rgba(0,0,0,0.1);
+      }
+      .game-info span {
+        flex: 1;
         text-align: center;
       }
 


### PR DESCRIPTION
## Summary
- modernize scoreboard with possession football icons and cleaner quarter display
- show down, distance, and ball-on in a compact row under the scoreboard
- relocate player selection and control buttons beneath the field for a streamlined flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e35df29b083249d39a20ff397becf