### PR TITLE
Add pass play button and load passing settings

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -214,12 +214,42 @@ function getTackleDistributions() {
     .sort((a, b) => a.yardageCap - b.yardageCap);
 }
 
+function getAirYardsCompletionTable() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
+  const data = sheet.getDataRange().getValues();
+
+  return data
+    .filter(row => typeof row[0] === "string" && row[0].startsWith("airYards_Completion_"))
+    .map(row => ({
+      label: row[0],
+      pastLos: Number(row[1]),
+      baseCompletion: Number(row[2]),
+      percentage: Number(row[3])
+    }));
+}
+
+function getRouteTypeAirYards() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
+  const data = sheet.getDataRange().getValues();
+
+  return data
+    .filter(row => typeof row[0] === "string" && row[0].startsWith("routeType_AirYardsReqd_"))
+    .map(row => ({
+      label: row[0],
+      routeType: String(row[1]),
+      minAirYards: Number(row[2]),
+      maxAirYards: Number(row[3])
+    }));
+}
+
 function getFrontendSettings() {
   return {
     thresholds: getRunThresholdsFromSettings(),
     breakaways: getBreakawayYards(),
     staminaDrains: getStaminaDrains(),
-    tackleTable: getTackleDistributions()
+    tackleTable: getTackleDistributions(),
+    completionTable: getAirYardsCompletionTable(),
+    routeTypeAirYards: getRouteTypeAirYards()
   };
 }
 function predictPlayType(down, distance) {

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -119,6 +119,7 @@
           <select id="playerDropdown"></select>
           <div class="button-row">
           <button onclick="runPlay()">▶️ Run Play</button>
+          <button onclick="passPlay(document.getElementById('playerDropdown').value)">🏈 Pass Play</button>
           <button onclick="nextDrive()">🔁 Next Drive</button>
         </div>
         <div id="result" class="result-box"></div>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -26,6 +26,8 @@
   let qbReadAssignments = {};
   let selectedPlayer = null;
   let runningClock = false;
+  let completionTable = [];
+  let routeTypeAirYards = [];
 
 
   function updateStickyOffsets() {
@@ -1059,6 +1061,8 @@
       breakawaySettings = data.breakaways;
       drainSettings = data.staminaDrains;
       tackleSettings = data.tackleTable || [];
+      completionTable = data.completionTable || [];
+      routeTypeAirYards = data.routeTypeAirYards || [];
       if (callback) callback();
     }).getFrontendSettings();
   }
@@ -1233,6 +1237,36 @@
     autoRelease = false;
     offStarPower = false;
     defStarPower = false;
+  }
+
+  // === PASS PLAY ===
+  async function passPlay(qbName) {
+    if (!qbName) return;
+    const routes = assignRoutes();
+    const timeToThrow = determineTimeToThrow(qbName);
+    const target = choosePassTarget(qbName, routes);
+    const result = determinePassOutcome(qbName, target, routes, timeToThrow);
+    console.log('Pass play result', result);
+  }
+
+  function assignRoutes() {
+    // Determine each receiver's route depth
+    return {};
+  }
+
+  function determineTimeToThrow(qbName) {
+    // Calculate how long the quarterback has to throw
+    return 0;
+  }
+
+  function choosePassTarget(qbName, routes) {
+    // Decide which receiver the quarterback targets
+    return null;
+  }
+
+  function determinePassOutcome(qbName, target, routes, timeToThrow) {
+    // Determine the outcome of the pass attempt
+    return { completed: false, yards: 0 };
   }
 
   // === MAIN PLAY ===


### PR DESCRIPTION
## Summary
- Add pass play button and placeholder logic for passing plays
- Load completion and route type tables from Settings on page load
- Expose passing settings via frontend settings API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab66e8751483248caf5097f39ca131