### PR TITLE
Highlight red zone in game info

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -1005,7 +1005,9 @@
     downEl.innerText = formatDownDistance(state.Down, state.Distance, state.BallOn, state.Possession);
     const inRedZone = (state.Possession === "Home" && state.BallOn >= 80) || (state.Possession === "Away" && state.BallOn <= 20);
     downEl.classList.toggle('red-zone', inRedZone);
-    document.getElementById("ballOn").innerText = formatBallOn(state.BallOn);
+    const ballEl = document.getElementById("ballOn");
+    ballEl.innerText = formatBallOn(state.BallOn);
+    ballEl.classList.toggle('red-zone', inRedZone);
     document.getElementById("homeName").innerText = state.Home;
     document.getElementById("awayName").innerText = state.Away;
     document.getElementById("homeRecord").innerText = state.HomeRecord || "";

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -374,6 +374,10 @@
     color: var(--text-light);
   }
 
+  .game-info .info-value.red-zone {
+    color: var(--accent-red);
+  }
+
   /* Field (unchanged except for wrapper positioning) */
   .field-wrapper {
     width: 100%;


### PR DESCRIPTION
## Summary
- Highlight red-zone situations in the in-game info, affecting down & ball-on displays.
- Add CSS rule so red-zone styling overrides default game-info text color.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899d9a80fa08324b5d6ac550cbdb5cd