### PR TITLE
Enhance mobile layout and sort box score by yards

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -546,13 +546,14 @@
   function renderBoxScore() {
     renderRushingTable("Home");
     renderRushingTable("Away");
+    sortBoxScoreTables();
   }
 
   function renderRushingTable(team) {
     const body = document.getElementById(team === "Home" ? "homeRushingBody" : "awayRushingBody");
     if (!body) return;
     body.innerHTML = "";
-    const players = frontendStats.filter(p => p.team === team);
+    const players = frontendStats.filter(p => p.team === team).sort((a, b) => b.yards - a.yards);
     let total = { carries: 0, yards: 0, tds: 0, long: 0 };
     players.forEach(p => {
       const avg = p.carries ? (p.yards / p.carries).toFixed(1) : "0.0";
@@ -570,6 +571,22 @@
       tr.innerHTML = `<td>TEAM</td><td>${total.carries}</td><td>${total.yards}</td><td>${avgTeam}</td><td>${total.tds}</td><td>${total.long}</td>`;
       body.appendChild(tr);
     }
+  }
+
+  function sortBoxScoreTables() {
+    document.querySelectorAll('#boxscore .stats-table tbody').forEach(tbody => {
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const teamRow = rows.find(r => r.firstElementChild && r.firstElementChild.textContent.trim().toUpperCase() === 'TEAM');
+      const playerRows = teamRow ? rows.filter(r => r !== teamRow) : rows;
+      playerRows.sort((a, b) => {
+        const aYards = parseFloat(a.children[2].textContent) || 0;
+        const bYards = parseFloat(b.children[2].textContent) || 0;
+        return bYards - aYards;
+      });
+      tbody.innerHTML = '';
+      playerRows.forEach(r => tbody.appendChild(r));
+      if (teamRow) tbody.appendChild(teamRow);
+    });
   }
 
   function applyFatigue(playerName, actionType) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -483,6 +483,71 @@
     font-weight: 700;
   }
   @media (max-width: 768px) {
+    body {
+      font-size: 18px;
+      padding: 30px;
+    }
+    .game-carousel {
+      gap: 16px;
+      padding: 14px;
+      height: 12vh;
+    }
+    .game-card {
+      width: 30vw;
+      padding: 14px;
+    }
+    .game-card .teams {
+      font-size: 16px;
+    }
+    .game-card .score {
+      font-size: 14px;
+    }
+    .tabs {
+      margin-bottom: 30px;
+    }
+    .tab-button {
+      padding: 14px 20px;
+      font-size: 18px;
+    }
+    .scoreboard {
+      padding: 20px;
+      height: 140px;
+    }
+    .team-name { font-size: 18px; }
+    .team-record { font-size: 20px; }
+    .team-score { font-size: 56px; }
+    .game-info {
+      padding: 12px 14px;
+      gap: 14px;
+    }
+    .game-info .info-label,
+    .game-info .info-value {
+      font-size: 20px;
+    }
+    .control-panel {
+      padding: 24px;
+    }
+    button {
+      padding: 16px;
+      font-size: 18px;
+    }
+    .full-stats-panel,
+    .boxscore-card,
+    .play-log-card {
+      padding: 24px;
+    }
+    .stats-header {
+      font-size: 28px;
+    }
+    .stats-table th,
+    .stats-table td {
+      padding: 12px;
+      font-size: 18px;
+    }
+    .boxscore-pill {
+      padding: 10px 16px;
+      font-size: 18px;
+    }
     .stats-row {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## Summary
- Increase font sizes, spacing, and button dimensions on small screens for better mobile usability
- Sort box score stat tables by yards and keep team totals at the bottom

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890212a2fac83248e1f87a59125f24f