### PR TITLE
Redesign scoreboard banner with team details and timeouts

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -10,21 +10,37 @@
     <div id="gameCarousel" class="game-carousel"></div>
     <div id="scoreboard" class="scoreboard">
       <div id="scoreBanner" class="score-banner"></div>
-      <div class="team">
-        <div class="team-name" id="home">Home</div>
-        <div class="score-row">
-          <div id="scoreHome" class="score">0</div>
+      <div class="team-block home">
+        <div class="team-info">
+          <img id="homeLogo" class="team-logo" src="" alt="Home Logo" />
+          <div id="homeName" class="team-name">Home</div>
+          <div id="homeRecord" class="team-record">0-0</div>
+        </div>
+        <div class="score-section">
           <span id="homeFootball" class="football-icon">🏈</span>
+          <div id="scoreHome" class="team-score">0</div>
+          <div id="homeTimeouts" class="timeouts">
+            <span class="timeout-dot"></span>
+            <span class="timeout-dot"></span>
+            <span class="timeout-dot"></span>
+          </div>
         </div>
       </div>
-      <div class="time-quarter">
-        <div><strong>QTR:</strong> <span id="quarter">1</span></div>
-      </div>
-      <div class="team">
-        <div class="team-name" id="away">Away</div>
-        <div class="score-row">
+      <div id="timeQuarter" class="center-info">0:00 - 1st</div>
+      <div class="team-block away">
+        <div class="team-info">
+          <img id="awayLogo" class="team-logo" src="" alt="Away Logo" />
+          <div id="awayName" class="team-name">Away</div>
+          <div id="awayRecord" class="team-record">0-0</div>
+        </div>
+        <div class="score-section">
           <span id="awayFootball" class="football-icon">🏈</span>
-          <div id="scoreAway" class="score">0</div>
+          <div id="scoreAway" class="team-score">0</div>
+          <div id="awayTimeouts" class="timeouts">
+            <span class="timeout-dot"></span>
+            <span class="timeout-dot"></span>
+            <span class="timeout-dot"></span>
+          </div>
         </div>
       </div>
     </div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -181,6 +181,20 @@
     return `${d} & ${distance}`;
   }
 
+  function formatQuarter(qtr) {
+    const ord = ["1st", "2nd", "3rd", "4th", "OT"];
+    return ord[qtr - 1] || qtr + "th";
+  }
+
+  function updateTimeoutDots(id, count) {
+    const container = document.getElementById(id);
+    if (!container) return;
+    const dots = Array.from(container.children);
+    dots.forEach((dot, idx) => {
+      dot.classList.toggle('used', idx >= count);
+    });
+  }
+
   function buildPlayText(play) {
     let text = `<strong>${play.Player}</strong> runs for ${play.Yards} Yards.`;
 
@@ -423,11 +437,17 @@
     document.getElementById("down").innerText = state.Down;
     document.getElementById("distance").innerText = state.Distance;
     document.getElementById("ballOn").innerText = formatBallOn(state.BallOn);
-    document.getElementById("home").innerText = state.Home;
-    document.getElementById("away").innerText = state.Away;
+    document.getElementById("homeName").innerText = state.Home;
+    document.getElementById("awayName").innerText = state.Away;
+    document.getElementById("homeRecord").innerText = state.HomeRecord || "";
+    document.getElementById("awayRecord").innerText = state.AwayRecord || "";
+    if (document.getElementById("homeLogo")) document.getElementById("homeLogo").src = state.HomeLogo || "";
+    if (document.getElementById("awayLogo")) document.getElementById("awayLogo").src = state.AwayLogo || "";
     document.getElementById("scoreHome").innerText = state.HomeScore;
     document.getElementById("scoreAway").innerText = state.AwayScore;
-    document.getElementById("quarter").innerText = state.Qtr;
+    document.getElementById("timeQuarter").innerText = `${state.Time} - ${formatQuarter(state.Qtr)}`;
+    updateTimeoutDots("homeTimeouts", state.HomeTimeouts || 0);
+    updateTimeoutDots("awayTimeouts", state.AwayTimeouts || 0);
     document.getElementById("homeFootball").style.visibility = state.Possession === "Home" ? "visible" : "hidden";
     document.getElementById("awayFootball").style.visibility = state.Possession === "Away" ? "visible" : "hidden";
   }

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -116,6 +116,7 @@
     position: relative;
     overflow: hidden;
     margin-bottom: 20px;
+    height: 120px;
   }
   .scoreboard.scoring {
     box-shadow: 0 0 25px var(--accent-red);
@@ -143,26 +144,71 @@
     from { background: gold; color: var(--gray-dark); }
     to { background: orange; color: var(--text-light); }
   }
-  .scoreboard .team {
-    text-align: center;
+  .team-block {
+    display: flex;
+    align-items: center;
+    height: 100%;
   }
-  .scoreboard .team-name {
-    font-size: 18px;
-    font-weight: 700;
+  .team-block.away {
+    flex-direction: row-reverse;
   }
-  .scoreboard .score {
-    font-size: 36px;
-    font-weight: 700;
+  .team-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    width: 120px;
   }
-  .score-row {
+  .team-logo {
+    flex: 0 0 50%;
+    max-height: 50%;
+    object-fit: contain;
+  }
+  .team-name {
+    flex: 0 0 25%;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    font-weight: 700;
   }
-  .time-quarter {
-    font-size: 18px;
-    font-weight: 500;
+  .team-record {
+    flex: 0 0 25%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+  }
+  .score-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 10px;
+  }
+  .team-score {
+    font-size: 48px;
+    font-weight: 700;
+  }
+  .timeouts {
+    display: flex;
+    gap: 4px;
+    margin-top: 4px;
+  }
+  .timeout-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: yellow;
+  }
+  .timeout-dot.used {
+    opacity: 0.2;
+  }
+  .center-info {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--accent-red);
+    text-align: center;
+    min-width: 120px;
   }
   .football-icon {
     font-size: 22px;


### PR DESCRIPTION
## Summary
- Redesign scoreboard banner to show stacked team logo, bold name, record and inner score with timeout dots
- Add central time/quarter display in red
- Update script to populate logos, records, scores and timeout indicators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688fe30934a08324b46180324c285826