### PR TITLE
feat: adjust completion by separation

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -257,6 +257,19 @@ function getTimeNeededToThrow() {
     }));
 }
 
+function getCompletionSeparationAdjustment() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
+  const data = sheet.getDataRange().getValues();
+
+  return data
+    .filter(row => typeof row[0] === "string" && row[0].startsWith("separation_"))
+    .map(row => ({
+      label: row[0],
+      separation: Number(row[1]),
+      catchPctChange: Number(row[2])
+    }));
+}
+
 function getFrontendSettings() {
   return {
     thresholds: getRunThresholdsFromSettings(),
@@ -265,7 +278,8 @@ function getFrontendSettings() {
     tackleTable: getTackleDistributions(),
     completionTable: getAirYardsCompletionTable(),
     routeTypeAirYards: getRouteTypeAirYards(),
-    timeNeededToThrow: getTimeNeededToThrow()
+    timeNeededToThrow: getTimeNeededToThrow(),
+    completionSeparationAdjustment: getCompletionSeparationAdjustment()
   };
 }
 function predictPlayType(down, distance) {

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -29,6 +29,7 @@
   let completionTable = [];
   let routeTypeAirYards = [];
   let timeNeededToOpen = [];
+  let completionSeparationAdjustment = [];
 
 
   function updateStickyOffsets() {
@@ -1065,6 +1066,7 @@
       completionTable = data.completionTable || [];
       routeTypeAirYards = data.routeTypeAirYards || [];
       timeNeededToOpen = data.timeNeededToThrow || [];
+      completionSeparationAdjustment = data.completionSeparationAdjustment || [];
       if (callback) callback();
     }).getFrontendSettings();
   }
@@ -1394,7 +1396,11 @@
       }
     }
 
-    const completionPct = baseCompletion + qbAccuracyAdjust(qb);
+    let completionPct = baseCompletion + qbAccuracyAdjust(qb);
+    const sepAdjust = completionSeparationAdjustment.find(r => Number(r.separation) === separation);
+    if (sepAdjust) {
+      completionPct += Number(sepAdjust.catchPctChange) || 0;
+    }
     return completionPct;
   }
 


### PR DESCRIPTION
## Summary
- load completionSeparationAdjustment table from Settings sheet
- expose separation adjustments to UI and factor into completion percentage

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab85945ba08324adb937f33a50daa1