### PR TITLE
Add touchdown scoreboard celebration

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -6,6 +6,7 @@
   </head>
   <body>    
     <div id="scoreboard" class="scoreboard">
+      <div id="scoreBanner" class="score-banner"></div>
       <div class="team">
         <div class="team-name" id="home">Home</div>
         <div class="score-row">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -166,6 +166,10 @@
     const predicted = predictPlayType(state.Down, state.Distance);
 
     const yardDelta = carryResult.yards;
+    const scoringTeam = state.Possession;
+    const oldScore = scoringTeam === "Home"
+      ? parseInt(state.HomeScore, 10) || 0
+      : parseInt(state.AwayScore, 10) || 0;
     // Home drives left ➡ right (0 -> 100); Away drives right ➡ left (100 -> 0)
     const newBall = state.Possession === "Home"
       ? Math.min(100, Math.max(0, state.BallOn + yardDelta))
@@ -183,6 +187,7 @@
     if (touchdown) {
       await handleTouchdown(newBall, playerName, carryResult, tackler, predicted);
       recordedYards = carryResult.yards; // handleTouchdown adjusts yards
+      await celebrateTouchdown(scoringTeam, oldScore, oldScore + 6);
     } else if (newDist <= 0) {
       result = "First Down";
       newDown = 1;
@@ -301,6 +306,32 @@
     document.getElementById("quarter").innerText = state.Qtr;
     document.getElementById("homeFootball").style.visibility = state.Possession === "Home" ? "visible" : "hidden";
     document.getElementById("awayFootball").style.visibility = state.Possession === "Away" ? "visible" : "hidden";
+  }
+
+  function celebrateTouchdown(team, oldScore, newScore) {
+    return new Promise(resolve => {
+      const scoreboard = document.getElementById("scoreboard");
+      const banner = document.getElementById("scoreBanner");
+      banner.textContent = "TOUCHDOWN!";
+      scoreboard.classList.add("scoring");
+      banner.classList.add("show");
+
+      setTimeout(() => {
+        banner.classList.remove("show");
+        const scoreEl = document.getElementById(team === "Home" ? "scoreHome" : "scoreAway");
+        let current = oldScore;
+        const increment = newScore > oldScore ? 1 : -1;
+        const interval = setInterval(() => {
+          current += increment;
+          scoreEl.innerText = current;
+          if (current === newScore) {
+            clearInterval(interval);
+            scoreboard.classList.remove("scoring");
+            resolve();
+          }
+        }, 100);
+      }, 2000);
+    });
   }
 
   function updateFrontendStats(player, yards, td) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -158,6 +158,37 @@
         font-family: 'Arial Black', sans-serif;
         margin-bottom: 20px;
         box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+        position: relative;
+        overflow: hidden;
+      }
+      .scoreboard.scoring {
+        box-shadow: 0 0 20px gold;
+      }
+      .score-banner {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: gold;
+        color: black;
+        font-size: 48px;
+        font-weight: bold;
+        text-shadow: 0 0 10px #fff;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.5s ease;
+      }
+      .score-banner.show {
+        opacity: 1;
+        animation: flash 0.5s alternate 4;
+      }
+      @keyframes flash {
+        from { background: gold; color: black; }
+        to { background: orange; color: white; }
       }
       .scoreboard .team {
         text-align: center;


### PR DESCRIPTION
## Summary
- overlay "TOUCHDOWN!" banner with flashing animation on the scoreboard
- roll-up animation for scoring team's score after the banner fades

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e67b928cc83249653128dd429450b