### PR TITLE
Revamp UI to mirror ESPN layout

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -22,6 +22,22 @@ function showPlayUI() {
 }
 
 //********************** */
+function getGames() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Games');
+  if (!sheet) {
+    throw new Error("Sheet 'Games' not found.");
+  }
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  return data.slice(1).map(row => {
+    const obj = {};
+    headers.forEach((h, i) => {
+      obj[h] = row[i];
+    });
+    return obj;
+  });
+}
+
 function getGameState(gameId) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Games');
   if (!sheet) {

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -5,12 +5,15 @@
     <?!= include('PlayUIstyle'); ?> 
   </head>
   <body>
+    <div id="gameCarousel" class="game-carousel"></div>
     <div class="tabs">
-      <button class="tab-button active" data-tab="tracker">Game Tracker</button>
-      <button class="tab-button" data-tab="log">Play Log</button>
+      <button class="tab-button active" data-tab="gamecast">Gamecast</button>
+      <button class="tab-button" data-tab="playbyplay">Play-by-Play</button>
+      <button class="tab-button" data-tab="boxscore">Box Score</button>
+      <button class="tab-button" data-tab="teamstats">Team Stats</button>
     </div>
 
-    <div id="tracker" class="tab-content active">
+    <div id="gamecast" class="tab-content active">
       <div id="scoreboard" class="scoreboard">
         <div id="scoreBanner" class="score-banner"></div>
         <div class="team">
@@ -76,30 +79,9 @@
           </div>
           <div id="result" class="result-box"></div>
         </div>
-
-        <div id="fullStatsPanel" class="full-stats-panel">
-        <div class="stats-header">Session Stats</div>
-        <div class="stats-table-container">
-          <table class="stats-table" id="statsTable">
-        <thead>
-          <tr>
-            <th>Player</th>
-            <th>Carries</th>
-            <th>Yards</th>
-            <th>TDs</th>
-            <th>Fumbles</th>
-            <th>Long</th>
-          </tr>
-        </thead>
-      <tbody id="statsTableBody">
-        <!-- rows added dynamically -->
-      </tbody>
-          </table>
-        </div>
-      </div>
     </div>
 
-    <div id="log" class="tab-content">
+    <div id="playbyplay" class="tab-content">
       <div class="play-log-card">
         <table class="play-log-table">
           <thead>
@@ -113,6 +95,33 @@
           <tbody id="playTimeline"></tbody>
         </table>
       </div>
+    </div>
+
+    <div id="boxscore" class="tab-content">
+      <div id="fullStatsPanel" class="full-stats-panel">
+        <div class="stats-header">Session Stats</div>
+        <div class="stats-table-container">
+          <table class="stats-table" id="statsTable">
+            <thead>
+              <tr>
+                <th>Player</th>
+                <th>Carries</th>
+                <th>Yards</th>
+                <th>TDs</th>
+                <th>Fumbles</th>
+                <th>Long</th>
+              </tr>
+            </thead>
+            <tbody id="statsTableBody">
+              <!-- rows added dynamically -->
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div id="teamstats" class="tab-content">
+      <div class="team-stats-placeholder">Team stats coming soon.</div>
     </div>
 
     <?!= include('PlayUIScript'); ?>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -19,7 +19,31 @@
         if (target) target.classList.add('active');
       });
     });
+    loadGames();
   });
+
+  function loadGames() {
+    google.script.run.withSuccessHandler(renderGames).getGames();
+  }
+
+  function renderGames(games) {
+    const container = document.getElementById('gameCarousel');
+    if (!container) return;
+    container.innerHTML = '';
+    games.forEach(g => {
+      const card = document.createElement('div');
+      card.className = 'game-card' + (g.GameId === gameId ? ' active' : '');
+      card.innerHTML = `
+        <div>${g.Home} vs ${g.Away}</div>
+        <div>${g.HomeScore}-${g.AwayScore}</div>`;
+      card.addEventListener('click', () => {
+        gameId = g.GameId;
+        refreshUI();
+        loadGames();
+      });
+      container.appendChild(card);
+    });
+  }
 
   function toggleMenu() {
     document.getElementById('playerMenu').classList.toggle('open');

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -18,6 +18,31 @@
     color: var(--floral-white);
   }
 
+  /* Game carousel */
+  .game-carousel {
+    display: flex;
+    overflow-x: auto;
+    gap: 12px;
+    padding-bottom: 15px;
+  }
+  .game-card {
+    flex: 0 0 auto;
+    min-width: 160px;
+    background: var(--raisin-black);
+    border: 1px solid var(--ue-red);
+    border-radius: 8px;
+    padding: 10px;
+    text-align: center;
+    cursor: pointer;
+    transition: background 0.3s;
+  }
+  .game-card:hover {
+    background: var(--ue-red);
+  }
+  .game-card.active {
+    background: var(--ue-red);
+  }
+
   /* Tabs */
   .tabs {
     display: flex;
@@ -47,6 +72,13 @@
   }
   .tab-content.active {
     display: block;
+  }
+
+  .team-stats-placeholder {
+    padding: 20px;
+    text-align: center;
+    background: var(--raisin-black);
+    border-radius: 12px;
   }
 
   /* Scoreboard */


### PR DESCRIPTION
## Summary
- Add scrolling game carousel to quickly switch between matchups
- Restructure tabs into Gamecast, Play-by-Play, Box Score, and Team Stats
- Style new components using existing theme variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688eb12686948324a7d15d2b540247b5