### PR TITLE
feat: replace game carousel with clickable list

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -62,13 +62,29 @@ function getGamesList() {
   const idxAway = headers.indexOf('Away');
   const idxHomeScore = headers.indexOf('HomeScore');
   const idxAwayScore = headers.indexOf('AwayScore');
+  const idxQtr = headers.indexOf('Qtr');
+  const idxTime = headers.indexOf('Time');
+  const idxDown = headers.indexOf('Down');
+  const idxDistance = headers.indexOf('Distance');
+  const idxBallOn = headers.indexOf('BallOn');
+  const idxPoss = headers.indexOf('Possession');
+  const idxHomeLogo = headers.indexOf('HomeLogo');
+  const idxAwayLogo = headers.indexOf('AwayLogo');
 
   return data.slice(1).map(row => ({
     GameId: row[idxId],
     Home: row[idxHome],
     Away: row[idxAway],
     HomeScore: row[idxHomeScore],
-    AwayScore: row[idxAwayScore]
+    AwayScore: row[idxAwayScore],
+    Qtr: row[idxQtr],
+    Time: row[idxTime],
+    Down: row[idxDown],
+    Distance: row[idxDistance],
+    BallOn: row[idxBallOn],
+    Possession: row[idxPoss],
+    HomeLogo: row[idxHomeLogo],
+    AwayLogo: row[idxAwayLogo]
   }));
 }
 

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -7,12 +7,10 @@
   </head>
   <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
-
-    <div class="carousel-wrapper">
-      <button id="carouselToggle" class="carousel-toggle">▲</button>
-      <div id="gameCarousel" class="game-carousel"></div>
-    </div>
-    <div id="scoreboard" class="scoreboard">
+    <div id="gameList" class="game-list"></div>
+    <div id="gameUI" style="display:none;">
+      <button id="backButton" class="back-button">← Back</button>
+      <div id="scoreboard" class="scoreboard">
       <div id="scoreBanner" class="score-banner"></div>
       <div class="team-block home">
         <div class="team-info">
@@ -54,15 +52,15 @@
           </div>
         </div>
       </div>
-    </div>
-    <div class="tabs">
-      <button class="tab-button active" data-tab="gamecast">Gamecast</button>
-      <button class="tab-button" data-tab="playbyplay">Play-by-Play</button>
-      <button class="tab-button" data-tab="boxscore">Box Score</button>
-      <button class="tab-button" data-tab="teamstats">Team Stats</button>
-    </div>
+      </div>
+      <div class="tabs">
+        <button class="tab-button active" data-tab="gamecast">Gamecast</button>
+        <button class="tab-button" data-tab="playbyplay">Play-by-Play</button>
+        <button class="tab-button" data-tab="boxscore">Box Score</button>
+        <button class="tab-button" data-tab="teamstats">Team Stats</button>
+      </div>
 
-    <div id="gamecast" class="tab-content active">
+      <div id="gamecast" class="tab-content active">
       <div class="game-info">
         <div class="info-block">
           <div class="info-label">DOWN:</div>
@@ -407,11 +405,12 @@
           <h4>Bench</h4>
           <div id="bench" class="bench"></div>
         </div>
-        <div class="formation-actions">
-          <button id="clearFormation">Clear</button>
-          <button id="saveFormation">Save</button>
-        </div>
+      <div class="formation-actions">
+        <button id="clearFormation">Clear</button>
+        <button id="saveFormation">Save</button>
       </div>
+    </div>
+    </div>
     </div>
 
     <?!= include('PlayUIScript'); ?>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -12,22 +12,10 @@
 
 
   function updateStickyOffsets() {
-    const carousel = document.getElementById('gameCarousel');
     const scoreboard = document.getElementById('scoreboard');
-    if (!carousel || !scoreboard) return;
+    if (!scoreboard) return;
     const root = document.documentElement;
-    const carouselHeight = carousel.classList.contains('collapsed') ? 0 : carousel.offsetHeight;
-    root.style.setProperty('--carouselHeight', carouselHeight + 'px');
     root.style.setProperty('--scoreboardHeight', scoreboard.offsetHeight + 'px');
-  }
-
-  function toggleCarousel() {
-    const carousel = document.getElementById('gameCarousel');
-    const toggle = document.getElementById('carouselToggle');
-    if (!carousel || !toggle) return;
-    carousel.classList.toggle('collapsed');
-    toggle.textContent = carousel.classList.contains('collapsed') ? '▼' : '▲';
-    updateStickyOffsets();
   }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -49,11 +37,18 @@
         if (target) target.classList.add('active');
       });
     });
-      const toggle = document.getElementById('carouselToggle');
-      if (toggle) toggle.addEventListener('click', toggleCarousel);
       updateStickyOffsets();
       window.addEventListener('resize', updateStickyOffsets);
       loadGamesList();
+      const backBtn = document.getElementById('backButton');
+      if (backBtn) {
+        backBtn.addEventListener('click', () => {
+          document.getElementById('gameUI').style.display = 'none';
+          document.getElementById('gameList').style.display = 'block';
+          backBtn.style.display = 'none';
+          loadGamesList();
+        });
+      }
       document.querySelectorAll('.formation-slot').forEach(slot => {
         slot.addEventListener('dragover', allowDrop);
         slot.addEventListener('drop', handleDrop);
@@ -82,22 +77,43 @@
   }
 
   function renderGameCards(games) {
-    const container = document.getElementById('gameCarousel');
+    const container = document.getElementById('gameList');
     if (!container) return;
     container.innerHTML = '';
     games.forEach(g => {
       const card = document.createElement('div');
       const id = Number(g.GameId);
-      card.className = 'game-card' + (id === gameId ? ' active' : '');
-      card.innerHTML = `<div class="teams">${g.Away} @ ${g.Home}</div><div class="score">${g.AwayScore} - ${g.HomeScore}</div>`;
+      card.className = 'game-card';
+      card.innerHTML = `
+        <div class="team-row">
+          <img class="team-logo" src="${g.HomeLogo || ''}" alt="Home Logo" />
+          <span class="team-name">${g.Home}</span>
+          <span class="poss-indicator">${g.Possession === 'Home' ? '🏈' : ''}</span>
+          <span class="team-score">${g.HomeScore}</span>
+          <span class="info-sep">|</span>
+          <span class="team-time">${g.Time || ''}</span>
+          <span class="team-down">${formatDownDistance(g.Down, g.Distance)}</span>
+        </div>
+        <div class="team-row">
+          <img class="team-logo" src="${g.AwayLogo || ''}" alt="Away Logo" />
+          <span class="team-name">${g.Away}</span>
+          <span class="poss-indicator">${g.Possession === 'Away' ? '🏈' : ''}</span>
+          <span class="team-score">${g.AwayScore}</span>
+          <span class="info-sep">|</span>
+          <span class="team-qtr">${formatQuarter(g.Qtr)}</span>
+          <span class="team-ball">${formatBallOnForPoss(g.BallOn, g.Possession)}</span>
+        </div>`;
       card.addEventListener('click', () => {
+        gameId = id;
         refreshUI(id);
-        document.querySelectorAll('.game-card').forEach(c => c.classList.remove('active'));
-        card.classList.add('active');
+        document.getElementById('gameList').style.display = 'none';
+        document.getElementById('gameUI').style.display = 'block';
+        const backBtn = document.getElementById('backButton');
+        if (backBtn) backBtn.style.display = 'block';
+        updateStickyOffsets();
       });
       container.appendChild(card);
     });
-    updateStickyOffsets();
   }
 
   function toggleMenu() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -9,7 +9,6 @@
     --gray-light: #2c2c2c;
     --text-light: #F5F5F5;
     --text-muted: #B0B0B0;
-    --carouselHeight: 0px;
     --scoreboardHeight: 0px;
   }
 
@@ -25,83 +24,51 @@
     color: var(--text-light);
   }
 
-  /* Game carousel */
-  .carousel-wrapper {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: var(--gray-medium);
-  }
-
-  .carousel-toggle {
-    position: absolute;
-    top: 0;
-    right: 0;
-    background: var(--gray-light);
-    color: var(--text-light);
-    border: none;
-    padding: 1vw;
-    cursor: pointer;
-    z-index: 105;
-  }
-
-  .game-carousel {
-    display: flex;
-    overflow-x: auto;
-    overflow-y: hidden;
-    gap: 3vw;
+  /* Game list */
+  .game-list {
     padding: 2.5vw;
-    margin-bottom: 0;
-    height: 10vh;
-    box-sizing: border-box;
-    scroll-behavior: smooth;
-    background: var(--gray-medium);
-    transition: height 0.3s ease, padding 0.3s ease, margin 0.3s ease;
-
-    /* Hide scrollbar - Chrome, Safari */
-    scrollbar-width: none;           /* Firefox */
-    -ms-overflow-style: none;        /* IE/Edge */
-  }
-  .game-carousel.collapsed {
-    height: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    margin-bottom: 0;
-    overflow: hidden;
-  }
-  .game-carousel::-webkit-scrollbar {
-    display: none;                   /* Chrome/Safari */
   }
 
   .game-card {
-    flex: 0 0 auto;
-    width: 20vw; /* 20% of screen width */
-    height: 100%;
     background: var(--gray-medium);
     border: 1px solid var(--gray-light);
     border-radius: 4px;
-    padding: 2.5vw;
+    margin-bottom: 3vw;
     cursor: pointer;
-    text-align: center;
-    box-sizing: border-box;
+    padding: 2.5vw;
+  }
+
+  .game-card .team-row {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-
-  .game-card.active {
-    border-color: var(--accent-red);
-  }
-
-  .game-card .teams {
-    font-weight: 600;
+    align-items: center;
+    gap: 2vw;
     font-size: 4vw;
-    line-height: 1.2em;
   }
 
-  .game-card .score {
-    font-size: 3vw;
+  .game-card .team-row + .team-row {
     margin-top: 1vw;
+  }
+
+  .game-card .team-logo {
+    width: 8vw;
+    height: 8vw;
+    object-fit: contain;
+  }
+
+  .game-card .team-name {
+    flex: 1;
+  }
+
+  .game-card .poss-indicator {
+    margin-right: 2vw;
+  }
+
+  .game-card .team-score {
+    font-weight: bold;
+  }
+
+  .game-card .info-sep {
+    margin: 0 2vw;
   }
 
 
@@ -115,7 +82,7 @@
     border-radius: 0 0 4px 4px;
     overflow: hidden;
     position: sticky;
-    top: calc(var(--carouselHeight) + var(--scoreboardHeight));
+    top: var(--scoreboardHeight);
     z-index: 80;
   }
   .tab-button {
@@ -156,12 +123,24 @@
     border-radius: 4px 4px 0 0;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
     position: sticky;
-    top: var(--carouselHeight);
+    top: 0;
     z-index: 90;
     overflow: hidden;
     margin-bottom: 0;
     height: clamp(120px, 50vw, 320px);
     border-bottom: none;
+  }
+  .back-button {
+    position: fixed;
+    top: 1vw;
+    left: 1vw;
+    background: var(--gray-light);
+    color: var(--text-light);
+    border: none;
+    padding: 1vw 2vw;
+    cursor: pointer;
+    z-index: 110;
+    display: none;
   }
   .scoreboard.scoring {
     box-shadow: 0 0 25px var(--accent-red);
@@ -633,25 +612,13 @@
       font-size: 24px;
     }
 
-    .game-carousel {
-      gap: 24px;
-      padding: 20px;
-      margin-bottom: 0;
-      height: 120px;
-    }
-
     .game-card {
-      width: 200px;
       padding: 20px;
+      margin-bottom: 24px;
     }
 
-    .game-card .teams {
+    .game-card .team-row {
       font-size: 32px;
-    }
-
-    .game-card .score {
-      font-size: 24px;
-      margin-top: 8px;
     }
 
     .tabs {


### PR DESCRIPTION
## Summary
- start on a game list instead of the carousel
- each list item shows logos, scores, possession, time, quarter and field position
- add back button to return from game UI to list

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6893924054648324b31abe6caf8c6c49