### PR TITLE
Limit '& Goal' to goal-to-go situations

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -294,8 +294,9 @@
   function formatDownDistance(down, distance, ballOn = state.BallOn, possession = state.Possession) {
     const ord = ["1st", "2nd", "3rd", "4th"];
     const d = ord[down - 1] || down + "th";
-    const yardsToGoal = possession === "Home" ? 100 - ballOn : ballOn;
-    const distText = (yardsToGoal < 10 && distance <= yardsToGoal) ? "Goal" : distance;
+    const yardsToGoal = possession === "Home" ? 100 - Number(ballOn) : Number(ballOn);
+    const dist = Number(distance);
+    const distText = dist === yardsToGoal ? "Goal" : dist;
     return `${d} & ${distText}`;
   }
 


### PR DESCRIPTION
## Summary
- Adjust down and distance formatter to display `Goal` only when the line to gain is the goal line, keeping the marker across the series.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899d617ebd8832494822b5201ed9687