### PR TITLE
Add quarter-by-quarter score chart to gamecast UI

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -114,7 +114,9 @@
       </div>
       
       <div id="lastPlayDesc" class="last-play-desc"></div>
-      
+
+      <div id="scoreChart" class="score-chart"></div>
+
       <div class="control-panel">
         <button id="openFormation">Edit Formation</button>
         <button id="viewLOS">View LOS</button>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -714,6 +714,7 @@
     computeDriveInfo();
     updateLastPlayDesc();
     renderScoringSummary();
+    renderQuarterScoreChart();
   }
 
   function renderScoringSummary() {
@@ -769,7 +770,52 @@
     });
   }
 
-    function loadPlayers() {
+  function getQuarterScores() {
+    const home = [0, 0, 0, 0];
+    const away = [0, 0, 0, 0];
+    let prevHome = 0;
+    let prevAway = 0;
+    playHistory.forEach(play => {
+      const q = parseInt(play.QTR ?? play.Qtr, 10);
+      let h = play.HomeScore !== undefined ? parseInt(play.HomeScore, 10) : prevHome;
+      let a = play.AwayScore !== undefined ? parseInt(play.AwayScore, 10) : prevAway;
+      if (isNaN(h)) h = prevHome;
+      if (isNaN(a)) a = prevAway;
+      if (q >= 1 && q <= 4) {
+        home[q - 1] += h - prevHome;
+        away[q - 1] += a - prevAway;
+      }
+      prevHome = h;
+      prevAway = a;
+    });
+    return { home, away };
+  }
+
+  function renderQuarterScoreChart() {
+    const container = document.getElementById('scoreChart');
+    if (!container) return;
+    const { home, away } = getQuarterScores();
+    container.innerHTML = `
+      <table>
+        <thead>
+          <tr><th></th><th>1</th><th>2</th><th>3</th><th>4</th><th>T</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="team-cell"><img src="${state.HomeLogo || ''}" alt="Home Logo" class="team-logo-small"><span>${state.Home}</span></td>
+            <td>${home[0]}</td><td>${home[1]}</td><td>${home[2]}</td><td>${home[3]}</td>
+            <td class="total-cell">${state.HomeScore}</td>
+          </tr>
+          <tr>
+            <td class="team-cell"><img src="${state.AwayLogo || ''}" alt="Away Logo" class="team-logo-small"><span>${state.Away}</span></td>
+            <td>${away[0]}</td><td>${away[1]}</td><td>${away[2]}</td><td>${away[3]}</td>
+            <td class="total-cell">${state.AwayScore}</td>
+          </tr>
+        </tbody>
+      </table>`;
+  }
+
+  function loadPlayers() {
       populateBench();
       updateRunnerDropdown();
       receiverRoutes = {};

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -525,6 +525,42 @@
     text-align: center;
   }
 
+  .score-chart {
+    max-width: 900px;
+    margin: 2vw auto;
+    font-size: 3vw;
+  }
+  .score-chart table {
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--text-muted);
+  }
+  .score-chart thead tr {
+    border-bottom: 1px solid var(--gray-light);
+  }
+  .score-chart th,
+  .score-chart td {
+    text-align: center;
+    padding: 1vw;
+  }
+  .score-chart .team-cell {
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+    justify-content: flex-start;
+    font-weight: 700;
+    color: var(--text-light);
+  }
+  .score-chart .team-logo-small {
+    width: 5vw;
+    height: 5vw;
+    object-fit: contain;
+  }
+  .score-chart .total-cell {
+    font-weight: 700;
+    color: var(--text-light);
+  }
+
   .red-zone {
     color: var(--accent-red);
   }


### PR DESCRIPTION
## Summary
- Display quarter-by-quarter score table below the last play description.
- Style the new score chart with white team names and totals and muted grey quarter columns.
- Compute and render per-quarter scores from play history after each play.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b36e3cf6588324878a46e1617c860d