### PR TITLE
Refine scoreboard and drive information presentation

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -17,8 +17,10 @@
           <div id="homeRecord" class="team-record">0-0</div>
         </div>
         <div class="score-section">
-          <span id="homeFootball" class="football-icon">🏈</span>
-          <div id="scoreHome" class="team-score">0</div>
+          <div class="score-row">
+            <div id="scoreHome" class="team-score">0</div>
+            <span id="homeFootball" class="football-icon">🏈</span>
+          </div>
           <div id="homeTimeouts" class="timeouts">
             <span class="timeout-dot"></span>
             <span class="timeout-dot"></span>
@@ -34,8 +36,10 @@
           <div id="awayRecord" class="team-record">0-0</div>
         </div>
         <div class="score-section">
-          <span id="awayFootball" class="football-icon">🏈</span>
-          <div id="scoreAway" class="team-score">0</div>
+          <div class="score-row">
+            <span id="awayFootball" class="football-icon">🏈</span>
+            <div id="scoreAway" class="team-score">0</div>
+          </div>
           <div id="awayTimeouts" class="timeouts">
             <span class="timeout-dot"></span>
             <span class="timeout-dot"></span>
@@ -53,9 +57,18 @@
 
     <div id="gamecast" class="tab-content active">
       <div class="game-info">
-        <div><strong>Down:</strong> <span id="down">...</span></div>
-        <div><strong>Distance:</strong> <span id="distance">...</span></div>
-        <div><strong>Ball On:</strong> <span id="ballOn">...</span></div>
+        <div class="info-block">
+          <div class="info-label">DOWN:</div>
+          <div id="downDistance" class="info-value">...</div>
+        </div>
+        <div class="info-block">
+          <div class="info-label">BALL ON:</div>
+          <div id="ballOn" class="info-value">...</div>
+        </div>
+        <div class="info-block">
+          <div class="info-label">DRIVE:</div>
+          <div id="driveInfo" class="info-value">0 plays, 0 yards</div>
+        </div>
       </div>
 
       <div class="field-wrapper">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -186,6 +186,19 @@
     return ord[qtr - 1] || qtr + "th";
   }
 
+  function computeDriveInfo() {
+    let plays = 0;
+    for (let i = playHistory.length - 1; i >= 0; i--) {
+      const play = playHistory[i];
+      if (play.Possession !== state.Possession) break;
+      plays++;
+    }
+    const yards = state.Possession === "Home"
+      ? state.BallOn - state.DriveStart
+      : state.DriveStart - state.BallOn;
+    return { plays, yards: Math.max(0, yards) };
+  }
+
   function updateTimeoutDots(id, count) {
     const container = document.getElementById(id);
     if (!container) return;
@@ -434,9 +447,10 @@
 
   function updateStateUI() {
     console.log(state);
-    document.getElementById("down").innerText = state.Down;
-    document.getElementById("distance").innerText = state.Distance;
+    document.getElementById("downDistance").innerText = formatDownDistance(state.Down, state.Distance);
     document.getElementById("ballOn").innerText = formatBallOn(state.BallOn);
+    const drive = computeDriveInfo();
+    document.getElementById("driveInfo").innerText = `${drive.plays} plays, ${drive.yards} yards`;
     document.getElementById("homeName").innerText = state.Home;
     document.getElementById("awayName").innerText = state.Away;
     document.getElementById("homeRecord").innerText = state.HomeRecord || "";

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -73,20 +73,22 @@
   /* Tabs */
   .tabs {
     display: flex;
-    margin-bottom: 20px;
+    margin: 0 0 20px 0;
     background: var(--gray-medium);
-    border-radius: 4px;
+    border: 1px solid var(--gray-light);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
     overflow: hidden;
   }
   .tab-button {
     flex: 1;
     padding: 10px 15px;
     background: var(--gray-medium);
-    color: var(--text-light);
+    color: var(--text-muted);
     border: none;
     border-bottom: 3px solid transparent;
     cursor: pointer;
-    font-weight: 600;
+    font-weight: 400;
     transition: background 0.3s, color 0.3s;
   }
   .tab-button:hover {
@@ -95,6 +97,7 @@
   .tab-button.active {
     color: var(--accent-red);
     border-bottom: 3px solid var(--accent-red);
+    font-weight: 400;
   }
   .tab-content {
     display: none;
@@ -111,12 +114,13 @@
     background: var(--gray-medium);
     padding: 15px 20px;
     border: 1px solid var(--gray-light);
-    border-radius: 4px;
+    border-radius: 4px 4px 0 0;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
     position: relative;
     overflow: hidden;
-    margin-bottom: 20px;
+    margin-bottom: 0;
     height: 120px;
+    border-bottom: none;
   }
   .scoreboard.scoring {
     box-shadow: 0 0 25px var(--accent-red);
@@ -185,6 +189,10 @@
     justify-content: center;
     margin: 0 10px;
   }
+  .score-row {
+    display: flex;
+    align-items: center;
+  }
   .team-score {
     font-size: 48px;
     font-weight: 700;
@@ -214,32 +222,41 @@
     font-size: 22px;
     visibility: hidden;
   }
+  .team-block.home .football-icon {
+    margin-left: 6px;
+  }
+  .team-block.away .football-icon {
+    margin-right: 6px;
+  }
 
   /* Game information */
   .game-info {
     display: flex;
-    gap: 10px;
     justify-content: space-around;
-    background: var(--gray-medium);
-    border: 1px solid var(--gray-light);
-    border-radius: 4px;
     padding: 8px 10px;
-    margin-bottom: 20px;
+    border-bottom: 1px solid var(--gray-light);
+    margin-bottom: 0;
+    background: none;
+    gap: 10px;
   }
-  .game-info div {
+  .game-info .info-block {
     flex: 1;
     text-align: center;
-    font-weight: 500;
   }
-  .game-info strong {
+  .game-info .info-label {
     color: var(--text-muted);
+    font-size: 14px;
+  }
+  .game-info .info-value {
+    color: black;
+    font-weight: 500;
   }
 
   /* Field (unchanged except for wrapper positioning) */
   .field-wrapper {
     width: 100%;
     max-width: 1600px;
-    margin: 20px auto;
+    margin: 0 auto 20px;
     overflow-x: auto;
     overflow-y: hidden;
     perspective: 1000px;
@@ -249,7 +266,7 @@
     width: 1200px;
     height: 180px;
     transform: rotateX(45deg);
-    margin: 30px auto;
+    margin: 0 auto;
     background: linear-gradient(to right, #007a33 0%, #006622 100%);
     border: 3px solid #333;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- Move possession football inside each team's score block and align near score
- Restyle tabs to sit flush with scoreboard and use light grey text
- Replace game info card with bar showing Down & Distance, Ball On, and Drive stats above field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688fe94e33448324a858c08c4b8649cc