### PR TITLE
Fix async handler to avoid await syntax error in play history loader

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -274,7 +274,6 @@
               receivingStats = [];
 
               playHistory.forEach(play => {
-              playHistory.forEach(play => {
                 if (!play.PlayType) return;
 
                 if (play.PlayType === 'Run') {


### PR DESCRIPTION
## Summary
- Remove duplicate `playHistory.forEach` loop so `await animatePlay()` executes within async success handler

## Testing
- `node --check PlayUIScript.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68aca14867ec8324bd5ac0469e63e25c