### PR TITLE
Adjust completion percentage for route variation

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -1774,6 +1774,18 @@
     routeInfo.defStarsPctBoost = defStarsPctBoost;
     completionPct += offStarsPctBoost + defStarsPctBoost;
 
+    // Adjust completion percentage based on route variation
+    if (routes) {
+      const typeSet = new Set();
+      Object.values(routes).forEach(r => {
+        let type = r.routeType;
+        if (type === 'Long' || type === 'Med-Long') type = 'Long';
+        typeSet.add(type);
+      });
+      const routeVariation = typeSet.size * 4;
+      completionPct += routeVariation - 18;
+    }
+
     return completionPct;
   }
 


### PR DESCRIPTION
## Summary
- factor variety of receiver routes into completion percentage calculation
- treat Long and Med-Long as the same type when computing route variation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0612add68832493c51f4d173c25f2