### PR TITLE
Ensure carousel clicks refresh selected game's UI

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -36,8 +36,7 @@
       card.className = 'game-card' + (id === gameId ? ' active' : '');
       card.innerHTML = `<div class="teams">${g.Away} @ ${g.Home}</div><div class="score">${g.AwayScore} - ${g.HomeScore}</div>`;
       card.addEventListener('click', () => {
-        gameId = id;
-        refreshUI();
+        refreshUI(id);
         document.querySelectorAll('.game-card').forEach(c => c.classList.remove('active'));
         card.classList.add('active');
       });
@@ -68,7 +67,10 @@
   }
 
   // === GAME SETUP ===
-  function refreshUI() {
+  function refreshUI(selectedGameId) {
+    if (typeof selectedGameId !== 'undefined') {
+      gameId = selectedGameId;
+    }
     google.script.run.withSuccessHandler(function (gameState) {
       console.log("✅ Loaded game state");
       state = gameState;


### PR DESCRIPTION
## Summary
- Allow clicking a game card to refresh the UI using that game's ID
- Update `refreshUI` to accept an optional gameId and update the global state

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688eb9cacd6c832497d6a364cfecdcf2