### PR TITLE
Implement tackle selection based on yardage and player traits

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -197,11 +197,28 @@ function getStaminaDrains() {
   return staminaDrainMap;
 }
 
+function getTackleDistributions() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
+  const data = sheet.getDataRange().getValues();
+
+  return data
+    .filter(row => typeof row[0] === "string" && row[0].startsWith("Tackle_"))
+    .map(row => ({
+      label: row[0],
+      yardageCap: Number(row[1]),
+      DL: Number(row[2]) || 0,
+      LB: Number(row[3]) || 0,
+      DBS: Number(row[4]) || 0
+    }))
+    .sort((a, b) => a.yardageCap - b.yardageCap);
+}
+
 function getFrontendSettings() {
   return {
     thresholds: getRunThresholdsFromSettings(),
     breakaways: getBreakawayYards(),
-    staminaDrains: getStaminaDrains()
+    staminaDrains: getStaminaDrains(),
+    tackleTable: getTackleDistributions()
   };
 }
 function predictPlayType(down, distance) {

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -5,6 +5,7 @@
   let rollThresholds = [];
   let breakawaySettings = [];
   let drainSettings = {};  // Populated from backend on load
+  let tackleSettings = [];
   let frontendStats = [];
   let gameId = 1;
   let playHistory = [];
@@ -907,6 +908,7 @@
       rollThresholds = data.thresholds;
       breakawaySettings = data.breakaways;
       drainSettings = data.staminaDrains;
+      tackleSettings = data.tackleTable || [];
       if (callback) callback();
     }).getFrontendSettings();
   }
@@ -934,6 +936,39 @@
     if (total <= 0) return { defenseWins: false };
     const roll = Math.floor(Math.random() * total) + 1;
     return { defenseWins: roll <= dlTotal };
+  }
+
+  function determineTackler(yards) {
+    if (!tackleSettings || tackleSettings.length === 0) return "NA";
+    const gain = Math.max(0, Math.floor(Math.abs(yards)));
+    let range = tackleSettings.find(r => gain <= r.yardageCap);
+    if (!range) range = tackleSettings[tackleSettings.length - 1];
+
+    const roll = Math.random() * 100;
+    let group = "DBS";
+    if (roll < range.DL) {
+      group = "DL";
+    } else if (roll < range.DL + range.LB) {
+      group = "LB";
+    }
+
+    const inGroup = defensiveFormation.filter(f => {
+      if (!f.player) return false;
+      if (group === "DL") return f.position.startsWith("DL");
+      if (group === "LB") return f.position.startsWith("LB");
+      return f.position.startsWith("DB") || f.position.startsWith("S");
+    });
+    if (inGroup.length === 0) return "NA";
+
+    const total = inGroup.reduce((sum, f) => sum + Number(playerTraits[f.player]?.tackleChance || 0), 0);
+    if (total <= 0) return inGroup[Math.floor(Math.random() * inGroup.length)].player;
+
+    let r = Math.random() * total;
+    for (const f of inGroup) {
+      r -= Number(playerTraits[f.player]?.tackleChance || 0);
+      if (r <= 0) return f.player;
+    }
+    return inGroup[inGroup.length - 1].player;
   }
 
   function tryAutoStuff() {
@@ -1034,6 +1069,10 @@
     const touchdown = state.Possession === "Home"
       ? (state.BallOn < 100 && newBall >= 100)
       : (state.BallOn > 0 && newBall <= 0);
+
+    if (!touchdown) {
+      tackler = determineTackler(yardDelta);
+    }
 
     let newDown = state.Down;
     let newDist = state.Distance - yardDelta;


### PR DESCRIPTION
## Summary
- read tackle probability settings from the Settings sheet and expose to the frontend
- determine tackler by yardage, defensive formation, and players' tackle chances
- log the selected tackler with each play

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4e39652948324869eacb3c2406d4d