### PR TITLE
Add overview side-by-side stats layout and refine box score UI

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -193,7 +193,112 @@
         </div>
 
         <div id="boxOverviewContent" class="boxscore-subtab">
-          <div class="stats-placeholder">Overview coming soon...</div>
+          <div class="overview-section">
+            <div class="stats-row">
+              <div class="team-table">
+                <div id="overviewHomePassingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>C/ATT</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>INT</th>
+                      <th>SACKS</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewHomePassingBody"></tbody>
+                </table>
+              </div>
+              <div class="team-table">
+                <div id="overviewAwayPassingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>C/ATT</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>INT</th>
+                      <th>SACKS</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewAwayPassingBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div class="overview-section">
+            <div class="stats-row">
+              <div class="team-table">
+                <div id="overviewHomeRushingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>CAR</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>LONG</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewHomeRushingBody"></tbody>
+                </table>
+              </div>
+              <div class="team-table">
+                <div id="overviewAwayRushingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>CAR</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>LONG</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewAwayRushingBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div class="overview-section">
+            <div class="stats-row">
+              <div class="team-table">
+                <div id="overviewHomeReceivingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>REC</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>LONG</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewHomeReceivingBody"></tbody>
+                </table>
+              </div>
+              <div class="team-table">
+                <div id="overviewAwayReceivingTitle" class="stats-title"></div>
+                <table class="stats-table condensed">
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>REC</th>
+                      <th>YDS</th>
+                      <th>TD</th>
+                      <th>LONG</th>
+                    </tr>
+                  </thead>
+                  <tbody id="overviewAwayReceivingBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div id="boxAwayContent" class="boxscore-subtab">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -477,11 +477,29 @@
       ["homeReceivingTitle", `${state.Home} Receiving`],
       ["awayPassingTitle", `${state.Away} Passing`],
       ["awayRushingTitle", `${state.Away} Rushing`],
-      ["awayReceivingTitle", `${state.Away} Receiving`]
+      ["awayReceivingTitle", `${state.Away} Receiving`],
+      ["overviewHomePassingTitle", `${state.Home} Passing`],
+      ["overviewHomeRushingTitle", `${state.Home} Rushing`],
+      ["overviewHomeReceivingTitle", `${state.Home} Receiving`],
+      ["overviewAwayPassingTitle", `${state.Away} Passing`],
+      ["overviewAwayRushingTitle", `${state.Away} Rushing`],
+      ["overviewAwayReceivingTitle", `${state.Away} Receiving`]
     ];
     titles.forEach(([id, text]) => {
       const el = document.getElementById(id);
       if (el) el.innerText = text;
+    });
+    highlightTeamRows();
+  }
+
+  function highlightTeamRows() {
+    document.querySelectorAll('.stats-table tbody').forEach(tb => {
+      tb.querySelectorAll('tr').forEach(row => {
+        const cell = row.querySelector('td');
+        if (cell && cell.textContent.trim().toUpperCase() === 'TEAM') {
+          row.classList.add('team-row');
+        }
+      });
     });
   }
 

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -439,9 +439,10 @@
   }
   .boxscore-pill-container {
     display: flex;
-    background: #d0d0d0;
+    background: var(--gray-light);
     border-radius: 20px;
-    overflow: hidden;
+    padding: 4px;
+    gap: 4px;
     margin-bottom: 20px;
   }
   .boxscore-pill {
@@ -452,17 +453,40 @@
     cursor: pointer;
     color: var(--gray-dark);
     font-weight: 600;
+    border-radius: 16px;
   }
   .boxscore-pill.active {
-    background: var(--gray-medium);
+    background: var(--accent-red);
     color: var(--text-light);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.5);
   }
   .boxscore-subtab { display: none; }
   .boxscore-subtab.active { display: block; }
   .stats-group { margin-bottom: 30px; }
   .stats-title { font-weight: 700; margin: 10px 0; }
   .stats-placeholder { text-align: center; padding: 40px 0; color: var(--text-muted); }
+
+  .overview-section { margin-bottom: 30px; }
+  .stats-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+  .team-table {
+    display: flex;
+    flex-direction: column;
+  }
+  .stats-table.condensed th,
+  .stats-table.condensed td {
+    padding: 6px 8px;
+  }
+  .stats-table .team-row td {
+    font-weight: 700;
+  }
+  @media (max-width: 768px) {
+    .stats-row {
+      grid-template-columns: 1fr;
+    }
+  }
 
   /* Play log */
   .play-log-card {


### PR DESCRIPTION
## Summary
- add Overview subtab with side-by-side home/away passing, rushing, and receiving tables
- highlight team total rows in all stats tables
- improve box score pill styling and responsive layout for overview tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68901ec4ee3c8324a74ae29182c751a3