### PR TITLE
Make formation modal fullscreen with card-style bench

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -406,9 +406,15 @@
           item.className = `player-item ${posClass}`;
           item.draggable = true;
           item.dataset.player = name;
-          //const initials = name.split(' ').map(n => n[0]).join('');
-          item.textContent = name;
           item.title = `${name} (${traits.position})`;
+          const offStars = '★'.repeat(Number(traits.offStars) || 0);
+          const defStars = '★'.repeat(Number(traits.defStars) || 0);
+          item.innerHTML = `
+            <div class="player-name">${name}</div>
+            <div class="star-row"><span>Off:</span><span class="stars off">${offStars}</span></div>
+            <div class="star-row"><span>Def:</span><span class="stars def">${defStars}</span></div>
+            <div class="player-attributes"><span>Size: ${traits.size}</span><span>Speed: ${traits.speed}</span></div>
+          `;
           item.addEventListener('dragstart', dragStart);
           item.addEventListener('touchstart', selectPlayer);
           item.addEventListener('click', selectPlayer);

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -749,6 +749,21 @@
     max-width: 90vw;
   }
 
+  /* Full screen formation modal */
+  #formationModal {
+    padding: 0;
+  }
+
+  #formationPanel {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
+
   .modal {
     position: fixed;
     top: 0;
@@ -811,7 +826,7 @@
     flex: 0 0 clamp(60px, 16vw, 90px);
     width: clamp(60px, 16vw, 90px);
     height: clamp(60px, 16vw, 90px);
-    border: 2px solid var(--text-muted);
+    border: 2px dotted var(--text-muted);
     border-radius: 50%;
     background: var(--gray-dark);
     display: flex;
@@ -822,6 +837,7 @@
     position: relative;
     color: var(--text-muted);
     touch-action: manipulation;
+    overflow: hidden;
   }
 
   .formation-slot::before {
@@ -864,23 +880,45 @@
   .bench {
     display: flex;
     flex-wrap: wrap;
-    gap: 3vw;
+    gap: 2vw;
   }
 
   .player-item {
-    width: clamp(60px, 16vw, 90px);
-    height: clamp(60px, 16vw, 90px);
+    flex: 1 1 calc(50% - 2vw);
+    max-width: calc(50% - 2vw);
     border: 2px solid var(--text-muted);
-    border-radius: 50%;
+    border-radius: 8px;
     background: var(--gray-dark);
+    padding: 1vw;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-direction: column;
+    gap: 0.5vw;
     font-size: clamp(12px, 4vw, 18px);
     font-weight: 500;
-    color: var(--text-muted);
-    cursor: grab;
+    color: var(--text-light);
+    cursor: pointer;
     touch-action: manipulation;
+  }
+
+  .player-item .player-name {
+    font-weight: 600;
+  }
+
+  .star-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5vw;
+  }
+
+  .star {
+    color: gold;
+  }
+
+  .player-attributes {
+    display: flex;
+    justify-content: space-between;
+    font-size: clamp(10px, 3vw, 14px);
+    color: var(--text-muted);
   }
 
   .player-item.selected {
@@ -888,10 +926,30 @@
     border-width: 4px;
   }
 
-  .player-item.qb { border-color: #64b5f6; color: #64b5f6; }
-  .player-item.rb { border-color: #81c784; color: #81c784; }
-  .player-item.wr { border-color: #ffb74d; color: #ffb74d; }
-  .player-item.teol { border-color: #ba68c8; color: #ba68c8; }
+  .player-item.qb { border-color: #64b5f6; }
+  .player-item.rb { border-color: #81c784; }
+  .player-item.wr { border-color: #ffb74d; }
+  .player-item.teol { border-color: #ba68c8; }
+
+  .formation-slot .player-item {
+    flex: none;
+    max-width: none;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    padding: 0;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .formation-slot .player-item .star-row,
+  .formation-slot .player-item .player-attributes {
+    display: none;
+  }
+
+  .formation-slot .player-item .player-name {
+    text-align: center;
+  }
 
   .los-panel { max-width: 90vw; }
   .los-field {


### PR DESCRIPTION
## Summary
- Expand formation modal to occupy full screen for easier editing
- Render bench players as selectable cards with star ratings and attributes
- Highlight empty formation slots with dotted borders that solidify when filled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899e0699ef88324bc13433fd118674d