### PR TITLE
Remove timestamps in favor of seconds-based game time

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -247,44 +247,39 @@ function logPlayHistory(play) {
     return;
   }
 
-  const {
-    gameid,
-    timestamp,  // ✅ use this
-    qtr,
-    time,
-    possession,
-    down,
-    distance,
-    ballon,
-    playtype,
-    player,
-    yards,
-    defensepredicted,
-    predictioncorrect,
-    tackler,
-    result,
-    desc,
-    newdown,
-    newdist,
-    newballon,
-    drivestart,
-    homescore,
-    awayscore
-  } = play;
+    const {
+      gameid,
+      time,
+      qtr,
+      possession,
+      down,
+      distance,
+      ballon,
+      playtype,
+      player,
+      yards,
+      defensepredicted,
+      predictioncorrect,
+      tackler,
+      result,
+      desc,
+      newdown,
+      newdist,
+      newballon,
+      drivestart,
+      homescore,
+      awayscore
+    } = play;
 
-  // Convert ISO string to Date object if needed
-  const ts = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
-
-  sheet.appendRow([
-    String(gameid || ""),
-    ts,
-    Number(qtr) || 0,
-    Number(time) || 0,
-    String(possession || ""),
-    Number(down) || 0,
-    Number(distance) || 0,
-    Number(ballon) || 0,
-    String(playtype || ""),
+    sheet.appendRow([
+      String(gameid || ""),
+      Number(time) || 0,
+      Number(qtr) || 0,
+      String(possession || ""),
+      Number(down) || 0,
+      Number(distance) || 0,
+      Number(ballon) || 0,
+      String(playtype || ""),
     String(player || ""),
     Number(yards) || 0,
     String(defensepredicted || ""),
@@ -311,25 +306,20 @@ function getPlayHistory(gameId) {
   const data = sheet.getDataRange().getValues();
   if (data.length < 2) return []; // no data
 
-  const headers = data[0];
-  const rows = data.slice(1);
-  const timezone = Session.getScriptTimeZone();
+    const headers = data[0];
+    const rows = data.slice(1);
 
-  const result = rows
-    .filter(row => row[0] == gameId) // column A = GameId
-    .map(row => {
-      const obj = {};
-      headers.forEach((key, i) => {
-        if (key === "Timestamp" && row[i] instanceof Date) {
-          obj[key] = Utilities.formatDate(row[i], timezone, "yyyy-MM-dd'T'HH:mm:ssXXX");
-        } else {
+    const result = rows
+      .filter(row => row[0] == gameId) // column A = GameId
+      .map(row => {
+        const obj = {};
+        headers.forEach((key, i) => {
           obj[key] = row[i];
+        });
+        if (obj.newballon !== undefined && obj.NewBallOn === undefined) {
+          obj.NewBallOn = obj.newballon;
+          delete obj.newballon;
         }
-      });
-      if (obj.newballon !== undefined && obj.NewBallOn === undefined) {
-        obj.NewBallOn = obj.newballon;
-        delete obj.newballon;
-      }
       if (obj.quarter !== undefined && obj.Qtr === undefined) {
         obj.Qtr = obj.quarter;
         delete obj.quarter;
@@ -404,10 +394,9 @@ function pushGameState({ gameId, quarter, time, down, distance, ballOn, homeScor
   });
 }
 
-function logPlayResult({ player, playType, yards, down, distance, ballOn }) {
+function logPlayResult({ player, playType, yards, down, distance, ballOn, time }) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("PlayHistory");
-  const ts = new Date();
-  sheet.appendRow([ts, down, distance, playType, player, yards]);
+  sheet.appendRow([time, down, distance, playType, player, yards]);
 
   const gameSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("GameState");
   const keys = ["Down", "Distance", "BallOn", "Previous"];

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -501,7 +501,7 @@
         sitDiv.innerHTML = `${downDist} at ${spot}`;
         const descDiv = document.createElement('div');
         descDiv.className = 'play-desc';
-        const time = new Date(play.Timestamp).toLocaleTimeString();
+        const time = formatClock(play.Time);
         const qtr = formatQuarter(play.Qtr || state.Qtr);
         const text = buildPlayText(play);
         descDiv.innerHTML = `(${time} - ${qtr}) ${text}`;
@@ -556,7 +556,7 @@
         const resultDiv = document.createElement('div');
         resultDiv.className = 'summary-result-time';
         const map = { 'Touchdown':'TD', 'Field Goal':'FG', 'Safety':'Safety' };
-        const time = new Date(play.Timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+        const time = formatClock(play.Time);
         resultDiv.textContent = `${map[play.Result] || play.Result} ${time}`;
         const homeScore = document.createElement('div');
         homeScore.className = 'summary-home-score';
@@ -1193,52 +1193,49 @@
     loadPlayers();
   }
 
-  function logPlayToDB(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, yards, tackler, result, predicted, qtr, time) {
-    const timestamp = new Date().toISOString();
-    const localPlay = {
-      Timestamp: timestamp,
-      Down: state.Down,
-      Distance: state.Distance,
-      Qtr: qtr,
-      Time: time,
-      Player: playerName,
-      Yards: yards,
-      Result: result || "Normal",
-      NewBallOn: ballOn,
-      BallOn: previousBallOn,
-      Tackler: tackler,
-      Possession: poss,
-      HomeScore: state.HomeScore,
-      AwayScore: state.AwayScore,
-      PlayType: "Run"
-    };
-    playHistory.push(localPlay);
+    function logPlayToDB(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, yards, tackler, result, predicted, qtr, time) {
+      const localPlay = {
+        Time: time,
+        Down: state.Down,
+        Distance: state.Distance,
+        Qtr: qtr,
+        Player: playerName,
+        Yards: yards,
+        Result: result || "Normal",
+        NewBallOn: ballOn,
+        BallOn: previousBallOn,
+        Tackler: tackler,
+        Possession: poss,
+        HomeScore: state.HomeScore,
+        AwayScore: state.AwayScore,
+        PlayType: "Run"
+      };
+      playHistory.push(localPlay);
 
-    google.script.run.logPlayHistory({
-      gameid: gameId,
-      timestamp: timestamp, // ✅ passed in from frontend
-      qtr: qtr,
-      time: time,
-      possession: poss,
-      down: state.Down,
-      distance: state.Distance,
-      ballon: state.BallOn,
-      playtype: "Run",
-      player: playerName,
-      yards: yards,
-      defensepredicted: predicted,
-      predictioncorrect: "",
-      tackler: tackler,
-      result: result,
-      desc: "",
-      newdown: down,
-      newdist: distance,
-      newballon: ballOn,
-      drivestart: state.DriveStart,
-      homescore: state.HomeScore,
-      awayscore: state.AwayScore
-    });
-  }
+      google.script.run.logPlayHistory({
+        gameid: gameId,
+        time: time,
+        qtr: qtr,
+        possession: poss,
+        down: state.Down,
+        distance: state.Distance,
+        ballon: state.BallOn,
+        playtype: "Run",
+        player: playerName,
+        yards: yards,
+        defensepredicted: predicted,
+        predictioncorrect: "",
+        tackler: tackler,
+        result: result,
+        desc: "",
+        newdown: down,
+        newdist: distance,
+        newballon: ballOn,
+        drivestart: state.DriveStart,
+        homescore: state.HomeScore,
+        awayscore: state.AwayScore
+      });
+    }
 
   function updateRunningClock(result) {
     const stopResults = ['Touchdown','Timeout','Field Goal','Kickoff','Punt','Safety','End of Quarter','TO on Downs'];
@@ -1751,10 +1748,10 @@
       ctx.strokeStyle = "black";
       ctx.lineCap = "round";
       let offset = 0;
-      let startTime = null;
-      function animate(timestamp) {
-        if (!startTime) startTime = timestamp;
-        const elapsed = timestamp - startTime;
+        let startTime = null;
+        function animate(time) {
+          if (!startTime) startTime = time;
+          const elapsed = time - startTime;
         offset -= 2;
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.setLineDash([10, 5]);


### PR DESCRIPTION
## Summary
- Store play times in seconds and drop timestamp usage in PlayHistory
- Render play log and scoring summary using m:ss clock formatting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f7ae19d48324924f6a2195bf53d0