### PR TITLE
feat: make header elements sticky and collapsible

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -8,7 +8,10 @@
   <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
 
-    <div id="gameCarousel" class="game-carousel"></div>
+    <div class="carousel-wrapper">
+      <button id="carouselToggle" class="carousel-toggle">▲</button>
+      <div id="gameCarousel" class="game-carousel"></div>
+    </div>
     <div id="scoreboard" class="scoreboard">
       <div id="scoreBanner" class="score-banner"></div>
       <div class="team-block home">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -8,7 +8,26 @@
   let frontendStats = [];
   let gameId = 1;
   let playHistory = [];
-  
+
+
+  function updateStickyOffsets() {
+    const carousel = document.getElementById('gameCarousel');
+    const scoreboard = document.getElementById('scoreboard');
+    if (!carousel || !scoreboard) return;
+    const root = document.documentElement;
+    const carouselHeight = carousel.classList.contains('collapsed') ? 0 : carousel.offsetHeight;
+    root.style.setProperty('--carouselHeight', carouselHeight + 'px');
+    root.style.setProperty('--scoreboardHeight', scoreboard.offsetHeight + 'px');
+  }
+
+  function toggleCarousel() {
+    const carousel = document.getElementById('gameCarousel');
+    const toggle = document.getElementById('carouselToggle');
+    if (!carousel || !toggle) return;
+    carousel.classList.toggle('collapsed');
+    toggle.textContent = carousel.classList.contains('collapsed') ? '▼' : '▲';
+    updateStickyOffsets();
+  }
 
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.tab-button').forEach(btn => {
@@ -29,6 +48,10 @@
         if (target) target.classList.add('active');
       });
     });
+    const toggle = document.getElementById('carouselToggle');
+    if (toggle) toggle.addEventListener('click', toggleCarousel);
+    updateStickyOffsets();
+    window.addEventListener('resize', updateStickyOffsets);
     loadGamesList();
   });
 
@@ -52,6 +75,7 @@
       });
       container.appendChild(card);
     });
+    updateStickyOffsets();
   }
 
   function toggleMenu() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -9,6 +9,8 @@
     --gray-light: #2c2c2c;
     --text-light: #F5F5F5;
     --text-muted: #B0B0B0;
+    --carouselHeight: 0px;
+    --scoreboardHeight: 0px;
   }
 
   * {
@@ -25,19 +27,48 @@
   }
 
   /* Game carousel */
+  .carousel-wrapper {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--gray-medium);
+  }
+
+  .carousel-toggle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: var(--gray-light);
+    color: var(--text-light);
+    border: none;
+    padding: 1vw;
+    cursor: pointer;
+    z-index: 105;
+  }
+
   .game-carousel {
     display: flex;
     overflow-x: auto;
+    overflow-y: hidden;
     gap: 3vw;
     padding: 2.5vw;
-    margin-bottom: 5vw;
+    margin-bottom: 0;
     height: 10vh;
     box-sizing: border-box;
     scroll-behavior: smooth;
+    background: var(--gray-medium);
+    transition: height 0.3s ease, padding 0.3s ease, margin 0.3s ease;
 
     /* Hide scrollbar - Chrome, Safari */
     scrollbar-width: none;           /* Firefox */
     -ms-overflow-style: none;        /* IE/Edge */
+  }
+  .game-carousel.collapsed {
+    height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-bottom: 0;
+    overflow: hidden;
   }
   .game-carousel::-webkit-scrollbar {
     display: none;                   /* Chrome/Safari */
@@ -84,6 +115,9 @@
     border-top: none;
     border-radius: 0 0 4px 4px;
     overflow: hidden;
+    position: sticky;
+    top: calc(var(--carouselHeight) + var(--scoreboardHeight));
+    z-index: 80;
   }
   .tab-button {
     flex: 1;
@@ -121,7 +155,9 @@
     border: 1px solid var(--gray-light);
     border-radius: 4px 4px 0 0;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
-    position: relative;
+    position: sticky;
+    top: var(--carouselHeight);
+    z-index: 90;
     overflow: hidden;
     margin-bottom: 0;
     height: clamp(120px, 50vw, 320px);
@@ -597,7 +633,7 @@
     .game-carousel {
       gap: 24px;
       padding: 20px;
-      margin-bottom: 40px;
+      margin-bottom: 0;
       height: 120px;
     }
 


### PR DESCRIPTION
## Summary
- make game carousel collapsible with toggle button
- keep game carousel, scoreboard, and tabs sticky
- ensure rest of content scrolls behind sticky header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890fa6a02cc8324ab3a67535b5c0900