### PR TITLE
feat: add detailed box score layout

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -129,24 +129,127 @@
     </div>
 
     <div id="boxscore" class="tab-content">
-      <div id="fullStatsPanel" class="full-stats-panel">
-        <div class="stats-header">Session Stats</div>
-        <div class="stats-table-container">
-          <table class="stats-table" id="statsTable">
-            <thead>
-              <tr>
-                <th>Player</th>
-                <th>Carries</th>
-                <th>Yards</th>
-                <th>TDs</th>
-                <th>Fumbles</th>
-                <th>Long</th>
-              </tr>
-            </thead>
-            <tbody id="statsTableBody">
-              <!-- rows added dynamically -->
-            </tbody>
-          </table>
+      <div class="boxscore-card">
+        <div class="boxscore-pill-container">
+          <button id="boxHomeTab" class="boxscore-pill active" data-subtab="boxHomeContent">Home</button>
+          <button class="boxscore-pill" data-subtab="boxOverviewContent">Overview</button>
+          <button id="boxAwayTab" class="boxscore-pill" data-subtab="boxAwayContent">Away</button>
+        </div>
+
+        <div id="boxHomeContent" class="boxscore-subtab active">
+          <div class="stats-group">
+            <div id="homePassingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>C/ATT</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>INT</th>
+                  <th>SACKS</th>
+                  <th>RTG</th>
+                </tr>
+              </thead>
+              <tbody id="homePassingBody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-group">
+            <div id="homeRushingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>CAR</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>LONG</th>
+                </tr>
+              </thead>
+              <tbody id="homeRushingBody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-group">
+            <div id="homeReceivingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>REC</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>LONG</th>
+                  <th>TGTS</th>
+                </tr>
+              </thead>
+              <tbody id="homeReceivingBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="boxOverviewContent" class="boxscore-subtab">
+          <div class="stats-placeholder">Overview coming soon...</div>
+        </div>
+
+        <div id="boxAwayContent" class="boxscore-subtab">
+          <div class="stats-group">
+            <div id="awayPassingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>C/ATT</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>INT</th>
+                  <th>SACKS</th>
+                  <th>RTG</th>
+                </tr>
+              </thead>
+              <tbody id="awayPassingBody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-group">
+            <div id="awayRushingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>CAR</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>LONG</th>
+                </tr>
+              </thead>
+              <tbody id="awayRushingBody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-group">
+            <div id="awayReceivingTitle" class="stats-title"></div>
+            <table class="stats-table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>REC</th>
+                  <th>YDS</th>
+                  <th>AVG</th>
+                  <th>TD</th>
+                  <th>LONG</th>
+                  <th>TGTS</th>
+                </tr>
+              </thead>
+              <tbody id="awayReceivingBody"></tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -20,6 +20,15 @@
         if (target) target.classList.add('active');
       });
     });
+    document.querySelectorAll('.boxscore-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.boxscore-pill').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.boxscore-subtab').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        const target = document.getElementById(btn.dataset.subtab);
+        if (target) target.classList.add('active');
+      });
+    });
     loadGamesList();
   });
 
@@ -97,19 +106,18 @@
               playHistory = data;
               frontendStats = [];
 
-              let lastPlayer = null;
-
               playHistory.forEach(play => {
                 if (!play.Player || !play.PlayType || play.PlayType !== 'Run') return;
 
                 const player = play.Player;
+                const team = play.Possession || '';
                 const yards = parseFloat(play.Yards) || 0;
                 const td = play.Result === "Touchdown";
                 const fumble = play.Result === "Fumble";
 
-                let p = frontendStats.find(s => s.playername === player);
+                let p = frontendStats.find(s => s.playername === player && s.team === team);
                 if (!p) {
-                  p = { playername: player, carries: 0, yards: 0, tds: 0, fumbles: 0, long: 0 };
+                  p = { playername: player, team, carries: 0, yards: 0, tds: 0, fumbles: 0, long: 0 };
                   frontendStats.push(p);
                 }
 
@@ -118,17 +126,12 @@
                 if (td) p.tds++;
                 if (fumble) p.fumbles++;
                 if (yards > p.long) p.long = yards;
-
-                lastPlayer = player;
               });
 
               renderPlayTimeline();
 
               updateFatigueBasedOnStatsOnInitialLoad();
-              if (lastPlayer) {
-                console.log("✅ Rendering stats for", lastPlayer);
-                renderFullStatsPanel(lastPlayer);
-              }
+              renderBoxScore();
               await animatePlay();
             })
             .withFailureHandler(function (error) {
@@ -337,7 +340,7 @@
 
     applyFatigue(playerName, "Run");
 
-    updateFrontendStats(playerName, recordedYards, touchdown);
+    updateFrontendStats(playerName, recordedYards, touchdown, state.Possession);
     console.log(carryResult);
 
     document.getElementById("result").innerHTML = `<strong>${rbStats.name}</strong> ran for <strong>${carryResult.yards} yards</strong><br/><br/>` +
@@ -464,6 +467,22 @@
     updateTimeoutDots("awayTimeouts", state.AwayTimeouts || 0);
     document.getElementById("homeFootball").style.visibility = state.Possession === "Home" ? "visible" : "hidden";
     document.getElementById("awayFootball").style.visibility = state.Possession === "Away" ? "visible" : "hidden";
+    const homeTab = document.getElementById("boxHomeTab");
+    const awayTab = document.getElementById("boxAwayTab");
+    if (homeTab) homeTab.innerText = state.Home;
+    if (awayTab) awayTab.innerText = state.Away;
+    const titles = [
+      ["homePassingTitle", `${state.Home} Passing`],
+      ["homeRushingTitle", `${state.Home} Rushing`],
+      ["homeReceivingTitle", `${state.Home} Receiving`],
+      ["awayPassingTitle", `${state.Away} Passing`],
+      ["awayRushingTitle", `${state.Away} Rushing`],
+      ["awayReceivingTitle", `${state.Away} Receiving`]
+    ];
+    titles.forEach(([id, text]) => {
+      const el = document.getElementById(id);
+      if (el) el.innerText = text;
+    });
   }
 
   function celebrateTouchdown(team, oldScore, newScore) {
@@ -492,10 +511,10 @@
     });
   }
 
-  function updateFrontendStats(player, yards, td) {
-    let p = frontendStats.find(s => s.playername === player);
+  function updateFrontendStats(player, yards, td, team) {
+    let p = frontendStats.find(s => s.playername === player && s.team === team);
     if (!p) {
-      p = { playername: player, carries: 0, yards: 0, tds: 0, fumbles: 0, long: 0 };
+      p = { playername: player, team, carries: 0, yards: 0, tds: 0, fumbles: 0, long: 0 };
       frontendStats.push(p);
     }
     p.carries++;
@@ -503,7 +522,36 @@
     if (td) p.tds++;
     if (yards > p.long) p.long = yards;
 
-    renderFullStatsPanel(player);
+    renderBoxScore();
+  }
+
+  function renderBoxScore() {
+    renderRushingTable("Home");
+    renderRushingTable("Away");
+  }
+
+  function renderRushingTable(team) {
+    const body = document.getElementById(team === "Home" ? "homeRushingBody" : "awayRushingBody");
+    if (!body) return;
+    body.innerHTML = "";
+    const players = frontendStats.filter(p => p.team === team);
+    let total = { carries: 0, yards: 0, tds: 0, long: 0 };
+    players.forEach(p => {
+      const avg = p.carries ? (p.yards / p.carries).toFixed(1) : "0.0";
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${p.playername}</td><td>${p.carries}</td><td>${p.yards}</td><td>${avg}</td><td>${p.tds}</td><td>${p.long}</td>`;
+      body.appendChild(tr);
+      total.carries += p.carries;
+      total.yards += p.yards;
+      total.tds += p.tds;
+      if (p.long > total.long) total.long = p.long;
+    });
+    if (players.length) {
+      const avgTeam = total.carries ? (total.yards / total.carries).toFixed(1) : "0.0";
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>TEAM</td><td>${total.carries}</td><td>${total.yards}</td><td>${avgTeam}</td><td>${total.tds}</td><td>${total.long}</td>`;
+      body.appendChild(tr);
+    }
   }
 
   function applyFatigue(playerName, actionType) {
@@ -807,41 +855,7 @@
     });
   }
 
-  function renderFullStatsPanel(latestPlayer = null) {
-    const tbody = document.getElementById("statsTableBody");
-    tbody.innerHTML = "";
-
-    frontendStats.forEach(player => {
-      const tr = document.createElement("tr");
-      if (player.playername === latestPlayer) {
-        tr.classList.add("highlighted");
-      }
-
-      const fatigue = playerTraits[player.playername]?.fatigue ?? 0;
-      const { emoji, color } = getFatigueFace(fatigue);
-
-      tr.innerHTML = `
-            <td><span style="color: ${color}; font-size: 20px;">${emoji}</span> ${player.playername}</td>
-            <td>${player.carries}</td>
-            <td>${player.yards}</td>
-            <td>${player.tds}</td>
-            <td>${player.fumbles}</td>
-            <td>${player.long}</td>
-          `;
-
-      tbody.appendChild(tr);
-    });
-  }
-
-  function getFatigueFace(fatigue) {
-    if (fatigue > 20) return { emoji: "😄", color: "darkgreen" };
-    if (fatigue > 0) return { emoji: "🙂", color: "lightgreen" };
-    if (fatigue > -15) return { emoji: "😐", color: "goldenrod" };
-    if (fatigue > -30) return { emoji: "😰", color: "orange" };
-    return { emoji: "😢", color: "red" };
-  }
-
-   function playSound(id) {
+  function playSound(id) {
     const sound = document.getElementById(id);
     if (sound) {
       sound.currentTime = 0; // rewind

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -428,6 +428,42 @@
     font-weight: bold;
   }
 
+  /* Box score card */
+  .boxscore-card {
+    max-width: 900px;
+    margin: 40px auto;
+    background: var(--gray-medium);
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 0 12px rgba(0,0,0,0.4);
+  }
+  .boxscore-pill-container {
+    display: flex;
+    background: #d0d0d0;
+    border-radius: 20px;
+    overflow: hidden;
+    margin-bottom: 20px;
+  }
+  .boxscore-pill {
+    flex: 1;
+    padding: 8px 12px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--gray-dark);
+    font-weight: 600;
+  }
+  .boxscore-pill.active {
+    background: var(--gray-medium);
+    color: var(--text-light);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  }
+  .boxscore-subtab { display: none; }
+  .boxscore-subtab.active { display: block; }
+  .stats-group { margin-bottom: 30px; }
+  .stats-title { font-weight: 700; margin: 10px 0; }
+  .stats-placeholder { text-align: center; padding: 40px 0; color: var(--text-muted); }
+
   /* Play log */
   .play-log-card {
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- add box score card with home/overview/away subtabs
- style pill tabs and dark mode tables for clarity
- render rushing stats per team and update UI dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68901a8b803c8324985eed14fa1308cb