### PR TITLE
feat: add carousel and tabs for game UI

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -45,6 +45,28 @@ function getGameState(gameId) {
   return result;
 }
 
+function getGamesList() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Games');
+  if (!sheet) {
+    throw new Error("Sheet 'Games' not found.");
+  }
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const idxId = headers.indexOf('GameId');
+  const idxHome = headers.indexOf('Home');
+  const idxAway = headers.indexOf('Away');
+  const idxHomeScore = headers.indexOf('HomeScore');
+  const idxAwayScore = headers.indexOf('AwayScore');
+
+  return data.slice(1).map(row => ({
+    GameId: row[idxId],
+    Home: row[idxHome],
+    Away: row[idxAway],
+    HomeScore: row[idxHomeScore],
+    AwayScore: row[idxAwayScore]
+  }));
+}
+
 function getPlayerTraits() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Players");
   if (!sheet) {

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -5,12 +5,15 @@
     <?!= include('PlayUIstyle'); ?> 
   </head>
   <body>
+    <div id="gameCarousel" class="game-carousel"></div>
     <div class="tabs">
-      <button class="tab-button active" data-tab="tracker">Game Tracker</button>
-      <button class="tab-button" data-tab="log">Play Log</button>
+      <button class="tab-button active" data-tab="gamecast">Gamecast</button>
+      <button class="tab-button" data-tab="playbyplay">Play-by-Play</button>
+      <button class="tab-button" data-tab="boxscore">Box Score</button>
+      <button class="tab-button" data-tab="teamstats">Team Stats</button>
     </div>
 
-    <div id="tracker" class="tab-content active">
+    <div id="gamecast" class="tab-content active">
       <div id="scoreboard" class="scoreboard">
         <div id="scoreBanner" class="score-banner"></div>
         <div class="team">
@@ -77,29 +80,9 @@
           <div id="result" class="result-box"></div>
         </div>
 
-        <div id="fullStatsPanel" class="full-stats-panel">
-        <div class="stats-header">Session Stats</div>
-        <div class="stats-table-container">
-          <table class="stats-table" id="statsTable">
-        <thead>
-          <tr>
-            <th>Player</th>
-            <th>Carries</th>
-            <th>Yards</th>
-            <th>TDs</th>
-            <th>Fumbles</th>
-            <th>Long</th>
-          </tr>
-        </thead>
-      <tbody id="statsTableBody">
-        <!-- rows added dynamically -->
-      </tbody>
-          </table>
-        </div>
-      </div>
     </div>
 
-    <div id="log" class="tab-content">
+    <div id="playbyplay" class="tab-content">
       <div class="play-log-card">
         <table class="play-log-table">
           <thead>
@@ -112,6 +95,35 @@
           </thead>
           <tbody id="playTimeline"></tbody>
         </table>
+      </div>
+    </div>
+
+    <div id="boxscore" class="tab-content">
+      <div id="fullStatsPanel" class="full-stats-panel">
+        <div class="stats-header">Session Stats</div>
+        <div class="stats-table-container">
+          <table class="stats-table" id="statsTable">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Carries</th>
+                <th>Yards</th>
+                <th>TDs</th>
+                <th>Fumbles</th>
+                <th>Long</th>
+              </tr>
+            </thead>
+            <tbody id="statsTableBody">
+              <!-- rows added dynamically -->
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div id="teamstats" class="tab-content">
+      <div class="play-log-card">
+        <p>Team stats coming soon...</p>
       </div>
     </div>
 

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -19,7 +19,31 @@
         if (target) target.classList.add('active');
       });
     });
+    loadGamesList();
   });
+
+  function loadGamesList() {
+    google.script.run.withSuccessHandler(renderGameCards).getGamesList();
+  }
+
+  function renderGameCards(games) {
+    const container = document.getElementById('gameCarousel');
+    if (!container) return;
+    container.innerHTML = '';
+    games.forEach(g => {
+      const card = document.createElement('div');
+      const id = Number(g.GameId);
+      card.className = 'game-card' + (id === gameId ? ' active' : '');
+      card.innerHTML = `<div class="teams">${g.Away} @ ${g.Home}</div><div class="score">${g.AwayScore} - ${g.HomeScore}</div>`;
+      card.addEventListener('click', () => {
+        gameId = id;
+        refreshUI();
+        document.querySelectorAll('.game-card').forEach(c => c.classList.remove('active'));
+        card.classList.add('active');
+      });
+      container.appendChild(card);
+    });
+  }
 
   function toggleMenu() {
     document.getElementById('playerMenu').classList.toggle('open');

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -18,6 +18,36 @@
     color: var(--floral-white);
   }
 
+  /* Game carousel */
+  .game-carousel {
+    display: flex;
+    overflow-x: auto;
+    gap: 12px;
+    padding: 10px 0;
+    margin-bottom: 20px;
+  }
+  .game-card {
+    flex: 0 0 auto;
+    background: var(--raisin-black);
+    border: 1px solid var(--ue-red);
+    border-radius: 8px;
+    padding: 10px;
+    min-width: 150px;
+    cursor: pointer;
+    text-align: center;
+  }
+  .game-card.active {
+    background: var(--ue-red);
+  }
+  .game-card .teams {
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .game-card .score {
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
   /* Tabs */
   .tabs {
     display: flex;


### PR DESCRIPTION
## Summary
- add Games sheet endpoint to fetch game list
- introduce horizontally scrolling game carousel and ESPN-style tabs
- move session stats to Box Score view and theme new components

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_688eb12686948324a7d15d2b540247b5