### PR TITLE
feat: sync game state to games sheet

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -272,6 +272,38 @@ function updateGameState({ down, distance, ballOn, possession, previous, driveSt
   }
 }
 
+function pushGameState({ gameId, quarter, down, distance, ballOn, homeScore, awayScore, driveStart }) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Games');
+  if (!sheet) {
+    throw new Error("Sheet 'Games' not found.");
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const rowIndex = data.slice(1).findIndex(r => r[0] === gameId);
+  if (rowIndex === -1) {
+    throw new Error("No row found for gameId: " + gameId);
+  }
+
+  const rowNumber = rowIndex + 2;
+  const updates = {
+    Qtr: quarter,
+    Down: down,
+    Distance: distance,
+    BallOn: ballOn,
+    HomeScore: homeScore,
+    AwayScore: awayScore,
+    DriveStart: driveStart
+  };
+
+  Object.keys(updates).forEach(key => {
+    const col = headers.indexOf(key);
+    if (col !== -1) {
+      sheet.getRange(rowNumber, col + 1).setValue(updates[key]);
+    }
+  });
+}
+
 function logPlayResult({ player, playType, yards, down, distance, ballOn }) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("PlayHistory");
   const ts = new Date();

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -237,6 +237,17 @@
           state.Possession = poss;
           state.Previous = previousBallOn;
           state.DriveStart = driveStart;
+
+          google.script.run.pushGameState({
+            gameId: gameId,
+            quarter: state.Qtr,
+            down: state.Down,
+            distance: state.Distance,
+            ballOn: state.BallOn,
+            homeScore: state.HomeScore,
+            awayScore: state.AwayScore,
+            driveStart: state.DriveStart
+          });
       }
 
       function updateStateUI(){


### PR DESCRIPTION
## Summary
- add server function to update Games sheet with current quarter, down, distance, ball spot, scores, and drive start
- call pushGameState after every play to persist game progress

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e3858ffa88324a08c49d5410869e0