### PR TITLE
Include defensive traits in player data fetch

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -94,7 +94,7 @@ function getPlayerTraits() {
     throw new Error("Sheet 'Players' not found.");
   }
 
-  const data = sheet.getRange("A2:T" + sheet.getLastRow()).getValues();
+  const data = sheet.getRange("A2:X" + sheet.getLastRow()).getValues();
   Logger.log(data);
   const result = data
     .filter(row => row[0] != null && row[0] !== '') // Ensure 'team' field exists
@@ -109,6 +109,10 @@ function getPlayerTraits() {
       juke: row[13],
       vision: row[14],
       acceleration: row[15],
+      runStop: row[20],
+      tackling: row[21],
+      runDef: row[22],
+      tackleChance: row[23],
       // Local tracking only
       carries: 0,
       fatigue: row[8]

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -131,17 +131,21 @@
     menu.innerHTML = '';
     Object.values(playerTraits).forEach(p => {
       const card = document.createElement('div');
-      card.className = 'player-card';
-      card.innerHTML = `
-            <h4>${p.name}</h4>
-            <div>Size: ${p.size}</div>
-            <div>Strength: ${p.strength}</div>
-            <div>Speed: ${p.speed}</div>
-            <div>Stamina: ${p.stamina}</div>
-          `;
-      menu.appendChild(card);
-    });
-  }
+        card.className = 'player-card';
+        card.innerHTML = `
+              <h4>${p.name}</h4>
+              <div>Size: ${p.size}</div>
+              <div>Strength: ${p.strength}</div>
+              <div>Speed: ${p.speed}</div>
+              <div>Stamina: ${p.stamina}</div>
+              <div>Run Stop: ${p.runStop}</div>
+              <div>Tackling: ${p.tackling}</div>
+              <div>Run Def: ${p.runDef}</div>
+              <div>Tackle Chance: ${p.tackleChance}</div>
+            `;
+        menu.appendChild(card);
+      });
+    }
 
   // === GAME SETUP ===
   function refreshUI(selectedGameId) {


### PR DESCRIPTION
## Summary
- Pull RunStop, Tackling, Run Def, and Tackle Chance from the Players sheet when fetching player traits.
- Display defensive attributes on player cards so they're available for future defensive attribution.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894c3ac73d483248a62bbefd8072f57