### PR TITLE
Make field responsive to viewport width

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -74,18 +74,18 @@
       <div class="field-wrapper">
         <div id="field3D">
         <!-- Yard lines -->
-        <div class="yardline" style="left: 100px;"></div>
-        <div class="yardline" style="left: 200px;">10</div>
-        <div class="yardline" style="left: 300px;">20</div>
-        <div class="yardline" style="left: 400px;">30</div>
-        <div class="yardline" style="left: 500px;">40</div>
-        <div class="yardline" style="left: 600px;">50</div>
-        <div class="yardline" style="left: 700px;">40</div>
-        <div class="yardline" style="left: 800px;">30</div>
-        <div class="yardline" style="left: 900px;">20</div>
-        <div class="yardline" style="left: 1000px;">10</div>
-        <div class="yardline" style="left: 1100px;"></div>
-        <div class="yardline" style="left: 1200px;"></div>
+        <div class="yardline" style="left: 8.3333%;"></div>
+        <div class="yardline" style="left: 16.6667%;">10</div>
+        <div class="yardline" style="left: 25%;">20</div>
+        <div class="yardline" style="left: 33.3333%;">30</div>
+        <div class="yardline" style="left: 41.6667%;">40</div>
+        <div class="yardline" style="left: 50%;">50</div>
+        <div class="yardline" style="left: 58.3333%;">40</div>
+        <div class="yardline" style="left: 66.6667%;">30</div>
+        <div class="yardline" style="left: 75%;">20</div>
+        <div class="yardline" style="left: 83.3333%;">10</div>
+        <div class="yardline" style="left: 91.6667%;"></div>
+        <div class="yardline" style="left: 100%;"></div>
         <!-- Drive Line (white line showing entire drive so far) -->
         <div id="drive3D" class="driveSegment">
           <div class="drive-dot"></div>
@@ -95,7 +95,7 @@
           <div class="drive-arrow">➤</div>
           <div class="last-dot"></div>
         </div>
-        <canvas id="arcCanvas" width="1200" height="180" style="position: absolute; top: 0; left: 0; z-index: 1;"></canvas>
+        <canvas id="arcCanvas" style="position: absolute; top: 0; left: 0; z-index: 1; width: 100%; height: 100%;"></canvas>
         <div id="catchPoint" style="position: absolute;  font-size: 22px;  color: black;  opacity: 0;  z-index: 4;  pointer-events: none;  transition: opacity 0.5s ease;"></div>
       </div>
         </div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -650,9 +650,16 @@
   //UI Functions ONLY - ANIMATIONS BELOW!
   function show3DDrive(startYard, prevYard, currentYard, playType = 'run', passComplete = true) {
     return new Promise(resolve => {
-      let drivePX = (startYard * 10) + 100;
-      let prevPX = (prevYard * 10) + 100;
-      let currPX = (currentYard * 10) + 100;
+      const field = document.getElementById("field3D");
+      const fieldWidth = field.offsetWidth;
+      const yardPx = fieldWidth / 120;
+      const fieldHeight = field.offsetHeight;
+      const canvas = document.getElementById("arcCanvas");
+      canvas.width = fieldWidth;
+      canvas.height = fieldHeight;
+      let drivePX = (startYard + 10) * yardPx;
+      let prevPX = (prevYard + 10) * yardPx;
+      let currPX = (currentYard + 10) * yardPx;
       let drive = document.getElementById("drive3D");
       const driveDot = drive.querySelector(".drive-dot");
       // Handle drive line based on direction
@@ -663,9 +670,9 @@
         driveDot.style.right = 'auto';
         driveDot.style.left = '0';
       } else {
-        drivePX = 1200 - drivePX;
-        prevPX = 1200 - prevPX;
-        currPX = 1200 - currPX;
+        drivePX = fieldWidth - drivePX;
+        prevPX = fieldWidth - prevPX;
+        currPX = fieldWidth - currPX;
         drive.style.left = `auto`;
         drive.style.right = `${drivePX}px`;
         drive.style.width = `${prevPX - drivePX}px`;
@@ -753,10 +760,11 @@
     return new Promise(resolve => {
       const canvas = document.getElementById("arcCanvas");
       const ctx = canvas.getContext("2d");
+      const yardPx = canvas.width / 120;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const midX = (x0 + x1) / 2;
       const y = canvas.height * 0.45;
-      const peakHeight = Math.min(120, Math.max(50, ((x1 - x0) / 10) * 6));
+      const peakHeight = Math.min(yardPx * 12, Math.max(yardPx * 5, (x1 - x0) * 0.6));
       ctx.setLineDash([10, 5]);
       ctx.lineWidth = 2;
       ctx.strokeStyle = "black";

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -265,8 +265,8 @@
   }
   #field3D {
     position: relative;
-    width: 1200px;
-    height: 180px;
+    width: min(95vw, 1200px);
+    height: calc(min(95vw, 1200px) * 0.15);
     transform: rotateX(45deg);
     margin: 0 auto;
     background: linear-gradient(to right, #007a33 0%, #006622 100%);


### PR DESCRIPTION
## Summary
- Make the 3D field width responsive (`min(95vw, 1200px)`) and scale height accordingly
- Position yard lines and pass arc canvas with percentages to fit any screen
- Drive and play animations now compute positions from current field width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890156159a08324ace9d8b49d028c0d