### PR TITLE
Improve scoreboard responsiveness and text scaling

### DIFF
--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -11,6 +11,10 @@
     --text-muted: #B0B0B0;
   }
 
+  * {
+    box-sizing: border-box;
+  }
+
   body {
     margin: 0;
     padding: 5vw;
@@ -109,18 +113,18 @@
 
   /* Scoreboard */
   .scoreboard {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
     background: var(--gray-medium);
-    padding: 3.75vw 5vw;
+    padding: clamp(10px, 3vw, 24px) clamp(12px, 5vw, 32px);
     border: 1px solid var(--gray-light);
     border-radius: 4px 4px 0 0;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
     position: relative;
     overflow: hidden;
     margin-bottom: 0;
-    height: 30vw;
+    height: clamp(120px, 30vw, 220px);
     border-bottom: none;
   }
   .scoreboard.scoring {
@@ -153,6 +157,7 @@
     display: flex;
     align-items: center;
     height: 100%;
+    justify-content: center;
   }
   .team-block.away {
     flex-direction: row-reverse;
@@ -162,7 +167,8 @@
     flex-direction: column;
     align-items: center;
     height: 100%;
-    width: 30vw;
+    width: auto;
+    flex: 1 1 0;
   }
   .team-logo {
     flex: 0 0 50%;
@@ -175,14 +181,14 @@
     align-items: center;
     justify-content: center;
     font-weight: 700;
-    font-size: 4vw;
+    font-size: clamp(14px, 4vw, 28px);
   }
   .team-record {
     flex: 0 0 25%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 4.5vw;
+    font-size: clamp(12px, 3.5vw, 24px);
     color: var(--text-muted);
   }
   .score-section {
@@ -190,14 +196,14 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin: 0 2.5vw;
+    margin: 0 clamp(1vw, 2vw, 16px);
   }
   .score-row {
     display: flex;
     align-items: center;
   }
   .team-score {
-    font-size: 12vw;
+    font-size: clamp(32px, 10vw, 120px);
     font-weight: 700;
   }
   .timeouts {
@@ -206,8 +212,8 @@
     margin-top: 1vw;
   }
   .timeout-dot {
-    width: 2vw;
-    height: 2vw;
+    width: clamp(6px, 2vw, 14px);
+    height: clamp(6px, 2vw, 14px);
     border-radius: 50%;
     background: yellow;
   }
@@ -215,14 +221,14 @@
     opacity: 0.2;
   }
   .center-info {
-    font-size: 6vw;
+    font-size: clamp(16px, 5vw, 36px);
     font-weight: 700;
     color: var(--accent-red);
     text-align: center;
-    min-width: 30vw;
+    min-width: clamp(80px, 25vw, 160px);
   }
   .football-icon {
-    font-size: 5.5vw;
+    font-size: clamp(20px, 5.5vw, 40px);
     visibility: hidden;
   }
   .team-block.home .football-icon {
@@ -338,6 +344,7 @@
     display: block;
     font-weight: 600;
     margin-bottom: 1.5vw;
+    font-size: clamp(14px, 4vw, 20px);
   }
   .control-panel select {
     width: 100%;
@@ -346,6 +353,7 @@
     color: var(--text-light);
     border: 1px solid var(--gray-light);
     border-radius: 4px;
+    font-size: clamp(14px, 4vw, 20px);
   }
   .button-row {
     display: flex;
@@ -358,7 +366,7 @@
 
   button {
     padding: 3vw;
-    font-size: 4vw;
+    font-size: clamp(14px, 4vw, 20px);
     background: var(--gray-light);
     color: var(--text-light);
     border: 1px solid var(--accent-red);
@@ -416,6 +424,7 @@
   .stats-table td {
     padding: 2.5vw;
     text-align: center;
+    font-size: clamp(12px, 3.5vw, 18px);
   }
   .stats-table th {
     background: var(--gray-light);
@@ -468,7 +477,7 @@
   .boxscore-subtab { display: none; }
   .boxscore-subtab.active { display: block; }
   .stats-group { margin-bottom: 7.5vw; }
-  .stats-title { font-weight: 700; margin: 2.5vw 0; }
+  .stats-title { font-weight: 700; margin: 2.5vw 0; font-size: clamp(14px, 4vw, 24px); }
   .stats-placeholder { text-align: center; padding: 10vw 0; color: var(--text-muted); }
 
   .overview-section { margin-bottom: 7.5vw; }
@@ -506,6 +515,7 @@
     padding: 2vw;
     border-bottom: 1px solid var(--gray-light);
     text-align: left;
+    font-size: clamp(12px, 3.5vw, 18px);
   }
   .play-log-table th {
     background: var(--gray-light);


### PR DESCRIPTION
## Summary
- Adjust scoreboard layout to use responsive grid and clamp-based font sizes
- Increase font sizes for player selection, play log and box score tables for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890cdcc3d688324a36936b9aa9485a3