### PR TITLE
Add QB read-defense logic for pass targeting

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -1316,6 +1316,17 @@
       route.separation = separation;
     });
 
+    const qb = playerTraits[qbName] || {};
+    const readRoll = randomInt(0, 100);
+    const qbReadsDefense = readRoll <= (Number(qb.readDefense) || 0);
+
+    Object.keys(routes).forEach(name => {
+      const route = routes[name];
+      const wr = playerTraits[name] || {};
+      route.percievedSeparation = qbReadsDefense ? route.separation : 0;
+      route.throwLikelyhood = ((Number(wr.qbFavorite) || 0) / 10) + (route.percievedSeparation * 3);
+    });
+
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Calculate perceived separation based on QB read-defense roll
- Derive throw likelihood from QB favorites and perceived separation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7991fc60832488e271742334ad67