### PR TITLE
Add scoring summary toggle to play-by-play view

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -126,7 +126,12 @@
     </div>
 
     <div id="playbyplay" class="tab-content">
+      <div class="playbyplay-pill-container">
+        <button class="playbyplay-pill active" data-subtab="all">All Plays</button>
+        <button class="playbyplay-pill" data-subtab="summary">Scoring Summary</button>
+      </div>
       <div id="playTimeline" class="drive-log"></div>
+      <div id="scoringSummary" class="scoring-summary" style="display:none;"></div>
     </div>
 
     <div id="boxscore" class="tab-content">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -45,6 +45,17 @@
         if (target) target.classList.add('active');
       });
     });
+    document.querySelectorAll('.playbyplay-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.playbyplay-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const showSummary = btn.dataset.subtab === 'summary';
+        document.getElementById('playTimeline').style.display = showSummary ? 'none' : '';
+        const summaryDiv = document.getElementById('scoringSummary');
+        if (showSummary) renderScoringSummary();
+        summaryDiv.style.display = showSummary ? '' : 'none';
+      });
+    });
       updateStickyOffsets();
       window.addEventListener('resize', updateStickyOffsets);
       loadGamesList();
@@ -474,6 +485,60 @@
     });
     computeDriveInfo();
     updateLastPlayDesc();
+    renderScoringSummary();
+  }
+
+  function renderScoringSummary() {
+    const container = document.getElementById('scoringSummary');
+    if (!container) return;
+    container.innerHTML = '';
+    const scoringPlays = playHistory.filter(p => ['Touchdown', 'Field Goal', 'Safety'].includes(p.Result));
+    const byQuarter = {};
+    scoringPlays.forEach(p => {
+      const q = p.Qtr || state.Qtr;
+      if (!byQuarter[q]) byQuarter[q] = [];
+      byQuarter[q].push(p);
+    });
+    Object.keys(byQuarter).sort((a,b) => a - b).forEach(q => {
+      const qLabel = formatQuarter(q).toUpperCase();
+      const qText = qLabel === 'OT' ? 'OVERTIME' : `${qLabel} QUARTER`;
+      const header = document.createElement('div');
+      header.className = 'summary-quarter';
+      header.innerHTML = `<span class="quarter-label">${qText}</span><span class="home-name">${state.Home}</span><span class="away-name">${state.Away}</span>`;
+      container.appendChild(header);
+      const line = document.createElement('div');
+      line.className = 'summary-line';
+      container.appendChild(line);
+      let idx = 0;
+      byQuarter[q].forEach(play => {
+        const row = document.createElement('div');
+        row.className = 'summary-play' + (idx % 2 ? ' alt' : '');
+        const logo = document.createElement('img');
+        logo.className = 'summary-logo';
+        logo.src = play.Possession === 'Home' ? (state.HomeLogo || '') : (state.AwayLogo || '');
+        const resultDiv = document.createElement('div');
+        resultDiv.className = 'summary-result-time';
+        const map = { 'Touchdown':'TD', 'Field Goal':'FG', 'Safety':'Safety' };
+        const time = new Date(play.Timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+        resultDiv.textContent = `${map[play.Result] || play.Result} ${time}`;
+        const homeScore = document.createElement('div');
+        homeScore.className = 'summary-home-score';
+        homeScore.textContent = play.HomeScore;
+        const awayScore = document.createElement('div');
+        awayScore.className = 'summary-away-score';
+        awayScore.textContent = play.AwayScore;
+        const desc = document.createElement('div');
+        desc.className = 'summary-description';
+        desc.innerHTML = buildPlayText(play);
+        row.appendChild(logo);
+        row.appendChild(resultDiv);
+        row.appendChild(homeScore);
+        row.appendChild(awayScore);
+        row.appendChild(desc);
+        container.appendChild(row);
+        idx++;
+      });
+    });
   }
 
     function loadPlayers() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1069,4 +1069,88 @@
     justify-content: flex-end;
     gap: 2vw;
   }
+
+  /* Play-by-play toggle */
+  .playbyplay-pill-container {
+    display: flex;
+    background: var(--gray-dark);
+    border-radius: 20px;
+    padding: clamp(4px, 1vw, 12px);
+    gap: clamp(4px, 1vw, 12px);
+    margin-bottom: 5vw;
+  }
+  .playbyplay-pill {
+    flex: 1;
+    padding: 2vw 3vw;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    border-radius: 16px;
+    color: var(--text-muted);
+    font-size: clamp(12px, 4vw, 30px);
+  }
+  .playbyplay-pill.active {
+    background: var(--gray-light);
+    color: var(--text-light);
+    font-weight: 700;
+  }
+
+  /* Scoring summary */
+  .summary-quarter {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    padding: 2vw;
+    font-weight: 700;
+    color: var(--text-light);
+  }
+  .summary-quarter .home-name,
+  .summary-quarter .away-name {
+    margin-left: 4vw;
+  }
+  .summary-line {
+    height: 1px;
+    background: var(--gray-light);
+  }
+  .summary-play {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    grid-template-rows: auto auto;
+    align-items: center;
+    padding: 2vw;
+    background: var(--gray-dark);
+  }
+  .summary-play.alt {
+    background: var(--gray-medium);
+  }
+  .summary-logo {
+    grid-row: 1 / span 2;
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 2vw;
+  }
+  .summary-result-time {
+    grid-row: 1;
+    grid-column: 2;
+    font-weight: 700;
+  }
+  .summary-home-score,
+  .summary-away-score {
+    grid-row: 1 / span 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+  }
+  .summary-home-score { grid-column: 3; }
+  .summary-away-score { grid-column: 4; }
+  .summary-description {
+    grid-row: 2;
+    grid-column: 2 / span 3;
+    margin-top: 0.5vw;
+  }
 </style>


### PR DESCRIPTION
## Summary
- add pill toggle for All Plays vs Scoring Summary on play-by-play card
- group scoring plays by quarter with alternating row colors and team logos
- style toggle and summary elements for pill appearance

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68a3955337b8832484be375c44489171