### PR TITLE
Improve mobile layout and accessibility

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -2,7 +2,8 @@
 <html>
   <head>
     <base target="_top" />
-    <?!= include('PlayUIstyle'); ?> 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <?!= include('PlayUIstyle'); ?>
   </head>
   <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -14,6 +14,7 @@
   body {
     margin: 0;
     padding: 20px;
+    min-height: 100vh;
     font-family: 'Roboto', Arial, sans-serif;
     background: linear-gradient(135deg, var(--gray-dark) 0%, var(--gray-medium) 100%);
     color: var(--text-light);
@@ -488,69 +489,73 @@
   }
   @media (max-width: 768px) {
     body {
-      font-size: 18px;
-      padding: 30px;
+      font-size: 20px;
+      padding: 40px 30px;
     }
     .game-carousel {
-      gap: 16px;
-      padding: 14px;
-      height: 12vh;
+      gap: 20px;
+      padding: 20px;
+      height: 14vh;
     }
     .game-card {
-      width: 30vw;
-      padding: 14px;
+      width: 40vw;
+      padding: 18px;
     }
     .game-card .teams {
-      font-size: 16px;
-    }
-    .game-card .score {
-      font-size: 14px;
-    }
-    .tabs {
-      margin-bottom: 30px;
-    }
-    .tab-button {
-      padding: 14px 20px;
       font-size: 18px;
     }
-    .scoreboard {
-      padding: 20px;
-      height: 140px;
+    .game-card .score {
+      font-size: 16px;
     }
-    .team-name { font-size: 18px; }
-    .team-record { font-size: 20px; }
-    .team-score { font-size: 56px; }
+    .tabs {
+      margin-bottom: 40px;
+    }
+    .tab-button {
+      padding: 16px 24px;
+      font-size: 20px;
+    }
+    .scoreboard {
+      padding: 24px;
+      height: 160px;
+    }
+    .team-name { font-size: 20px; }
+    .team-record { font-size: 22px; }
+    .team-score { font-size: 64px; }
     .game-info {
-      padding: 12px 14px;
-      gap: 14px;
+      padding: 16px 18px;
+      gap: 18px;
     }
     .game-info .info-label,
     .game-info .info-value {
-      font-size: 20px;
+      font-size: 22px;
     }
     .control-panel {
-      padding: 24px;
+      padding: 28px;
+    }
+    .button-row {
+      gap: 20px;
+      margin-top: 24px;
     }
     button {
-      padding: 16px;
-      font-size: 18px;
+      padding: 20px;
+      font-size: 20px;
     }
     .full-stats-panel,
     .boxscore-card,
     .play-log-card {
-      padding: 24px;
+      padding: 28px;
     }
     .stats-header {
-      font-size: 28px;
+      font-size: 32px;
     }
     .stats-table th,
     .stats-table td {
-      padding: 12px;
-      font-size: 18px;
+      padding: 14px;
+      font-size: 20px;
     }
     .boxscore-pill {
-      padding: 10px 16px;
-      font-size: 18px;
+      padding: 12px 18px;
+      font-size: 20px;
     }
     .stats-row {
       grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Add viewport meta tag and body min-height to fill tall mobile screens
- Increase font sizes, padding, and button spacing for better touch targets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890c62208948324851513b87f87bb66