### PR TITLE
Factor receiver hands into completion percentage

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -1401,6 +1401,12 @@
     if (sepAdjust) {
       completionPct += Number(sepAdjust.catchPctChange) || 0;
     }
+    const receiver = playerTraits[target.target] || {};
+    const hands = Number(receiver.hands);
+    if (!isNaN(hands)) {
+      const diff = (hands - 60) / 10;
+      completionPct += (diff ** 2) / 2;
+    }
     return completionPct;
   }
 


### PR DESCRIPTION
## Summary
- consider receiver hands trait when computing completion percentage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab8787e7d083249a73fa6eaa4d80e5