### PR TITLE
feat: add dedicated play log tab

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -179,7 +179,9 @@ function logPlayHistory(play) {
     newdown,
     newdist,
     newballon,
-    drivestart
+    drivestart,
+    homescore,
+    awayscore
   } = play;
 
   // Convert ISO string to Date object if needed
@@ -203,7 +205,9 @@ function logPlayHistory(play) {
     Number(newdown) || 0,
     Number(newdist) || 0,
     Number(newballon) || 0,
-    Number(drivestart) || 0
+    Number(drivestart) || 0,
+    Number(homescore) || 0,
+    Number(awayscore) || 0
   ]);
 }
 

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -4,9 +4,15 @@
     <base target="_top" />
     <?!= include('PlayUIstyle'); ?> 
   </head>
-  <body>    
-    <div id="scoreboard" class="scoreboard">
-      <div id="scoreBanner" class="score-banner"></div>
+  <body>
+    <div class="tabs">
+      <button class="tab-button active" data-tab="tracker">Game Tracker</button>
+      <button class="tab-button" data-tab="log">Play Log</button>
+    </div>
+
+    <div id="tracker" class="tab-content active">
+      <div id="scoreboard" class="scoreboard">
+        <div id="scoreBanner" class="score-banner"></div>
       <div class="team">
         <div class="team-name" id="home">Home</div>
         <div class="score-row">
@@ -24,16 +30,16 @@
           <div id="scoreAway" class="score">0</div>
         </div>
       </div>
-    </div>
+      </div>
 
-    <div class="game-info">
-      <span><strong>Down:</strong> <span id="down">...</span></span>
-      <span><strong>Distance:</strong> <span id="distance">...</span></span>
-      <span><strong>Ball On:</strong> <span id="ballOn">...</span></span>
-    </div>
+      <div class="game-info">
+        <span><strong>Down:</strong> <span id="down">...</span></span>
+        <span><strong>Distance:</strong> <span id="distance">...</span></span>
+        <span><strong>Ball On:</strong> <span id="ballOn">...</span></span>
+      </div>
 
-    <div class="field-wrapper">
-      <div id="field3D">
+      <div class="field-wrapper">
+        <div id="field3D">
         <!-- Yard lines -->
         <div class="yardline" style="left: 100px;"></div>
         <div class="yardline" style="left: 200px;">10</div>
@@ -59,23 +65,21 @@
         <canvas id="arcCanvas" width="1200" height="180" style="position: absolute; top: 0; left: 0; z-index: 1;"></canvas>
         <div id="catchPoint" style="position: absolute;  font-size: 22px;  color: black;  opacity: 0;  z-index: 4;  pointer-events: none;  transition: opacity 0.5s ease;"></div>
       </div>
-    </div>
+        </div>
 
-    <label>Select Player:
-      <select id="playerDropdown"></select>
-    </label>
+        <label>Select Player:
+          <select id="playerDropdown"></select>
+        </label>
 
-    <button onclick="runPlay()">▶️ Run Play</button>
-    <button onclick="nextDrive()">🔁 Next Drive</button>
+        <button onclick="runPlay()">▶️ Run Play</button>
+        <button onclick="nextDrive()">🔁 Next Drive</button>
 
-    <div id="result" class="result-box"></div>
+        <div id="result" class="result-box"></div>
 
-    <div id="playTimeline" class="play-timeline"></div>
-
-    <div id="fullStatsPanel" class="full-stats-panel">
-    <div class="stats-header">Session Stats</div>
-    <div class="stats-table-container">
-      <table class="stats-table" id="statsTable">
+        <div id="fullStatsPanel" class="full-stats-panel">
+        <div class="stats-header">Session Stats</div>
+        <div class="stats-table-container">
+          <table class="stats-table" id="statsTable">
         <thead>
           <tr>
             <th>Player</th>
@@ -89,8 +93,25 @@
       <tbody id="statsTableBody">
         <!-- rows added dynamically -->
       </tbody>
-      </table>
+          </table>
+        </div>
+      </div>
     </div>
+
+    <div id="log" class="tab-content">
+      <div class="play-log-card">
+        <table class="play-log-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Play</th>
+              <th>Offense</th>
+              <th>Score</th>
+            </tr>
+          </thead>
+          <tbody id="playTimeline"></tbody>
+        </table>
+      </div>
     </div>
 
     <?!= include('PlayUIScript'); ?>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -9,6 +9,18 @@
   let gameId = 1;
   let playHistory = [];
 
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.tab-button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        const target = document.getElementById(btn.dataset.tab);
+        if (target) target.classList.add('active');
+      });
+    });
+  });
+
   function toggleMenu() {
     document.getElementById('playerMenu').classList.toggle('open');
   }
@@ -148,9 +160,10 @@
       const time = new Date(play.Timestamp).toLocaleTimeString();
       const downDist = formatDownDistance(play.Down, play.Distance);
       const text = buildPlayText(play);
-      const row = document.createElement("div");
-      row.className = "play-row";
-      row.innerHTML = `<div class="play-time">${time}</div><div class="play-desc"><div class="play-down">${downDist}</div><div class="play-text">${text}</div></div>`;
+      const offense = play.Possession || "";
+      const score = `${play.HomeScore !== undefined ? play.HomeScore : state.HomeScore} - ${play.AwayScore !== undefined ? play.AwayScore : state.AwayScore}`;
+      const row = document.createElement("tr");
+      row.innerHTML = `<td>${time}</td><td><div class="play-down">${downDist}</div><div class="play-text">${text}</div></td><td>${offense}</td><td>${score}</td>`;
       container.appendChild(row);
     });
   }
@@ -297,7 +310,10 @@
       Result: result || "Normal",
       NewBallOn: ballOn,
       Tackler: tackler,
-      Possession: state.Possession
+      Possession: state.Possession,
+      HomeScore: state.HomeScore,
+      AwayScore: state.AwayScore,
+      PlayType: "Run"
     };
     playHistory.push(localPlay);
     renderPlayTimeline();
@@ -320,7 +336,9 @@
       newdown: down,
       newdist: distance,
       newballon: ballOn,
-      drivestart: state.DriveStart
+      drivestart: state.DriveStart,
+      homescore: state.HomeScore,
+      awayscore: state.AwayScore
     });
   }
 

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -95,6 +95,54 @@
         font-size: 0.9em;
         color: #555;
       }
+
+      /* Tabs */
+      .tabs {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 20px;
+      }
+      .tab-button {
+        flex: 1;
+        padding: 8px 12px;
+        background: #f2f2f2;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: bold;
+      }
+      .tab-button.active {
+        background: #007bff;
+        color: #fff;
+      }
+      .tab-content {
+        display: none;
+      }
+      .tab-content.active {
+        display: block;
+      }
+
+      /* Play Log */
+      .play-log-card {
+        margin-top: 20px;
+        padding: 10px;
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 0 6px rgba(0,0,0,0.1);
+      }
+      .play-log-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .play-log-table th,
+      .play-log-table td {
+        padding: 8px;
+        border-bottom: 1px solid #ccc;
+        text-align: left;
+      }
+      .play-log-table th {
+        background: #f2f2f2;
+      }
       
       /* FIELD STUFF */
       #field3D {


### PR DESCRIPTION
## Summary
- add Game Tracker/Play Log tab navigation and play log table
- render play history with offense and score fields and persist scores
- style new tabs and log card to match app theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e6d8de2188324b284b18db46820c5