### PR TITLE
Add receiver routes modal

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -114,6 +114,7 @@
         <div class="control-panel">
           <button id="openFormation">Edit Formation</button>
           <button id="viewLOS">View LOS</button>
+          <button id="openRoutes">Set Receiver Routes</button>
           <label for="playerDropdown">Select Player:</label>
           <select id="playerDropdown"></select>
           <div class="button-row">
@@ -450,6 +451,18 @@
         <span id="closeLOS" class="close-button">&times;</span>
         <h3>Line of Scrimmage</h3>
         <div id="losField" class="los-field"></div>
+      </div>
+    </div>
+
+    <div id="routesModal" class="modal">
+      <div class="formation-panel routes-panel">
+        <span id="closeRoutes" class="close-button">&times;</span>
+        <h3>Receiver Routes</h3>
+        <div id="routesList"></div>
+        <div class="formation-actions">
+          <button id="clearRoutes">Clear</button>
+          <button id="saveRoutes">Save</button>
+        </div>
       </div>
     </div>
 

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -19,6 +19,11 @@
   let defStarPower = false;
   let defStarPowerTackler = '';
   const RUN_POSITIONS = ['WR1','RB1','RB2','QB'];
+  const ROUTE_OPTIONS = ['Screen','Short','Medium','Med-Long','Long','Deep'];
+  const QB_READ_OPTIONS = ['Primary','2nd','3rd','4th','Checkdown'];
+  let receiverRoutes = {};
+  let playerReadSelection = {};
+  let qbReadAssignments = {};
   let selectedPlayer = null;
   let runningClock = false;
 
@@ -105,6 +110,21 @@
       const closeLOS = document.getElementById('closeLOS');
       if (closeLOS) closeLOS.addEventListener('click', () => {
         document.getElementById('losModal').classList.remove('open');
+      });
+      const routeBtn = document.getElementById('openRoutes');
+      if (routeBtn) routeBtn.addEventListener('click', () => {
+        renderRoutesModal();
+        document.getElementById('routesModal').classList.add('open');
+      });
+      const closeRoutes = document.getElementById('closeRoutes');
+      if (closeRoutes) closeRoutes.addEventListener('click', () => {
+        document.getElementById('routesModal').classList.remove('open');
+      });
+      const clearRoutesBtn = document.getElementById('clearRoutes');
+      if (clearRoutesBtn) clearRoutesBtn.addEventListener('click', clearRoutes);
+      const saveRoutesBtn = document.getElementById('saveRoutes');
+      if (saveRoutesBtn) saveRoutesBtn.addEventListener('click', () => {
+        document.getElementById('routesModal').classList.remove('open');
       });
     });
 
@@ -611,6 +631,9 @@
     function loadPlayers() {
       populateBench();
       updateRunnerDropdown();
+      receiverRoutes = {};
+      playerReadSelection = {};
+      qbReadAssignments = {};
     }
 
     function populateBench() {
@@ -779,6 +802,78 @@
       console.log('Saved formation', formation);
       setDefensiveFormation();
       document.getElementById('formationModal').classList.remove('open');
+    }
+
+    function getEligibleReceivers() {
+      const wrs = currentFormation.filter(f => f.position.startsWith('WR') && f.player);
+      const rbs = currentFormation.filter(f => f.position.startsWith('RB') && f.player);
+      const teols = currentFormation
+        .filter(f => f.position.startsWith('TEOL') && f.player)
+        .sort((a,b) => parseInt(a.position.replace('TEOL','')) - parseInt(b.position.replace('TEOL','')));
+      const eligibleTeols = [];
+      if (teols.length > 0) {
+        eligibleTeols.push(teols[0]);
+        if (teols.length > 1) eligibleTeols.push(teols[teols.length - 1]);
+      }
+      return [...wrs, ...rbs, ...eligibleTeols];
+    }
+
+    function renderRoutesModal() {
+      const list = document.getElementById('routesList');
+      if (!list) return;
+      list.innerHTML = '';
+      const players = getEligibleReceivers();
+      players.forEach(p => {
+        const row = document.createElement('div');
+        row.className = 'route-row';
+        row.innerHTML = `
+          <span class="route-player">${p.player}</span>
+          <select class="route-select" data-player="${p.player}">
+            ${ROUTE_OPTIONS.map(r => `<option value="${r}">${r}</option>`).join('')}
+          </select>
+          <select class="qb-read-select" data-player="${p.player}">
+            <option value=""></option>
+            ${QB_READ_OPTIONS.map(r => `<option value="${r}">${r}</option>`).join('')}
+          </select>
+        `;
+        list.appendChild(row);
+        const routeSel = row.querySelector('.route-select');
+        routeSel.value = receiverRoutes[p.player] || 'Short';
+        routeSel.addEventListener('change', e => {
+          receiverRoutes[p.player] = e.target.value;
+        });
+        const readSel = row.querySelector('.qb-read-select');
+        readSel.value = playerReadSelection[p.player] || '';
+        readSel.addEventListener('change', e => handleReadChange(p.player, e.target));
+      });
+    }
+
+    function handleReadChange(player, select) {
+      const val = select.value;
+      const prev = playerReadSelection[player];
+      if (prev) {
+        delete qbReadAssignments[prev];
+      }
+      if (val && qbReadAssignments[val]) {
+        const otherPlayer = qbReadAssignments[val];
+        playerReadSelection[otherPlayer] = '';
+        const otherSelect = document.querySelector(`.qb-read-select[data-player="${otherPlayer}"]`);
+        if (otherSelect) otherSelect.value = '';
+      }
+      if (val) {
+        qbReadAssignments[val] = player;
+        playerReadSelection[player] = val;
+      } else {
+        playerReadSelection[player] = '';
+      }
+    }
+
+    function clearRoutes() {
+      receiverRoutes = {};
+      playerReadSelection = {};
+      qbReadAssignments = {};
+      document.querySelectorAll('.route-select').forEach(sel => sel.value = 'Short');
+      document.querySelectorAll('.qb-read-select').forEach(sel => sel.value = '');
     }
 
   function setDefensiveFormation() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -879,6 +879,30 @@
     overflow-x: auto;
   }
 
+  .routes-panel {
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+
+  #routesList {
+    margin-bottom: 4vw;
+  }
+
+  .route-row {
+    display: flex;
+    align-items: center;
+    gap: 2vw;
+    margin-bottom: 2vw;
+  }
+
+  .route-row .route-player {
+    flex: 1;
+  }
+
+  .route-row select {
+    flex: 0 0 30%;
+  }
+
   .formation-row {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- Add Set Receiver Routes button and modal for configuring eligible receivers
- Track receiver route and QB read selections with defaults and unique read assignments
- Style routes modal and reset selections at new drive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab61471a208324b20dacd0c5402ee2