### PR TITLE
Add play timeline rendering

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -70,6 +70,8 @@
 
     <div id="result" class="result-box"></div>
 
+    <div id="playTimeline" class="play-timeline"></div>
+
     <div id="fullStatsPanel" class="full-stats-panel">
     <div class="stats-header">Session Stats</div>
     <div class="stats-table-container">
@@ -84,12 +86,13 @@
             <th>Long</th>
           </tr>
         </thead>
-        <tbody id="statsTableBody">
-          <!-- rows added dynamically -->
-        </tbody>
+      <tbody id="statsTableBody">
+        <!-- rows added dynamically -->
+      </tbody>
       </table>
     </div>
+    </div>
 
-    <?!= include('PlayUIScript'); ?> 
+    <?!= include('PlayUIScript'); ?>
   </body>
 </html>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -71,6 +71,8 @@
                 lastPlayer = player;
               });
 
+              renderPlayTimeline();
+
               updateFatigueBasedOnStatsOnInitialLoad();
               if (lastPlayer) {
                 console.log("✅ Rendering stats for", lastPlayer);
@@ -113,6 +115,44 @@
     const perspectiveYard = state.Possession === "Home" ? yard : 100 - yard;
     if (perspectiveYard <= 50) return "own " + perspectiveYard;
     return "opp " + (100 - perspectiveYard);
+  }
+
+  function formatBallOnForPoss(yard, possession) {
+    yard = parseInt(yard, 10);
+    const perspectiveYard = possession === "Home" ? yard : 100 - yard;
+    if (perspectiveYard <= 50) return "own " + perspectiveYard;
+    return "opp " + (100 - perspectiveYard);
+  }
+
+  function formatDownDistance(down, distance) {
+    const ord = ["1st", "2nd", "3rd", "4th"];
+    const d = ord[down - 1] || down + "th";
+    return `${d} & ${distance}`;
+  }
+
+  function buildPlayText(play) {
+    let text = `${play.Player} runs for ${play.Yards} Yards.`;
+    if (play.Result && play.Result !== "Normal") {
+      text += ` ${play.Result}!`;
+    }
+    text += ` Tackle made at the ${formatBallOnForPoss(play.NewBallOn, play.Possession)} by ${play.Tackler}.`;
+    return text;
+  }
+
+  function renderPlayTimeline() {
+    const container = document.getElementById("playTimeline");
+    if (!container) return;
+    container.innerHTML = "";
+    playHistory.forEach(play => {
+      if (!play.Player || (play.PlayType && play.PlayType !== "Run")) return;
+      const time = new Date(play.Timestamp).toLocaleTimeString();
+      const downDist = formatDownDistance(play.Down, play.Distance);
+      const text = buildPlayText(play);
+      const row = document.createElement("div");
+      row.className = "play-row";
+      row.innerHTML = `<div class="play-time">${time}</div><div class="play-desc"><div class="play-down">${downDist}</div><div class="play-text">${text}</div></div>`;
+      container.appendChild(row);
+    });
   }
 
   function loadPlayers() {
@@ -247,9 +287,24 @@
   }
 
   function logPlayToDB(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, yards, tackler, result, predicted) {
+    const timestamp = new Date().toISOString();
+    const localPlay = {
+      Timestamp: timestamp,
+      Down: state.Down,
+      Distance: state.Distance,
+      Player: playerName,
+      Yards: yards,
+      Result: result || "Normal",
+      NewBallOn: ballOn,
+      Tackler: tackler,
+      Possession: state.Possession
+    };
+    playHistory.push(localPlay);
+    renderPlayTimeline();
+
     google.script.run.logPlayHistory({
       gameid: 1,
-      timestamp: new Date().toISOString(), // ✅ passed in from frontend
+      timestamp: timestamp, // ✅ passed in from frontend
       possession: state.Possession,
       down: state.Down,
       distance: state.Distance,

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -75,6 +75,26 @@
         font-weight: bold;
         text-decoration: underline;
       }
+
+      .play-timeline {
+        margin-top: 20px;
+      }
+      .play-row {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 8px;
+      }
+      .play-time {
+        width: 80px;
+        font-weight: bold;
+      }
+      .play-desc {
+        flex: 1;
+      }
+      .play-down {
+        font-size: 0.9em;
+        color: #555;
+      }
       
       /* FIELD STUFF */
       #field3D {


### PR DESCRIPTION
## Summary
- add play timeline container in UI
- style timeline items
- render timeline from playHistory with timestamp, down & distance, and play text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e6a10fa1083248b72371096d3e216