### PR TITLE
Rework UI theme and layout

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -8,6 +8,26 @@
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
 
     <div id="gameCarousel" class="game-carousel"></div>
+    <div id="scoreboard" class="scoreboard">
+      <div id="scoreBanner" class="score-banner"></div>
+      <div class="team">
+        <div class="team-name" id="home">Home</div>
+        <div class="score-row">
+          <div id="scoreHome" class="score">0</div>
+          <span id="homeFootball" class="football-icon">🏈</span>
+        </div>
+      </div>
+      <div class="time-quarter">
+        <div><strong>QTR:</strong> <span id="quarter">1</span></div>
+      </div>
+      <div class="team">
+        <div class="team-name" id="away">Away</div>
+        <div class="score-row">
+          <span id="awayFootball" class="football-icon">🏈</span>
+          <div id="scoreAway" class="score">0</div>
+        </div>
+      </div>
+    </div>
     <div class="tabs">
       <button class="tab-button active" data-tab="gamecast">Gamecast</button>
       <button class="tab-button" data-tab="playbyplay">Play-by-Play</button>
@@ -16,27 +36,6 @@
     </div>
 
     <div id="gamecast" class="tab-content active">
-      <div id="scoreboard" class="scoreboard">
-        <div id="scoreBanner" class="score-banner"></div>
-        <div class="team">
-          <div class="team-name" id="home">Home</div>
-          <div class="score-row">
-            <div id="scoreHome" class="score">0</div>
-            <span id="homeFootball" class="football-icon">🏈</span>
-          </div>
-        </div>
-        <div class="time-quarter">
-          <div><strong>QTR:</strong> <span id="quarter">1</span></div>
-        </div>
-        <div class="team">
-          <div class="team-name" id="away">Away</div>
-          <div class="score-row">
-            <span id="awayFootball" class="football-icon">🏈</span>
-            <div id="scoreAway" class="score">0</div>
-          </div>
-        </div>
-      </div>
-
       <div class="game-info">
         <div><strong>Down:</strong> <span id="down">...</span></div>
         <div><strong>Distance:</strong> <span id="distance">...</span></div>

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -2,20 +2,21 @@
   @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 
   :root {
-    --ue-red: #C10206;
-    --carmine: #A50113;
-    --floral-white: #FFFBF2;
-    --chinese-white: #DFE2DB;
-    --raisin-black: #211D21;
-    --rich-black: #010A10;
+    --accent-red: #C10206;
+    --accent-red-dark: #A50113;
+    --gray-dark: #121212;
+    --gray-medium: #1e1e1e;
+    --gray-light: #2c2c2c;
+    --text-light: #F5F5F5;
+    --text-muted: #B0B0B0;
   }
 
   body {
     margin: 0;
     padding: 20px;
     font-family: 'Roboto', Arial, sans-serif;
-    background: linear-gradient(135deg, var(--rich-black) 0%, var(--raisin-black) 100%);
-    color: var(--floral-white);
+    background: linear-gradient(135deg, var(--gray-dark) 0%, var(--gray-medium) 100%);
+    color: var(--text-light);
   }
 
   /* Game carousel */
@@ -41,9 +42,9 @@
     flex: 0 0 auto;
     width: 20vw; /* 20% of screen width */
     height: 100%;
-    background: var(--raisin-black);
-    border: 1px solid var(--ue-red);
-    border-radius: 8px;
+    background: var(--gray-medium);
+    border: 1px solid var(--gray-light);
+    border-radius: 4px;
     padding: 10px;
     cursor: pointer;
     text-align: center;
@@ -54,7 +55,7 @@
   }
 
   .game-card.active {
-    background: var(--ue-red);
+    border-color: var(--accent-red);
   }
 
   .game-card .teams {
@@ -72,26 +73,28 @@
   /* Tabs */
   .tabs {
     display: flex;
-    gap: 12px;
     margin-bottom: 20px;
+    background: var(--gray-medium);
+    border-radius: 4px;
+    overflow: hidden;
   }
   .tab-button {
     flex: 1;
     padding: 10px 15px;
-    border: 1px solid var(--ue-red);
-    background: var(--raisin-black);
-    color: var(--floral-white);
-    border-radius: 8px;
+    background: var(--gray-medium);
+    color: var(--text-light);
+    border: none;
+    border-bottom: 3px solid transparent;
     cursor: pointer;
     font-weight: 600;
-    transition: background 0.3s, transform 0.2s;
+    transition: background 0.3s, color 0.3s;
   }
   .tab-button:hover {
-    background: var(--ue-red);
-    transform: translateY(-2px);
+    background: var(--gray-light);
   }
   .tab-button.active {
-    background: var(--ue-red);
+    color: var(--accent-red);
+    border-bottom: 3px solid var(--accent-red);
   }
   .tab-content {
     display: none;
@@ -105,15 +108,17 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: linear-gradient(90deg, var(--ue-red), var(--carmine));
+    background: var(--gray-medium);
     padding: 15px 20px;
-    border-radius: 12px;
-    box-shadow: 0 0 15px rgba(193, 2, 6, 0.5);
+    border: 1px solid var(--gray-light);
+    border-radius: 4px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
     position: relative;
     overflow: hidden;
+    margin-bottom: 20px;
   }
   .scoreboard.scoring {
-    box-shadow: 0 0 25px gold;
+    box-shadow: 0 0 25px var(--accent-red);
   }
   .score-banner {
     position: absolute;
@@ -122,7 +127,7 @@
     justify-content: center;
     align-items: center;
     background: gold;
-    color: var(--rich-black);
+    color: var(--gray-dark);
     font-size: 48px;
     font-weight: bold;
     text-shadow: 0 0 10px #fff;
@@ -135,8 +140,8 @@
     animation: flash 0.5s alternate 4;
   }
   @keyframes flash {
-    from { background: gold; color: var(--rich-black); }
-    to { background: orange; color: var(--floral-white); }
+    from { background: gold; color: var(--gray-dark); }
+    to { background: orange; color: var(--text-light); }
   }
   .scoreboard .team {
     text-align: center;
@@ -169,9 +174,9 @@
     display: flex;
     gap: 10px;
     justify-content: space-around;
-    background: var(--raisin-black);
-    border: 1px solid var(--ue-red);
-    border-radius: 8px;
+    background: var(--gray-medium);
+    border: 1px solid var(--gray-light);
+    border-radius: 4px;
     padding: 8px 10px;
     margin-bottom: 20px;
   }
@@ -181,7 +186,7 @@
     font-weight: 500;
   }
   .game-info strong {
-    color: var(--chinese-white);
+    color: var(--text-muted);
   }
 
   /* Field (unchanged except for wrapper positioning) */
@@ -253,8 +258,8 @@
   .control-panel {
     max-width: 900px;
     margin: 30px auto;
-    background: var(--raisin-black);
-    border-radius: 12px;
+    background: var(--gray-medium);
+    border-radius: 4px;
     padding: 20px;
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
   }
@@ -266,10 +271,10 @@
   .control-panel select {
     width: 100%;
     padding: 8px;
-    background: var(--rich-black);
-    color: var(--floral-white);
-    border: 1px solid var(--chinese-white);
-    border-radius: 6px;
+    background: var(--gray-dark);
+    color: var(--text-light);
+    border: 1px solid var(--gray-light);
+    border-radius: 4px;
   }
   .button-row {
     display: flex;
@@ -283,24 +288,24 @@
   button {
     padding: 12px;
     font-size: 16px;
-    background: var(--ue-red);
-    color: var(--floral-white);
-    border: none;
-    border-radius: 8px;
+    background: var(--gray-light);
+    color: var(--text-light);
+    border: 1px solid var(--accent-red);
+    border-radius: 4px;
     cursor: pointer;
-    transition: background 0.3s, transform 0.2s;
+    transition: background 0.3s, color 0.3s;
   }
   button:hover {
-    background: var(--carmine);
-    transform: scale(1.03);
+    background: var(--gray-medium);
+    color: var(--accent-red);
   }
 
   .result-box {
     margin-top: 20px;
     padding: 15px;
-    background: var(--rich-black);
-    border-left: 4px solid var(--ue-red);
-    border-radius: 8px;
+    background: var(--gray-dark);
+    border-left: 4px solid var(--accent-red);
+    border-radius: 4px;
     min-height: 40px;
   }
   .highlight {
@@ -308,7 +313,7 @@
     font-weight: bold;
   }
   .turnover {
-    color: var(--ue-red);
+    color: var(--accent-red);
     font-weight: bold;
   }
 
@@ -316,8 +321,8 @@
   .full-stats-panel {
     max-width: 900px;
     margin: 40px auto;
-    background: var(--raisin-black);
-    border-radius: 12px;
+    background: var(--gray-medium);
+    border-radius: 4px;
     padding: 20px;
     box-shadow: 0 0 12px rgba(0,0,0,0.4);
   }
@@ -325,7 +330,7 @@
     font-size: 24px;
     font-weight: 700;
     margin-bottom: 15px;
-    border-bottom: 2px solid var(--ue-red);
+    border-bottom: 2px solid var(--accent-red);
     padding-bottom: 6px;
     text-align: center;
   }
@@ -342,18 +347,19 @@
     text-align: center;
   }
   .stats-table th {
-    background: var(--ue-red);
-    color: var(--floral-white);
+    background: var(--gray-light);
+    border-bottom: 2px solid var(--accent-red);
+    color: var(--text-light);
   }
   .stats-table tr:nth-child(even) {
-    background: var(--rich-black);
+    background: var(--gray-dark);
   }
   .stats-table tr:nth-child(odd) {
-    background: var(--raisin-black);
+    background: var(--gray-medium);
   }
   .stats-table tr.highlighted {
-    background: var(--ue-red);
-    color: var(--floral-white);
+    background: var(--accent-red);
+    color: var(--text-light);
     font-weight: bold;
   }
 
@@ -361,8 +367,8 @@
   .play-log-card {
     margin-top: 20px;
     padding: 20px;
-    background: var(--raisin-black);
-    border-radius: 12px;
+    background: var(--gray-medium);
+    border-radius: 4px;
     box-shadow: 0 0 10px rgba(0,0,0,0.4);
   }
   .play-log-table {
@@ -372,11 +378,12 @@
   .play-log-table th,
   .play-log-table td {
     padding: 8px;
-    border-bottom: 1px solid var(--chinese-white);
+    border-bottom: 1px solid var(--gray-light);
     text-align: left;
   }
   .play-log-table th {
-    background: var(--ue-red);
-    color: var(--floral-white);
+    background: var(--gray-light);
+    border-bottom: 2px solid var(--accent-red);
+    color: var(--text-light);
   }
 </style>


### PR DESCRIPTION
## Summary
- Restyle interface with a gray-focused dark theme and subtle red accents
- Move scoreboard banner beneath the game list and connect the tab bar
- Tighten corner radii and soften buttons for a sleeker look

## Testing
- `npm test` *(fails: ENOENT, no package.json)*


------
https://chatgpt.com/codex/tasks/task_b_688fe0d1191c832494e466937d096aa5