### PR TITLE
Add game leaders card below score chart

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -117,6 +117,8 @@
 
       <div id="scoreChart" class="score-chart"></div>
 
+      <div id="leadersCard" class="leaders-card"></div>
+
       <div class="control-panel">
         <button id="openFormation">Edit Formation</button>
         <button id="viewLOS">View LOS</button>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -816,6 +816,92 @@
       </table>`;
   }
 
+  function renderGameLeaders() {
+    const container = document.getElementById('leadersCard');
+    if (!container) return;
+
+    const homeTeam = state.Home || '';
+    const awayTeam = state.Away || '';
+    const placeholder = '<div class="player-placeholder"><span>👤</span></div>';
+
+    function leader(arr, team, stat, hasStatsFn) {
+      const players = arr.filter(p => p.team === team && (hasStatsFn ? hasStatsFn(p) : (p[stat] || 0) > 0));
+      if (!players.length) return null;
+      return players.reduce((max, p) => (p[stat] > (max[stat] || 0) ? p : max));
+    }
+
+    const passHome = leader(passingStats, 'Home', 'yards', p => (p.attempts || p.completions || p.yards));
+    const passAway = leader(passingStats, 'Away', 'yards', p => (p.attempts || p.completions || p.yards));
+    const rushHome = leader(frontendStats, 'Home', 'yards', p => (p.carries || p.yards));
+    const rushAway = leader(frontendStats, 'Away', 'yards', p => (p.carries || p.yards));
+    const recHome = leader(receivingStats, 'Home', 'yards', p => (p.receptions || p.yards));
+    const recAway = leader(receivingStats, 'Away', 'yards', p => (p.receptions || p.yards));
+    const sackHome = leader(defensiveStats, 'Home', 'sacks', p => (p.sacks));
+    const sackAway = leader(defensiveStats, 'Away', 'sacks', p => (p.sacks));
+    const tklHome = leader(defensiveStats, 'Home', 'tackles', p => (p.tackles));
+    const tklAway = leader(defensiveStats, 'Away', 'tackles', p => (p.tackles));
+
+    function statLinePassing(p){
+      return `${p.completions}/${p.attempts}, ${p.yards} YDS, ${p.tds} TD, ${p.ints} INT`;
+    }
+    function statLineRushing(p){
+      return `${p.carries} CAR, ${p.yards} YDS, ${p.tds} TD`;
+    }
+    function statLineReceiving(p){
+      return `${p.receptions} REC, ${p.yards} YDS, ${p.tds} TD`;
+    }
+
+    function buildSection(label, homePlayer, awayPlayer, statField, lineFn){
+      const homeName = homePlayer ? homePlayer.playername : '';
+      const awayName = awayPlayer ? awayPlayer.playername : '';
+      const homePos = homePlayer && playerTraits[homeName] ? playerTraits[homeName].position : '';
+      const awayPos = awayPlayer && playerTraits[awayName] ? playerTraits[awayName].position : '';
+      const homeVal = homePlayer ? homePlayer[statField] : '--';
+      const awayVal = awayPlayer ? awayPlayer[statField] : '--';
+      let html = `
+        <div class="leader-row values">
+          <div class="leader-left">${placeholder}<span class="leader-value">${homeVal}</span></div>
+          <div class="leader-center"></div>
+          <div class="leader-right"><span class="leader-value">${awayVal}</span>${placeholder}</div>
+        </div>
+        <div class="leader-row names">
+          <div class="leader-left">${homePlayer ? `<span class="leader-name">${homeName}</span><span class="leader-pos">${homePos}</span>` : ''}</div>
+          <div class="leader-center leader-label">${label}</div>
+          <div class="leader-right">${awayPlayer ? `<span class="leader-name">${awayName}</span><span class="leader-pos">${awayPos}</span>` : ''}</div>
+        </div>`;
+      if (lineFn && (homePlayer || awayPlayer)) {
+        html += `<div class="leader-row statlines">
+          <div class="leader-left">${homePlayer ? `<span class="leader-statline">${lineFn(homePlayer)}</span>` : ''}</div>
+          <div class="leader-center"></div>
+          <div class="leader-right">${awayPlayer ? `<span class="leader-statline">${lineFn(awayPlayer)}</span>` : ''}</div>
+        </div>`;
+      }
+      html += '<div class="leader-divider"></div>';
+      return html;
+    }
+
+    container.innerHTML = `
+      <div class="leaders-header">GAME LEADERS</div>
+      <div class="leaders-team-row">
+        <div class="team home"><img src="${state.HomeLogo || ''}" class="team-logo-small"><span class="team-name">${homeTeam}</span></div>
+        <div class="team away"><span class="team-name">${awayTeam}</span><img src="${state.AwayLogo || ''}" class="team-logo-small"></div>
+      </div>
+      <div class="leader-divider"></div>
+      ${buildSection('Passing Yards', passHome, passAway, 'yards', statLinePassing)}
+      ${buildSection('Rushing Yards', rushHome, rushAway, 'yards', statLineRushing)}
+      ${buildSection('Receiving Yards', recHome, recAway, 'yards', statLineReceiving)}
+      ${buildSection('Sacks', sackHome, sackAway, 'sacks')}
+      ${buildSection('Tackles', tklHome, tklAway, 'tackles')}
+      <div id="boxscoreLink" class="boxscore-link">Full Box Score</div>
+    `;
+
+    const link = document.getElementById('boxscoreLink');
+    if (link) link.addEventListener('click', () => {
+      const tab = document.querySelector('.tab-button[data-tab="boxscore"]');
+      if (tab) tab.click();
+    });
+  }
+
   function loadPlayers() {
       populateBench();
       updateRunnerDropdown();
@@ -2817,6 +2903,7 @@
     renderDefensiveTable("Home");
     renderDefensiveTable("Away");
     sortBoxScoreTables();
+    renderGameLeaders();
   }
 
   function renderPassingTable(team) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -573,6 +573,119 @@
     font-weight: bold;
   }
 
+  /* Game leaders card */
+  .leaders-card {
+    max-width: 900px;
+    margin: 2vw auto;
+    background: var(--gray-medium);
+    border: 1px solid var(--gray-light);
+    border-radius: 4px;
+    padding: 2vw;
+    font-size: 3vw;
+  }
+  .leaders-header {
+    text-align: center;
+    font-weight: 700;
+    margin-bottom: 1vw;
+    color: var(--text-light);
+  }
+  .leaders-team-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 700;
+    margin-bottom: 1vw;
+    color: var(--text-light);
+  }
+  .leaders-team-row .team {
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+  }
+  .leaders-team-row .team.away {
+    flex-direction: row-reverse;
+  }
+  .leader-divider {
+    border-bottom: 1px solid var(--gray-light);
+    margin: 1.5vw 0;
+  }
+  .leader-row {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    margin: 1vw 0;
+  }
+  .leader-row.values .leader-left,
+  .leader-row.values .leader-right {
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+  }
+  .leader-row.values .leader-left {
+    justify-content: flex-start;
+  }
+  .leader-row.values .leader-right {
+    justify-content: flex-end;
+  }
+  .player-placeholder {
+    width: 10vw;
+    height: 10vw;
+    border-radius: 50%;
+    background: var(--gray-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 5vw;
+    color: var(--gray-dark);
+  }
+  .leader-value,
+  .leader-name,
+  .leader-label {
+    font-weight: 700;
+    color: var(--text-light);
+  }
+  .leader-label {
+    text-align: center;
+  }
+  .leader-name-pos {
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+  }
+  .leader-pos,
+  .leader-statline {
+    color: var(--text-muted);
+    font-weight: normal;
+  }
+  .leader-row.names .leader-left,
+  .leader-row.names .leader-right {
+    display: flex;
+    gap: 1vw;
+  }
+  .leader-row.names .leader-left {
+    justify-content: flex-start;
+  }
+  .leader-row.names .leader-right {
+    justify-content: flex-end;
+  }
+  .leader-row.statlines .leader-left,
+  .leader-row.statlines .leader-right {
+    display: flex;
+  }
+  .leader-row.statlines .leader-left {
+    justify-content: flex-start;
+  }
+  .leader-row.statlines .leader-right {
+    justify-content: flex-end;
+  }
+  .boxscore-link {
+    text-align: center;
+    color: #4da3ff;
+    text-decoration: underline;
+    cursor: pointer;
+    margin-top: 1vw;
+  }
+
   /* Stats panel */
   .full-stats-panel {
     max-width: 900px;


### PR DESCRIPTION
## Summary
- add game leaders card with placeholder avatars beneath score-by-quarter chart
- style leaders card and link to box score
- compute and render team leaders for passing, rushing, receiving, sacks, and tackles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b3753eba1c83249231a22d1ec6b9a2