### PR TITLE
Add movable first down line to field

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -86,6 +86,8 @@
         <div class="yardline" style="left: 83.3333%;">10</div>
         <div class="yardline" style="left: 91.6667%;"></div>
         <div class="yardline" style="left: 100%;"></div>
+        <!-- First down line -->
+        <div id="firstDownLine" class="yardline first-down-line"></div>
         <!-- Drive Line (white line showing entire drive so far) -->
         <div id="drive3D" class="driveSegment">
           <div class="drive-dot"></div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -490,6 +490,7 @@
       if (el) el.innerText = text;
     });
     highlightTeamRows();
+    updateFirstDownLine();
   }
 
   function highlightTeamRows() {
@@ -501,6 +502,21 @@
         }
       });
     });
+  }
+
+  function updateFirstDownLine() {
+    const line = document.getElementById('firstDownLine');
+    const field = document.getElementById('field3D');
+    if (!line || !field) return;
+    const fieldWidth = field.offsetWidth;
+    const yardPx = fieldWidth / 120;
+    const ball = Number(state.BallOn) || 0;
+    const dist = Number(state.Distance) || 0;
+    let targetYard = state.Possession === 'Home'
+      ? ball + dist
+      : ball - dist;
+    targetYard = Math.max(0, Math.min(100, targetYard));
+    line.style.left = `${(targetYard + 10) * yardPx}px`;
   }
 
   function celebrateTouchdown(team, oldScore, newScore) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -286,6 +286,10 @@
     font-size: 16px;
     color: white;
   }
+  .first-down-line {
+    background-color: yellow;
+    z-index: 1;
+  }
   .driveSegment {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Summary
- Draw a yellow first down marker on the field
- Style the marker to overlay yard lines without blocking drive animations
- Reposition the marker dynamically from game state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890230945948324bce2e069d901f267