### PR TITLE
Revamp routes modal UI with draggable receiver cards

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -963,29 +963,110 @@
       const list = document.getElementById('routesList');
       if (!list) return;
       list.innerHTML = '';
+
+      const field = list;
+      const fieldHeight = field.clientHeight;
+      const zoneHeight = fieldHeight / ROUTE_OPTIONS.length;
+
+      ROUTE_OPTIONS.forEach((r, i) => {
+        const line = document.createElement('div');
+        line.className = 'route-line';
+        line.style.bottom = `${(i * 100) / ROUTE_OPTIONS.length}%`;
+        line.textContent = r;
+        field.appendChild(line);
+      });
+
       const players = getEligibleReceivers();
-      players.forEach(p => {
-        const row = document.createElement('div');
-        row.className = 'route-row';
-        row.innerHTML = `
-          <span class="route-player">${p.player}</span>
-          <select class="route-select" data-player="${p.player}">
-            ${ROUTE_OPTIONS.map(r => `<option value="${r}">${r}</option>`).join('')}
-          </select>
-          <select class="qb-read-select" data-player="${p.player}">
-            <option value=""></option>
-            ${QB_READ_OPTIONS.map(r => `<option value="${r}">${r}</option>`).join('')}
-          </select>
+      players.forEach((p, idx) => {
+        const card = document.createElement('div');
+        card.className = 'player-card';
+        card.setAttribute('data-player', p.player);
+        const t = playerTraits[p.player] || {};
+        card.innerHTML = `
+          <div class="read-badge"></div>
+          <div class="player-name">${p.player}</div>
+          <div class="stars">⭐${t.offStars || 0}</div>
+          <div class="traits">
+            <span>SZ:${t.size || 0}</span>
+            <span>SPD:${t.speed || 0}</span>
+            <span>RR:${t.routeRunning || 0}</span>
+            <span>JMP:${t.jump || 0}</span>
+            <span>HND:${t.hands || 0}</span>
+          </div>
+          <div class="stam">Stam:${t.fatigue || 0}</div>
         `;
-        list.appendChild(row);
-        const routeSel = row.querySelector('.route-select');
-        routeSel.value = receiverRoutes[p.player] || 'Short';
-        routeSel.addEventListener('change', e => {
-          receiverRoutes[p.player] = e.target.value;
-        });
-        const readSel = row.querySelector('.qb-read-select');
-        readSel.value = playerReadSelection[p.player] || '';
-        readSel.addEventListener('change', e => handleReadChange(p.player, e.target));
+        field.appendChild(card);
+
+        const cardWidth = card.offsetWidth;
+        const readIdx = playerReadSelection[p.player] ? QB_READ_OPTIONS.indexOf(playerReadSelection[p.player]) : idx;
+        card.style.left = `${readIdx * (cardWidth + 10)}px`;
+
+        const route = receiverRoutes[p.player] || 'Short';
+        const rIdx = ROUTE_OPTIONS.indexOf(route);
+        const top = fieldHeight - (rIdx + 0.5) * zoneHeight - card.offsetHeight / 2;
+        card.style.top = `${top}px`;
+
+        initCardDrag(card, field);
+      });
+
+      updateReads(field);
+    }
+
+    function initCardDrag(card, field) {
+      card.addEventListener('mousedown', startDrag);
+
+      function startDrag(e) {
+        e.preventDefault();
+        const rect = field.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        const offsetX = e.clientX - cardRect.left;
+        const offsetY = e.clientY - cardRect.top;
+
+        function move(ev) {
+          let x = ev.clientX - rect.left - offsetX;
+          let y = ev.clientY - rect.top - offsetY;
+          x = Math.max(0, Math.min(x, rect.width - card.offsetWidth));
+          y = Math.max(0, Math.min(y, rect.height - card.offsetHeight));
+          card.style.left = `${x}px`;
+          card.style.top = `${y}px`;
+        }
+
+        function up() {
+          document.removeEventListener('mousemove', move);
+          document.removeEventListener('mouseup', up);
+          updateRoute(card, field);
+          updateReads(field);
+        }
+
+        document.addEventListener('mousemove', move);
+        document.addEventListener('mouseup', up);
+      }
+    }
+
+    function updateRoute(card, field) {
+      const top = parseFloat(card.style.top) || 0;
+      const cardHeight = card.offsetHeight;
+      const fieldHeight = field.clientHeight;
+      const distanceFromBottom = fieldHeight - (top + cardHeight / 2);
+      let pct = distanceFromBottom / fieldHeight;
+      pct = Math.max(0, Math.min(0.9999, pct));
+      let idx = Math.floor(pct * ROUTE_OPTIONS.length);
+      const route = ROUTE_OPTIONS[idx];
+      const player = card.dataset.player;
+      receiverRoutes[player] = route;
+      const zoneHeight = fieldHeight / ROUTE_OPTIONS.length;
+      const newTop = fieldHeight - (idx + 0.5) * zoneHeight - cardHeight / 2;
+      card.style.top = `${newTop}px`;
+    }
+
+    function updateReads(field) {
+      const cards = Array.from(field.querySelectorAll('.player-card'));
+      cards.sort((a, b) => parseFloat(a.style.left) - parseFloat(b.style.left));
+      cards.forEach((card, i) => {
+        const read = QB_READ_OPTIONS[i] || '';
+        const badge = card.querySelector('.read-badge');
+        if (badge) badge.textContent = read;
+        handleReadChange(card.dataset.player, { value: read });
       });
     }
 
@@ -1013,8 +1094,7 @@
       receiverRoutes = {};
       playerReadSelection = {};
       qbReadAssignments = {};
-      document.querySelectorAll('.route-select').forEach(sel => sel.value = 'Short');
-      document.querySelectorAll('.qb-read-select').forEach(sel => sel.value = '');
+      renderRoutesModal();
     }
 
   function setDefensiveFormation() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -891,6 +891,57 @@
 
   #routesList {
     margin-bottom: 4vw;
+    position: relative;
+    height: 60vh;
+    background: #2e7d32;
+    border: 2px solid #fff;
+    overflow: hidden;
+  }
+
+  .route-line {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    border-top: 2px solid #fff;
+    color: #fff;
+    font-size: 2.5vw;
+    padding-left: 2vw;
+    pointer-events: none;
+  }
+
+  .player-card {
+    position: absolute;
+    width: clamp(80px, 20vw, 120px);
+    background: #fff;
+    color: #000;
+    border-radius: 6px;
+    padding: 1vw;
+    cursor: grab;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    font-size: 2.5vw;
+  }
+
+  .player-card:active {
+    cursor: grabbing;
+  }
+
+  .player-card .traits {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1vw;
+    font-size: 2vw;
+    margin-top: 0.5vw;
+  }
+
+  .player-card .read-badge {
+    position: absolute;
+    top: 0.5vw;
+    right: 0.5vw;
+    background: var(--accent-red);
+    color: #fff;
+    border-radius: 4px;
+    padding: 0.5vw 1vw;
+    font-size: 2vw;
   }
 
   .route-row {


### PR DESCRIPTION
## Summary
- Replace list-based routes editor with draggable receiver cards displaying traits, stars, and stamina.
- Add green field backdrop with route depth lines for vertical drag to set route depth.
- Support horizontal dragging to reorder reads, updating badges automatically.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b367aa03508324979b8dda0741a4ce