### PR TITLE
Refine formation modal layout and bench UI

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -384,6 +384,7 @@
         <div class="formation-field">
           <div class="formation-row top-row">
             <div class="formation-slot wr" data-position="WR1"></div>
+            <div class="formation-slot gap" aria-hidden="true"></div>
             <div class="te-group">
               <div class="formation-slot teol" data-position="TEOL1"></div>
               <div class="formation-slot teol required" data-position="TEOL2"></div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -327,10 +327,14 @@
       Object.entries(playerTraits).forEach(([name, traits]) => {
         if (traits.team === teamName) {
           const item = document.createElement('div');
-          item.className = 'player-item';
+          let posClass = traits.position.toLowerCase();
+          if (posClass === 'te' || posClass === 'ol') posClass = 'teol';
+          item.className = `player-item ${posClass}`;
           item.draggable = true;
           item.dataset.player = name;
-          item.textContent = `${name} (${traits.position})`;
+          const initials = name.split(' ').map(n => n[0]).join('');
+          item.textContent = initials;
+          item.title = `${name} (${traits.position})`;
           item.addEventListener('dragstart', dragStart);
           bench.appendChild(item);
         }

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -722,11 +722,19 @@
 
   .close-button {
     position: absolute;
-    top: 1vw;
-    right: 1vw;
-    font-size: 4vw;
+    top: -2vw;
+    right: -2vw;
+    width: clamp(24px, 6vw, 32px);
+    height: clamp(24px, 6vw, 32px);
+    font-size: clamp(16px, 4vw, 24px);
     line-height: 1;
     cursor: pointer;
+    background: var(--gray-medium);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
   }
 
   .formation-field {
@@ -742,7 +750,7 @@
   }
 
   .formation-row.top-row {
-    justify-content: space-between;
+    justify-content: center;
   }
 
   .te-group {
@@ -778,6 +786,11 @@
   .formation-slot.wr { border-color: #ffb74d; color: #ffb74d; }
   .formation-slot.teol { border-color: #ba68c8; color: #ba68c8; }
 
+  .formation-slot.gap {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
   .formation-slot.required {
     box-shadow: none;
   }
@@ -800,17 +813,28 @@
   .bench {
     display: flex;
     flex-wrap: wrap;
-    gap: 1vw;
+    gap: 3vw;
   }
 
   .player-item {
-    padding: 1vw 2vw;
-    background: var(--gray-light);
-    border: 1px solid var(--text-light);
-    border-radius: 4px;
+    width: clamp(40px, 12vw, 70px);
+    height: clamp(40px, 12vw, 70px);
+    border: 2px solid var(--text-muted);
+    border-radius: 50%;
+    background: var(--gray-dark);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: clamp(10px, 3vw, 14px);
+    font-weight: 500;
+    color: var(--text-muted);
     cursor: grab;
-    color: var(--text-light);
   }
+
+  .player-item.qb { border-color: #64b5f6; color: #64b5f6; }
+  .player-item.rb { border-color: #81c784; color: #81c784; }
+  .player-item.wr { border-color: #ffb74d; color: #ffb74d; }
+  .player-item.teol { border-color: #ba68c8; color: #ba68c8; }
 
   .formation-actions {
     display: flex;


### PR DESCRIPTION
## Summary
- Position modal close button outside content to avoid overlap
- Render bench players as color-coded circular tokens for easier dragging
- Add placeholder gap to center WR1 relative to TE/OL group in formation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68937ca528c48324873e3472d971661c