### PR TITLE
Order play history by quarter then clock

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -297,6 +297,27 @@ function logPlayHistory(play) {
   ]);
 }
 
+function parseTimeToSeconds(t) {
+  if (typeof t === 'number') return t;
+  if (typeof t === 'string') {
+    if (t.includes(':')) {
+      const parts = t.split(':').map(Number);
+      if (parts.length === 2) return parts[0] * 60 + parts[1];
+    }
+    const num = Number(t);
+    if (!isNaN(num)) return num;
+  }
+  return 0;
+}
+
+function parseQuarter(q) {
+  if (typeof q === 'number') return q;
+  const str = String(q).toUpperCase();
+  if (str === 'OT') return 5;
+  const num = parseInt(str, 10);
+  return isNaN(num) ? 0 : num;
+}
+
 function getPlayHistory(gameId) {
   Logger.log(gameId);
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("PlayHistory");
@@ -335,6 +356,13 @@ function getPlayHistory(gameId) {
       }
       return obj;
     });
+
+  result.sort((a, b) => {
+    const qA = parseQuarter(a.Qtr);
+    const qB = parseQuarter(b.Qtr);
+    if (qA !== qB) return qA - qB;
+    return parseTimeToSeconds(b.Time) - parseTimeToSeconds(a.Time);
+  });
 
   Logger.log(result[0]);
   return result;

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -235,6 +235,7 @@
             .withSuccessHandler(async function (data) {
               console.log("✅ Loaded play history", data);
               playHistory = data;
+              sortPlayHistory(playHistory);
               if (!state.StartingPossession) {
                 const first = playHistory[0];
                 state.StartingPossession = first ? first.Possession : state.Possession;
@@ -357,6 +358,23 @@
       if (!isNaN(num)) return num;
     }
     return 0;
+  }
+
+  function parseQuarter(q) {
+    if (typeof q === 'number') return q;
+    const str = String(q).toUpperCase();
+    if (str === 'OT') return 5;
+    const num = parseInt(str, 10);
+    return isNaN(num) ? 0 : num;
+  }
+
+  function sortPlayHistory(arr) {
+    arr.sort((a, b) => {
+      const qA = parseQuarter(a.Qtr || a.qtr);
+      const qB = parseQuarter(b.Qtr || b.qtr);
+      if (qA !== qB) return qA - qB;
+      return parseTimeToSeconds(b.Time || b.time) - parseTimeToSeconds(a.Time || a.time);
+    });
   }
 
   function formatClock(seconds) {
@@ -1298,6 +1316,7 @@
         PlayType: "Run"
       };
       playHistory.push(localPlay);
+      sortPlayHistory(playHistory);
 
       google.script.run.logPlayHistory({
         gameid: gameId,


### PR DESCRIPTION
## Summary
- Ensure backend play history is sorted by quarter and remaining time
- Add client-side utilities to parse quarters and times and sort play history on load or new entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a7170e09ec8324ac7b2e7cae33244a