### PR TITLE
Sort play history by quarter then time

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -297,27 +297,6 @@ function logPlayHistory(play) {
   ]);
 }
 
-function parseTimeToSeconds(t) {
-  if (typeof t === 'number') return t;
-  if (typeof t === 'string') {
-    if (t.includes(':')) {
-      const parts = t.split(':').map(Number);
-      if (parts.length === 2) return parts[0] * 60 + parts[1];
-    }
-    const num = Number(t);
-    if (!isNaN(num)) return num;
-  }
-  return 0;
-}
-
-function parseQuarter(q) {
-  if (typeof q === 'number') return q;
-  const str = String(q).toUpperCase();
-  if (str === 'OT') return 5;
-  const num = parseInt(str, 10);
-  return isNaN(num) ? 0 : num;
-}
-
 function getPlayHistory(gameId) {
   Logger.log(gameId);
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("PlayHistory");
@@ -357,11 +336,25 @@ function getPlayHistory(gameId) {
       return obj;
     });
 
+  const quarterOrder = { '1': 1, '2': 2, '3': 3, '4': 4, 'OT': 5 };
+  const parseTime = t => {
+    if (typeof t === 'number') return t;
+    if (typeof t === 'string') {
+      const parts = t.split(':').map(Number);
+      if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+        return parts[0] * 60 + parts[1];
+      }
+      const num = Number(t);
+      return isNaN(num) ? 0 : num;
+    }
+    return 0;
+  };
+
   result.sort((a, b) => {
-    const qA = parseQuarter(a.Qtr);
-    const qB = parseQuarter(b.Qtr);
+    const qA = quarterOrder[String(a.Qtr).toUpperCase()] || 99;
+    const qB = quarterOrder[String(b.Qtr).toUpperCase()] || 99;
     if (qA !== qB) return qA - qB;
-    return parseTimeToSeconds(b.Time) - parseTimeToSeconds(a.Time);
+    return parseTime(b.Time) - parseTime(a.Time);
   });
 
   Logger.log(result[0]);

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -235,7 +235,6 @@
             .withSuccessHandler(async function (data) {
               console.log("✅ Loaded play history", data);
               playHistory = data;
-              sortPlayHistory(playHistory);
               if (!state.StartingPossession) {
                 const first = playHistory[0];
                 state.StartingPossession = first ? first.Possession : state.Possession;
@@ -358,23 +357,6 @@
       if (!isNaN(num)) return num;
     }
     return 0;
-  }
-
-  function parseQuarter(q) {
-    if (typeof q === 'number') return q;
-    const str = String(q).toUpperCase();
-    if (str === 'OT') return 5;
-    const num = parseInt(str, 10);
-    return isNaN(num) ? 0 : num;
-  }
-
-  function sortPlayHistory(arr) {
-    arr.sort((a, b) => {
-      const qA = parseQuarter(a.Qtr || a.qtr);
-      const qB = parseQuarter(b.Qtr || b.qtr);
-      if (qA !== qB) return qA - qB;
-      return parseTimeToSeconds(b.Time || b.time) - parseTimeToSeconds(a.Time || a.time);
-    });
   }
 
   function formatClock(seconds) {
@@ -1316,7 +1298,6 @@
         PlayType: "Run"
       };
       playHistory.push(localPlay);
-      sortPlayHistory(playHistory);
 
       google.script.run.logPlayHistory({
         gameid: gameId,


### PR DESCRIPTION
## Summary
- revert prior play-order update
- ensure `getPlayHistory` sorts plays by quarter then time in descending order

## Testing
- `node --check Code.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a77a2013988324b3a2ddc5dd783310