### PR TITLE
Add offensive formation builder with drag-and-drop

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -106,9 +106,42 @@
             <div class="last-dot"></div>
           </div>
           <canvas id="arcCanvas" style="position: absolute; top: 0; left: 0; z-index: 1; width: 100%; height: 100%;"></canvas>
-          <div id="catchPoint" style="position: absolute;  font-size: 5.5vw;  color: black;  opacity: 0;  z-index: 4;  pointer-events: none;  transition: opacity 0.5s ease;"></div>
+        <div id="catchPoint" style="position: absolute;  font-size: 5.5vw;  color: black;  opacity: 0;  z-index: 4;  pointer-events: none;  transition: opacity 0.5s ease;"></div>
         </div>
       </div>
+        </div>
+
+        <div id="formationPanel" class="formation-panel">
+          <h3>Offensive Formation</h3>
+          <div class="formation-field">
+            <div class="formation-row top-row">
+              <div class="formation-slot wr" data-position="WR1"></div>
+              <div class="te-group">
+                <div class="formation-slot teol" data-position="TEOL1"></div>
+                <div class="formation-slot teol required" data-position="TEOL2"></div>
+                <div class="formation-slot teol required" data-position="TEOL3"></div>
+                <div class="formation-slot teol required" data-position="TEOL4"></div>
+                <div class="formation-slot teol" data-position="TEOL5"></div>
+              </div>
+              <div class="formation-slot wr" data-position="WR2"></div>
+              <div class="formation-slot wr" data-position="WR3"></div>
+            </div>
+            <div class="formation-row middle-row">
+              <div class="formation-slot qb required" data-position="QB"></div>
+            </div>
+            <div class="formation-row bottom-row">
+              <div class="formation-slot rb" data-position="RB1"></div>
+              <div class="formation-slot rb" data-position="RB2"></div>
+            </div>
+          </div>
+          <div class="player-bank-wrapper">
+            <h4>Player Bank</h4>
+            <div id="playerBank" class="player-bank"></div>
+          </div>
+          <div class="formation-actions">
+            <button id="clearFormation">Clear</button>
+            <button id="saveFormation">Save</button>
+          </div>
         </div>
 
         <div class="control-panel">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -8,6 +8,7 @@
   let frontendStats = [];
   let gameId = 1;
   let playHistory = [];
+  let savedFormations = [];
 
 
   function updateStickyOffsets() {
@@ -48,12 +49,25 @@
         if (target) target.classList.add('active');
       });
     });
-    const toggle = document.getElementById('carouselToggle');
-    if (toggle) toggle.addEventListener('click', toggleCarousel);
-    updateStickyOffsets();
-    window.addEventListener('resize', updateStickyOffsets);
-    loadGamesList();
-  });
+      const toggle = document.getElementById('carouselToggle');
+      if (toggle) toggle.addEventListener('click', toggleCarousel);
+      updateStickyOffsets();
+      window.addEventListener('resize', updateStickyOffsets);
+      loadGamesList();
+      document.querySelectorAll('.formation-slot').forEach(slot => {
+        slot.addEventListener('dragover', allowDrop);
+        slot.addEventListener('drop', handleDrop);
+      });
+      const bank = document.getElementById('playerBank');
+      if (bank) {
+        bank.addEventListener('dragover', allowDrop);
+        bank.addEventListener('drop', handleDrop);
+      }
+      const clearBtn = document.getElementById('clearFormation');
+      if (clearBtn) clearBtn.addEventListener('click', clearFormation);
+      const saveBtn = document.getElementById('saveFormation');
+      if (saveBtn) saveBtn.addEventListener('click', saveFormation);
+    });
 
   function loadGamesList() {
     google.script.run.withSuccessHandler(renderGameCards).getGamesList();
@@ -272,21 +286,112 @@
     computeDriveInfo();
   }
 
-  function loadPlayers() {
-    const dropdown = document.getElementById("playerDropdown");
-    dropdown.innerHTML = "";
+    function loadPlayers() {
+      const dropdown = document.getElementById("playerDropdown");
+      dropdown.innerHTML = "";
 
-    const teamName = state[state.Possession];
+      const teamName = state[state.Possession];
 
-    Object.entries(playerTraits).forEach(([name, traits]) => {
-      if (traits.team === teamName) {
-        const option = document.createElement("option");
-        option.value = name;
-        option.text = name;
-        dropdown.appendChild(option);
+      Object.entries(playerTraits).forEach(([name, traits]) => {
+        if (traits.team === teamName) {
+          const option = document.createElement("option");
+          option.value = name;
+          option.text = name;
+          dropdown.appendChild(option);
+        }
+      });
+      populatePlayerBank();
+    }
+
+    function populatePlayerBank() {
+      const bank = document.getElementById('playerBank');
+      if (!bank) return;
+      // Clear existing assignments
+      document.querySelectorAll('.formation-slot').forEach(slot => {
+        if (slot.firstChild) {
+          bank.appendChild(slot.firstChild);
+        }
+        slot.classList.remove('filled');
+        slot.dataset.player = '';
+      });
+      bank.innerHTML = '';
+      const teamName = state[state.Possession];
+      Object.entries(playerTraits).forEach(([name, traits]) => {
+        if (traits.team === teamName) {
+          const item = document.createElement('div');
+          item.className = 'player-item';
+          item.draggable = true;
+          item.dataset.player = name;
+          item.textContent = name;
+          item.addEventListener('dragstart', dragStart);
+          bank.appendChild(item);
+        }
+      });
+    }
+
+    function dragStart(e) {
+      e.dataTransfer.setData('text/plain', e.target.dataset.player);
+    }
+
+    function allowDrop(e) {
+      e.preventDefault();
+    }
+
+    function handleDrop(e) {
+      e.preventDefault();
+      const name = e.dataTransfer.getData('text/plain');
+      const item = document.querySelector(`.player-item[data-player="${name}"]`);
+      if (!item) return;
+      const source = item.parentElement;
+      const target = e.currentTarget;
+      if (target.classList.contains('formation-slot')) {
+        if (target.firstChild) {
+          document.getElementById('playerBank').appendChild(target.firstChild);
+        }
+        target.appendChild(item);
+        target.classList.add('filled');
+        target.dataset.player = name;
+      } else {
+        target.appendChild(item);
       }
-    });
-  }
+      if (source.classList && source.classList.contains('formation-slot')) {
+        source.classList.remove('filled');
+        source.dataset.player = '';
+      }
+    }
+
+    function clearFormation() {
+      const bank = document.getElementById('playerBank');
+      if (!bank) return;
+      document.querySelectorAll('.formation-slot').forEach(slot => {
+        if (slot.firstChild) {
+          bank.appendChild(slot.firstChild);
+        }
+        slot.classList.remove('filled');
+        slot.dataset.player = '';
+      });
+    }
+
+    function saveFormation() {
+      const required = ['QB','TEOL2','TEOL3','TEOL4'];
+      const formation = [];
+      let valid = true;
+      document.querySelectorAll('.formation-slot').forEach(slot => {
+        const pos = slot.dataset.position;
+        const playerEl = slot.querySelector('.player-item');
+        if (playerEl) {
+          formation.push({ position: pos, player: playerEl.dataset.player });
+        } else if (required.includes(pos)) {
+          valid = false;
+        }
+      });
+      if (!valid) {
+        alert('Please fill all required positions');
+        return;
+      }
+      savedFormations.push(formation);
+      console.log('Saved formation', formation);
+    }
 
   function loadPlayersTraits(callback) {
     google.script.run.withSuccessHandler(function (playerData) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -686,9 +686,77 @@
       padding: 16px;
     }
 
-    .stats-title {
+  .stats-title {
       font-size: 24px;
       margin: 20px 0;
     }
+  }
+
+  /* Formation builder */
+  .formation-panel {
+    margin-top: 5vw;
+    padding: 5vw;
+    background: var(--gray-medium);
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.4);
+  }
+
+  .formation-field {
+    margin-bottom: 4vw;
+  }
+
+  .formation-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 2vw;
+    margin-bottom: 2vw;
+  }
+
+  .formation-row.top-row {
+    justify-content: space-between;
+  }
+
+  .te-group {
+    display: flex;
+    gap: 2vw;
+  }
+
+  .formation-slot {
+    width: 10vw;
+    height: 10vw;
+    border: 2px dashed var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: clamp(10px, 3vw, 14px);
+  }
+
+  .formation-slot.required {
+    border-color: var(--accent-red);
+  }
+
+  .formation-slot.filled {
+    border-style: solid;
+  }
+
+  .player-bank {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1vw;
+  }
+
+  .player-item {
+    padding: 1vw 2vw;
+    background: var(--gray-light);
+    border: 1px solid var(--text-light);
+    border-radius: 4px;
+    cursor: grab;
+  }
+
+  .formation-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 2vw;
   }
 </style>


### PR DESCRIPTION
## Summary
- add offensive formation panel with draggable roster slots
- style formation builder and player bank
- implement drag-and-drop logic and save/clear formation support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6893714cd07483248ed14f22fe72dc18