### PR TITLE
feat: modernize formation editor

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -85,6 +85,7 @@ function getPlayerTraits() {
     .map(row => ({
       team: row[0],
       name: row[1],
+      position: row[2],
       size: row[5],
       strength: row[6],
       speed: row[7],

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -111,40 +111,8 @@
       </div>
         </div>
 
-        <div id="formationPanel" class="formation-panel">
-          <h3>Offensive Formation</h3>
-          <div class="formation-field">
-            <div class="formation-row top-row">
-              <div class="formation-slot wr" data-position="WR1"></div>
-              <div class="te-group">
-                <div class="formation-slot teol" data-position="TEOL1"></div>
-                <div class="formation-slot teol required" data-position="TEOL2"></div>
-                <div class="formation-slot teol required" data-position="TEOL3"></div>
-                <div class="formation-slot teol required" data-position="TEOL4"></div>
-                <div class="formation-slot teol" data-position="TEOL5"></div>
-              </div>
-              <div class="formation-slot wr" data-position="WR2"></div>
-              <div class="formation-slot wr" data-position="WR3"></div>
-            </div>
-            <div class="formation-row middle-row">
-              <div class="formation-slot qb required" data-position="QB"></div>
-            </div>
-            <div class="formation-row bottom-row">
-              <div class="formation-slot rb" data-position="RB1"></div>
-              <div class="formation-slot rb" data-position="RB2"></div>
-            </div>
-          </div>
-          <div class="player-bank-wrapper">
-            <h4>Player Bank</h4>
-            <div id="playerBank" class="player-bank"></div>
-          </div>
-          <div class="formation-actions">
-            <button id="clearFormation">Clear</button>
-            <button id="saveFormation">Save</button>
-          </div>
-        </div>
-
         <div class="control-panel">
+          <button id="openFormation">Edit Formation</button>
           <label for="playerDropdown">Select Player:</label>
           <select id="playerDropdown"></select>
           <div class="button-row">
@@ -406,6 +374,42 @@
     <div id="teamstats" class="tab-content">
       <div class="play-log-card">
         <p>Team stats coming soon...</p>
+      </div>
+    </div>
+
+    <div id="formationModal" class="modal">
+      <div id="formationPanel" class="formation-panel">
+        <span id="closeFormation" class="close-button">&times;</span>
+        <h3>Offensive Formation</h3>
+        <div class="formation-field">
+          <div class="formation-row top-row">
+            <div class="formation-slot wr" data-position="WR1"></div>
+            <div class="te-group">
+              <div class="formation-slot teol" data-position="TEOL1"></div>
+              <div class="formation-slot teol required" data-position="TEOL2"></div>
+              <div class="formation-slot teol required" data-position="TEOL3"></div>
+              <div class="formation-slot teol required" data-position="TEOL4"></div>
+              <div class="formation-slot teol" data-position="TEOL5"></div>
+            </div>
+            <div class="formation-slot wr" data-position="WR2"></div>
+            <div class="formation-slot wr" data-position="WR3"></div>
+          </div>
+          <div class="formation-row middle-row">
+            <div class="formation-slot qb required" data-position="QB"></div>
+          </div>
+          <div class="formation-row bottom-row">
+            <div class="formation-slot rb" data-position="RB1"></div>
+            <div class="formation-slot rb" data-position="RB2"></div>
+          </div>
+        </div>
+        <div class="bench-wrapper">
+          <h4>Bench</h4>
+          <div id="bench" class="bench"></div>
+        </div>
+        <div class="formation-actions">
+          <button id="clearFormation">Clear</button>
+          <button id="saveFormation">Save</button>
+        </div>
       </div>
     </div>
 

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -58,15 +58,23 @@
         slot.addEventListener('dragover', allowDrop);
         slot.addEventListener('drop', handleDrop);
       });
-      const bank = document.getElementById('playerBank');
-      if (bank) {
-        bank.addEventListener('dragover', allowDrop);
-        bank.addEventListener('drop', handleDrop);
+      const bench = document.getElementById('bench');
+      if (bench) {
+        bench.addEventListener('dragover', allowDrop);
+        bench.addEventListener('drop', handleDrop);
       }
       const clearBtn = document.getElementById('clearFormation');
       if (clearBtn) clearBtn.addEventListener('click', clearFormation);
       const saveBtn = document.getElementById('saveFormation');
       if (saveBtn) saveBtn.addEventListener('click', saveFormation);
+      const openBtn = document.getElementById('openFormation');
+      if (openBtn) openBtn.addEventListener('click', () => {
+        document.getElementById('formationModal').classList.add('open');
+      });
+      const closeBtn = document.getElementById('closeFormation');
+      if (closeBtn) closeBtn.addEventListener('click', () => {
+        document.getElementById('formationModal').classList.remove('open');
+      });
     });
 
   function loadGamesList() {
@@ -300,21 +308,21 @@
           dropdown.appendChild(option);
         }
       });
-      populatePlayerBank();
+      populateBench();
     }
 
-    function populatePlayerBank() {
-      const bank = document.getElementById('playerBank');
-      if (!bank) return;
+    function populateBench() {
+      const bench = document.getElementById('bench');
+      if (!bench) return;
       // Clear existing assignments
       document.querySelectorAll('.formation-slot').forEach(slot => {
         if (slot.firstChild) {
-          bank.appendChild(slot.firstChild);
+          bench.appendChild(slot.firstChild);
         }
         slot.classList.remove('filled');
         slot.dataset.player = '';
       });
-      bank.innerHTML = '';
+      bench.innerHTML = '';
       const teamName = state[state.Possession];
       Object.entries(playerTraits).forEach(([name, traits]) => {
         if (traits.team === teamName) {
@@ -322,9 +330,9 @@
           item.className = 'player-item';
           item.draggable = true;
           item.dataset.player = name;
-          item.textContent = name;
+          item.textContent = `${name} (${traits.position})`;
           item.addEventListener('dragstart', dragStart);
-          bank.appendChild(item);
+          bench.appendChild(item);
         }
       });
     }
@@ -346,7 +354,7 @@
       const target = e.currentTarget;
       if (target.classList.contains('formation-slot')) {
         if (target.firstChild) {
-          document.getElementById('playerBank').appendChild(target.firstChild);
+          document.getElementById('bench').appendChild(target.firstChild);
         }
         target.appendChild(item);
         target.classList.add('filled');
@@ -361,11 +369,11 @@
     }
 
     function clearFormation() {
-      const bank = document.getElementById('playerBank');
-      if (!bank) return;
+      const bench = document.getElementById('bench');
+      if (!bench) return;
       document.querySelectorAll('.formation-slot').forEach(slot => {
         if (slot.firstChild) {
-          bank.appendChild(slot.firstChild);
+          bench.appendChild(slot.firstChild);
         }
         slot.classList.remove('filled');
         slot.dataset.player = '';

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -694,11 +694,37 @@
 
   /* Formation builder */
   .formation-panel {
-    margin-top: 5vw;
     padding: 5vw;
     background: var(--gray-medium);
     border-radius: 4px;
     box-shadow: 0 0 10px rgba(0,0,0,0.4);
+    position: relative;
+  }
+
+  .modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal.open {
+    display: flex;
+  }
+
+  .close-button {
+    position: absolute;
+    top: 1vw;
+    right: 1vw;
+    font-size: 4vw;
+    line-height: 1;
+    cursor: pointer;
   }
 
   .formation-field {
@@ -725,22 +751,38 @@
   .formation-slot {
     width: 10vw;
     height: 10vw;
-    border: 2px dashed var(--text-muted);
+    border: 2px dotted var(--text-muted);
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: clamp(10px, 3vw, 14px);
+    position: relative;
+    color: var(--text-muted);
   }
 
+  .formation-slot::before {
+    content: attr(data-position);
+  }
+
+  .formation-slot.filled::before {
+    content: '';
+  }
+
+  .formation-slot.qb { border-color: #2196f3; color: #2196f3; }
+  .formation-slot.rb { border-color: #4caf50; color: #4caf50; }
+  .formation-slot.wr { border-color: #ff9800; color: #ff9800; }
+  .formation-slot.teol { border-color: #9c27b0; color: #9c27b0; }
+
   .formation-slot.required {
-    border-color: var(--accent-red);
+    box-shadow: 0 0 0 2px var(--accent-red);
   }
 
   .formation-slot.filled {
     border-style: solid;
   }
 
-  .player-bank {
+  .bench {
     display: flex;
     flex-wrap: wrap;
     gap: 1vw;
@@ -752,6 +794,7 @@
     border: 1px solid var(--text-light);
     border-radius: 4px;
     cursor: grab;
+    color: var(--text-light);
   }
 
   .formation-actions {


### PR DESCRIPTION
## Summary
- convert formation editor to modal with dedicated "Bench" and open/close controls
- display default positions and color-coded, dotted-circle slots
- expose player position data to front-end

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689376e1de788324b2f7f503d40a6aa5