### PR TITLE
Handle negative and away run animations

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -2700,50 +2700,49 @@
         //lastDot.style.opacity = 1;
         //arrow.style.opacity = 1;
         if(state.Possession == "Home"){
-          //lastDot.style.left = `0`;
-          //lastDot.style.right = `auto`;
           lastPlay.style.left = `${prevPX}px`;
-          //arrow.style.left = `0px`;
-          //arrow.style.right = `auto`;
-        } else{
-          //lastDot.style.right = `0`;
-          //lastDot.style.left = `auto`;
+          lastPlay.style.right = `auto`;
+        } else {
           lastPlay.style.right = `${prevPX}px`;
-          //arrow.style.left = `auto`;
-          //arrow.style.right = `0px`;
+          lastPlay.style.left = `auto`;
         }
 
         if (playType === 'Run') {
           lastPlay.style.top = `50%`;
           lastPlay.style.height = `6px`;
-          //arrow.style.top = `-10px`;
+
+          const delta = currPX - prevPX;
+          const isHome = state.Possession == "Home";
+          const isForward = delta >= 0;
+          const dist = Math.abs(delta);
+
+          runDiv.classList.remove('home','away','forward','backward');
+          runDiv.classList.add(isHome ? 'home' : 'away');
+          runDiv.classList.add(isForward ? 'forward' : 'backward');
+
           setTimeout(() => {
-            // Animate based on direction of play
-            if (state.Possession == "Home") {
-              lastPlay.style.transition = "width 1.4s ease, left 1.4s ease";
-              //arrow.style.transition = "left 1.4s ease";
-              lastPlay.style.left = `${prevPX}px`;
-              lastPlay.style.right = `auto`;
-              lastPlay.style.width = `${currPX - prevPX}px`;
-              //arrow.style.left = `${(currPX - prevPX) - 10}px`;
-              //arrow.style.right = `auto`;
-              //arrow.style.transform = "rotate(0deg)";
+            if (isHome) {
+              if (isForward) {
+                lastPlay.style.transition = "width 1.4s ease";
+                lastPlay.style.width = `${dist}px`;
+              } else {
+                lastPlay.style.transition = "width 1.4s ease, left 1.4s ease";
+                lastPlay.style.left = `${currPX}px`;
+                lastPlay.style.width = `${dist}px`;
+              }
             } else {
-              lastPlay.style.transition = "width 1.4s ease, right 1.4s ease";
-              //arrow.style.transition = "right 1.4s ease";
-              lastPlay.style.left = `auto`;
-              lastPlay.style.right = `${prevPX}px`;
-              lastPlay.style.width = `${(currPX - prevPX)}px`;
-              //arrow.style.left = `auto`;
-              //arrow.style.right = `${(currPX - prevPX) - 10}px`;
-              //arrow.style.transform = "rotate(180deg)";
+              if (isForward) {
+                lastPlay.style.transition = "width 1.4s ease";
+                lastPlay.style.width = `${dist}px`;
+              } else {
+                lastPlay.style.transition = "width 1.4s ease, right 1.4s ease";
+                lastPlay.style.right = `${currPX}px`;
+                lastPlay.style.width = `${dist}px`;
+              }
             }
-            const playWidth = currPX - prevPX;
-            if (playWidth <= 0) {
-              // No animation to wait for; resolve manually after short delay
-              setTimeout(() => {
-                resolve();
-              }, 300);
+
+            if (dist === 0) {
+              setTimeout(() => resolve(), 300);
             } else {
               const onEnd = (e) => {
                 if (e.propertyName === 'width') {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1243,28 +1243,76 @@
   left: 0px;                  /* sits immediately after drive-line */
   width: 0;                     /* animate from 0 to target */
   background-color: #333;
-  animation: grow-line 2s forwards;
 }
-.play-line::before {
+
+.play-line::before,
+.play-line::after {
   content: "";
   position: absolute;
   top: 50%;
-  left: -10px;
   transform: translateY(-50%);
+}
+
+/* Home team gains (left to right) */
+.play-line.home.forward::before,
+.play-line.away.backward::before {
+  left: -10px;
   width: 12px;
   height: 12px;
   background-color: #333;
   border-radius: 50%;
 }
-.play-line::after {
-  content: "";
-  position: absolute;
-  top: 50%;
+.play-line.home.forward::after,
+.play-line.away.backward::after {
   right: -10px;
-  transform: translateY(-50%);
-  border-top: clamp(6px, 3vw, 9px) solid transparent;
-  border-bottom: clamp(6px, 3vw, 9px) solid transparent;
-  border-left: clamp(12px, 3vw, 18px) solid #333;
+  border-top: var(--arrow-h) solid transparent;
+  border-bottom: var(--arrow-h) solid transparent;
+  border-left: var(--arrow-l) solid #333;
+}
+
+/* Home team losses (right to left) */
+.play-line.home.backward::before {
+  left: -10px;
+  border-top: var(--arrow-h) solid transparent;
+  border-bottom: var(--arrow-h) solid transparent;
+  border-right: var(--arrow-l) solid #333;
+}
+.play-line.home.backward::after {
+  right: -10px;
+  width: 12px;
+  height: 12px;
+  background-color: #333;
+  border-radius: 50%;
+}
+
+/* Away team gains (right to left) */
+.play-line.away.forward::before {
+  right: -10px;
+  border-top: var(--arrow-h) solid transparent;
+  border-bottom: var(--arrow-h) solid transparent;
+  border-right: var(--arrow-l) solid #333;
+}
+.play-line.away.forward::after {
+  left: -10px;
+  width: 12px;
+  height: 12px;
+  background-color: #333;
+  border-radius: 50%;
+}
+
+/* Away team losses (left to right) */
+.play-line.away.backward::before {
+  right: -10px;
+  width: 12px;
+  height: 12px;
+  background-color: #333;
+  border-radius: 50%;
+}
+.play-line.away.backward::after {
+  left: -10px;
+  border-top: var(--arrow-h) solid transparent;
+  border-bottom: var(--arrow-h) solid transparent;
+  border-left: var(--arrow-l) solid #333;
 }
     :root {
       /* Match your arrow sizes exactly */


### PR DESCRIPTION
## Summary
- Animate negative yardage runs by moving the play marker backward on the field.
- Adjust run animation for away possessions so arrow and dot swap positions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b06c1f7edc8324a3bec79e45bad99c