### PR TITLE
Refine UI layout and button styling

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -94,7 +94,7 @@
         <!-- First down line -->
         <div id="firstDownLine" class="yardline first-down-line"></div>
         <!-- Drive Line (white line showing entire drive so far) -->
-        <div class="driveWrapper">
+      <div class="driveWrapper">
           <div id="drive3D" class="driveSegment">
             <div class="drive-dot"></div>
           </div>
@@ -109,6 +109,8 @@
       </div>
         </div>
 
+        <div id="lastPlayDesc" class="last-play-desc"></div>
+
         <div class="control-panel">
           <button id="openFormation">Edit Formation</button>
           <button id="viewLOS">View LOS</button>
@@ -119,7 +121,6 @@
           <button onclick="nextDrive()">🔁 Next Drive</button>
         </div>
         <div id="result" class="result-box"></div>
-        <div id="lastPlayDesc" class="last-play-desc"></div>
       </div>
 
     </div>

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -459,7 +459,7 @@
   /* Control panel */
   .control-panel {
     max-width: 900px;
-    margin: 7.5vw auto;
+    margin: 3vw auto 7.5vw;
     background: var(--gray-medium);
     border-radius: 4px;
     padding: 5vw;
@@ -490,18 +490,18 @@
   }
 
   button {
-    padding: 3vw;
+    padding: 2vw 4vw;
     font-size: clamp(14px, 4vw, 20px);
-    background: var(--gray-light);
+    background: var(--accent-red);
     color: var(--text-light);
-    border: 1px solid var(--accent-red);
+    border: none;
     border-radius: 4px;
     cursor: pointer;
     transition: background 0.3s, color 0.3s;
   }
   button:hover {
-    background: var(--gray-medium);
-    color: var(--accent-red);
+    background: var(--accent-red-dark);
+    color: var(--text-light);
   }
 
   .result-box {
@@ -514,8 +514,10 @@
   }
 
   .last-play-desc {
-    margin-top: 2vw;
+    max-width: 900px;
+    margin: 2vw auto;
     font-size: 3vw;
+    text-align: center;
   }
 
   .red-zone {


### PR DESCRIPTION
## Summary
- Show last play summary beneath field and before the control panel card.
- Style buttons with team accent colors and improved padding.
- Tweak control panel spacing and align last-play description for better layout.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/football-game/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68a24eadb8788324937c0005539beb1b