### PR TITLE
Improve mobile formation editor

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -382,24 +382,24 @@
         <h3>Offensive Formation</h3>
         <div class="formation-field">
           <div class="formation-row top-row">
-            <div class="formation-slot wr" data-position="WR1"></div>
+            <div class="formation-slot wr" data-position="WR1" data-label="WR 1"></div>
             <div class="formation-slot gap" aria-hidden="true"></div>
             <div class="te-group">
-              <div class="formation-slot teol" data-position="TEOL1"></div>
-              <div class="formation-slot teol required" data-position="TEOL2"></div>
-              <div class="formation-slot teol required" data-position="TEOL3"></div>
-              <div class="formation-slot teol required" data-position="TEOL4"></div>
-              <div class="formation-slot teol" data-position="TEOL5"></div>
+              <div class="formation-slot teol" data-position="TEOL1" data-label="TEOL1"></div>
+              <div class="formation-slot teol required" data-position="TEOL2" data-label="TEOL2"></div>
+              <div class="formation-slot teol required" data-position="TEOL3" data-label="TEOL3"></div>
+              <div class="formation-slot teol required" data-position="TEOL4" data-label="TEOL4"></div>
+              <div class="formation-slot teol" data-position="TEOL5" data-label="TEOL5"></div>
             </div>
-            <div class="formation-slot wr" data-position="WR2"></div>
-            <div class="formation-slot wr" data-position="WR3"></div>
+            <div class="formation-slot wr" data-position="WR2" data-label="Slot WR"></div>
+            <div class="formation-slot wr" data-position="WR3" data-label="WR 2"></div>
           </div>
           <div class="formation-row middle-row">
-            <div class="formation-slot qb required" data-position="QB"></div>
+            <div class="formation-slot qb required" data-position="QB" data-label="QB"></div>
           </div>
           <div class="formation-row bottom-row">
-            <div class="formation-slot rb" data-position="RB1"></div>
-            <div class="formation-slot rb" data-position="RB2"></div>
+            <div class="formation-slot rb" data-position="RB1" data-label="RB Left"></div>
+            <div class="formation-slot rb" data-position="RB2" data-label="RB Right"></div>
           </div>
         </div>
         <div class="bench-wrapper">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -16,6 +16,7 @@
   let offStarPower = false;
   let defStarPower = false;
   const RUN_POSITIONS = ['WR1','RB1','RB2','QB'];
+  let selectedPlayer = null;
 
 
   function updateStickyOffsets() {
@@ -59,11 +60,15 @@
       document.querySelectorAll('.formation-slot').forEach(slot => {
         slot.addEventListener('dragover', allowDrop);
         slot.addEventListener('drop', handleDrop);
+        slot.addEventListener('click', () => moveSelectedTo(slot));
+        slot.addEventListener('touchstart', e => { e.preventDefault(); moveSelectedTo(slot); });
       });
       const bench = document.getElementById('bench');
       if (bench) {
         bench.addEventListener('dragover', allowDrop);
         bench.addEventListener('drop', handleDrop);
+        bench.addEventListener('click', e => { if (e.target === bench) moveSelectedTo(bench); });
+        bench.addEventListener('touchstart', e => { if (e.target === bench) { e.preventDefault(); moveSelectedTo(bench); } });
       }
       const clearBtn = document.getElementById('clearFormation');
       if (clearBtn) clearBtn.addEventListener('click', clearFormation);
@@ -365,6 +370,8 @@
           item.textContent = name;
           item.title = `${name} (${traits.position})`;
           item.addEventListener('dragstart', dragStart);
+          item.addEventListener('touchstart', selectPlayer);
+          item.addEventListener('click', selectPlayer);
           bench.appendChild(item);
         }
       });
@@ -421,6 +428,44 @@
       }
     }
 
+    function selectPlayer(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      const item = e.currentTarget;
+      if (selectedPlayer === item) {
+        item.classList.remove('selected');
+        selectedPlayer = null;
+        return;
+      }
+      if (selectedPlayer) selectedPlayer.classList.remove('selected');
+      selectedPlayer = item;
+      item.classList.add('selected');
+    }
+
+    function moveSelectedTo(target) {
+      if (!selectedPlayer) return;
+      const bench = document.getElementById('bench');
+      const item = selectedPlayer;
+      const source = item.parentElement;
+      if (target.classList.contains('formation-slot')) {
+        if (target.firstChild) {
+          bench.appendChild(target.firstChild);
+          target.classList.remove('filled');
+        }
+        target.appendChild(item);
+        target.classList.add('filled');
+        target.dataset.player = item.dataset.player;
+      } else {
+        target.appendChild(item);
+      }
+      if (source.classList && source.classList.contains('formation-slot')) {
+        source.classList.remove('filled');
+        source.dataset.player = '';
+      }
+      item.classList.remove('selected');
+      selectedPlayer = null;
+    }
+
     function clearFormation() {
       const bench = document.getElementById('bench');
       if (!bench) return;
@@ -432,6 +477,8 @@
         slot.dataset.player = '';
       });
       currentFormation = [];
+      selectedPlayer = null;
+      document.querySelectorAll('.player-item.selected').forEach(p => p.classList.remove('selected'));
       updateRunnerDropdown();
     }
 
@@ -457,6 +504,7 @@
       savedFormations.push(formation);
       console.log('Saved formation', formation);
       setDefensiveFormation();
+      document.getElementById('formationModal').classList.remove('open');
     }
 
   function setDefensiveFormation() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -742,11 +742,11 @@
 
   .close-button {
     position: absolute;
-    top: -2vw;
-    right: -2vw;
-    width: clamp(24px, 6vw, 32px);
-    height: clamp(24px, 6vw, 32px);
-    font-size: clamp(16px, 4vw, 24px);
+    top: -3vw;
+    right: -3vw;
+    width: clamp(32px, 10vw, 60px);
+    height: clamp(32px, 10vw, 60px);
+    font-size: clamp(24px, 8vw, 40px);
     line-height: 1;
     cursor: pointer;
     background: var(--gray-medium);
@@ -765,8 +765,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 3vw;
-    margin-bottom: 3vw;
+    gap: 4vw;
+    margin-bottom: 4vw;
   }
 
   .formation-row.top-row {
@@ -779,22 +779,23 @@
   }
 
   .formation-slot {
-    width: clamp(40px, 12vw, 70px);
-    height: clamp(40px, 12vw, 70px);
+    width: clamp(60px, 16vw, 90px);
+    height: clamp(60px, 16vw, 90px);
     border: 2px solid var(--text-muted);
     border-radius: 50%;
     background: var(--gray-dark);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: clamp(10px, 3vw, 14px);
+    font-size: clamp(12px, 4vw, 18px);
     font-weight: 500;
     position: relative;
     color: var(--text-muted);
+    touch-action: manipulation;
   }
 
   .formation-slot::before {
-    content: attr(data-position);
+    content: attr(data-label);
   }
 
   .formation-slot.filled::before {
@@ -837,18 +838,24 @@
   }
 
   .player-item {
-    width: clamp(40px, 12vw, 70px);
-    height: clamp(40px, 12vw, 70px);
+    width: clamp(60px, 16vw, 90px);
+    height: clamp(60px, 16vw, 90px);
     border: 2px solid var(--text-muted);
     border-radius: 50%;
     background: var(--gray-dark);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: clamp(10px, 3vw, 14px);
+    font-size: clamp(12px, 4vw, 18px);
     font-weight: 500;
     color: var(--text-muted);
     cursor: grab;
+    touch-action: manipulation;
+  }
+
+  .player-item.selected {
+    border-color: var(--accent-red);
+    border-width: 4px;
   }
 
   .player-item.qb { border-color: #64b5f6; color: #64b5f6; }


### PR DESCRIPTION
## Summary
- Resize formation slots, player nodes, and close button for easier mobile interactions
- Enable tap-to-select and tap-to-place for formation players; save action closes the modal
- Rename formation slot labels for clarity (RB Left/Right, WR labels)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6897812eb0fc83248a3a5f8849b987dc