### PR TITLE
Ensure formation slots stay uniform size and scroll

### DIFF
--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -768,6 +768,7 @@
 
   .formation-field {
     margin-bottom: 4vw;
+    overflow-x: auto;
   }
 
   .formation-row {
@@ -785,9 +786,11 @@
   .te-group {
     display: flex;
     gap: 2vw;
+    flex-shrink: 0;
   }
 
   .formation-slot {
+    flex: 0 0 clamp(60px, 16vw, 90px);
     width: clamp(60px, 16vw, 90px);
     height: clamp(60px, 16vw, 90px);
     border: 2px solid var(--text-muted);


### PR DESCRIPTION
## Summary
- Prevent formation slots from shrinking by applying a fixed flex-basis
- Add horizontal scrolling to the formation field so all slots remain visible
- Keep tight end group width from collapsing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689786d92c0c8324b03612f400237dc7