### PR TITLE
Fix play-by-play drive yardage and quarter display

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -502,7 +502,8 @@
         const descDiv = document.createElement('div');
         descDiv.className = 'play-desc';
         const time = formatClock(play.Time);
-        const qtr = formatQuarter(play.Qtr || state.Qtr);
+        const playQuarter = play.QTR ?? play.Qtr ?? state.Qtr;
+        const qtr = formatQuarter(playQuarter);
         const text = buildPlayText(play);
         descDiv.innerHTML = `(${time} - ${qtr}) ${text}`;
         playRow.appendChild(sitDiv);
@@ -532,7 +533,7 @@
     const scoringPlays = playHistory.filter(p => ['Touchdown', 'Field Goal', 'Safety'].includes(p.Result));
     const byQuarter = {};
     scoringPlays.forEach(p => {
-      const q = p.Qtr || state.Qtr;
+      const q = p.QTR ?? p.Qtr ?? state.Qtr;
       if (!byQuarter[q]) byQuarter[q] = [];
       byQuarter[q].push(p);
     });
@@ -1198,7 +1199,9 @@
         Time: time,
         Down: state.Down,
         Distance: state.Distance,
+        QTR: qtr,
         Qtr: qtr,
+        DriveStart: Number(driveStart),
         Player: playerName,
         Yards: yards,
         Result: result || "Normal",


### PR DESCRIPTION
## Summary
- preserve drive yardage during session by logging DriveStart with each play
- show quarter in play-by-play and scoring summary using QTR from play history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4fc723580832481314c00a0a3d09b