### PR TITLE
feat: add dynamic team stats tab

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -415,8 +415,18 @@
     </div>
 
     <div id="teamstats" class="tab-content">
-      <div class="play-log-card">
-        <p>Team stats coming soon...</p>
+      <div class="play-log-card team-stats-card">
+        <div class="team-stats-title">TEAM STATS</div>
+        <table id="teamStatsTable" class="stats-table team-stats-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th><img id="teamStatsHomeLogo" class="team-stats-logo" src="" alt="Home Logo" /></th>
+              <th><img id="teamStatsAwayLogo" class="team-stats-logo" src="" alt="Away Logo" /></th>
+            </tr>
+          </thead>
+          <tbody id="teamStatsBody"></tbody>
+        </table>
       </div>
     </div>
 

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -902,6 +902,118 @@
     });
   }
 
+  function computeTeamStats() {
+    const init = () => ({ firstDowns: 0, thirdAtt: 0, thirdConv: 0, fourthAtt: 0, fourthConv: 0,
+      passYds: 0, rushYds: 0, passAtt: 0, passComp: 0, ints: 0, sacks: 0, sackYds: 0,
+      rushAtt: 0, fumLost: 0, possTime: 0 });
+    const teams = { Home: init(), Away: init() };
+    const quarterLen = 15 * 60;
+    let prev = { Possession: state.StartingPossession || 'Home', Time: quarterLen, Qtr: 1 };
+    playHistory.forEach(play => {
+      const team = play.Possession;
+      if (!team) return;
+      const yards = Number(play.Yards) || 0;
+      const down = Number(play.Down);
+      const distance = Number(play.Distance);
+      const result = play.Result || '';
+      const playType = play.PlayType;
+      const currTime = parseTimeToSeconds(play.Time);
+      const currQtr = Number(play.Qtr || play.QTR || prev.Qtr);
+      let diff = 0;
+      if (currQtr === prev.Qtr) diff = prev.Time - currTime;
+      else diff = prev.Time + (quarterLen * (currQtr - prev.Qtr - 1)) + (quarterLen - currTime);
+      if (teams[prev.Possession]) teams[prev.Possession].possTime += diff;
+      prev = { Possession: team, Time: currTime, Qtr: currQtr };
+
+      if (playType === 'Pass') {
+        if (result === 'Sack') {
+          teams[team].sacks++;
+          teams[team].sackYds += yards;
+          teams[team].passYds += yards;
+        } else {
+          teams[team].passAtt++;
+          if (result !== 'Incomplete' && result !== 'Interception') {
+            teams[team].passComp++;
+            teams[team].passYds += yards;
+          }
+          if (result === 'Interception') teams[team].ints++;
+          if (result === 'Fumble' && play.RecoveredBy && play.RecoveredBy !== (play.Receiver || play.Player)) {
+            teams[team].fumLost++;
+          }
+        }
+      } else if (playType === 'Run') {
+        teams[team].rushAtt++;
+        teams[team].rushYds += yards;
+        if (result === 'Fumble' && play.RecoveredBy && play.RecoveredBy !== play.Player) {
+          teams[team].fumLost++;
+        }
+      }
+
+      if (playType === 'Run' || playType === 'Pass') {
+        const converted = yards >= distance || result === 'Touchdown';
+        if (down === 3) {
+          teams[team].thirdAtt++;
+          if (converted) teams[team].thirdConv++;
+        } else if (down === 4) {
+          teams[team].fourthAtt++;
+          if (converted) teams[team].fourthConv++;
+        }
+        if (converted) teams[team].firstDowns++;
+      }
+    });
+    ['Home','Away'].forEach(t => {
+      teams[t].totalYds = teams[t].passYds + teams[t].rushYds;
+      teams[t].passYPP = teams[t].passAtt ? teams[t].passYds / teams[t].passAtt : 0;
+      teams[t].rushYPR = teams[t].rushAtt ? teams[t].rushYds / teams[t].rushAtt : 0;
+      teams[t].turnovers = teams[t].fumLost + teams[t].ints;
+    });
+    return teams;
+  }
+
+  function renderTeamStats() {
+    const body = document.getElementById('teamStatsBody');
+    if (!body) return;
+    const stats = computeTeamStats();
+    const rows = [
+      { label: '1st Downs', key: 'firstDowns', cls: 'header-row' },
+      { label: '3rd down efficiency', fmt: t => `${t.thirdConv}-${t.thirdAtt}`, cls: 'stat-row', indent: 'indent-1' },
+      { label: '4th down efficiency', fmt: t => `${t.fourthConv}-${t.fourthAtt}`, cls: 'stat-row', indent: 'indent-1' },
+      { label: 'Total Yards', key: 'totalYds', cls: 'header-row' },
+      { label: 'Passing', key: 'passYds', cls: 'header2-row', indent: 'indent-1' },
+      { label: 'Comp/Att', fmt: t => `${t.passComp}/${t.passAtt}`, cls: 'stat-row', indent: 'indent-2' },
+      { label: 'Yards per pass', fmt: t => t.passAtt ? (t.passYds / t.passAtt).toFixed(1) : '0.0', cls: 'stat-row', indent: 'indent-2' },
+      { label: 'Interceptions thrown', key: 'ints', cls: 'stat-row', indent: 'indent-2' },
+      { label: 'Rushing', key: 'rushYds', cls: 'header2-row', indent: 'indent-1' },
+      { label: 'Rushing Attempts', key: 'rushAtt', cls: 'stat-row', indent: 'indent-2' },
+      { label: 'Yards per rush', fmt: t => t.rushAtt ? (t.rushYds / t.rushAtt).toFixed(1) : '0.0', cls: 'stat-row', indent: 'indent-2' },
+      { label: 'Sacks', fmt: t => `${t.sacks}-${Math.abs(t.sackYds)}`, cls: 'header2-row', indent: 'indent-1' },
+      { label: 'Turnovers', key: 'turnovers', cls: 'header-row' },
+      { label: 'Fumbles lost', key: 'fumLost', cls: 'stat-row', indent: 'indent-1' },
+      { label: 'Interceptions thrown', key: 'ints', cls: 'stat-row', indent: 'indent-1' },
+      { label: 'Possession', fmt: t => formatClock(t.possTime), cls: 'header-row' }
+    ];
+    body.innerHTML = '';
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.className = r.cls + (r.indent ? ' ' + r.indent : '');
+      const labelTd = document.createElement('td');
+      labelTd.textContent = r.label;
+      const homeTd = document.createElement('td');
+      const awayTd = document.createElement('td');
+      const getVal = team => r.key !== undefined ? stats[team][r.key] : r.fmt(stats[team]);
+      homeTd.textContent = getVal('Home');
+      awayTd.textContent = getVal('Away');
+      tr.appendChild(labelTd);
+      tr.appendChild(homeTd);
+      tr.appendChild(awayTd);
+      body.appendChild(tr);
+    });
+    const hLogo = document.getElementById('teamStatsHomeLogo');
+    const aLogo = document.getElementById('teamStatsAwayLogo');
+    if (hLogo) hLogo.src = state.HomeLogo || '';
+    if (aLogo) aLogo.src = state.AwayLogo || '';
+  }
+
   function loadPlayers() {
       populateBench();
       updateRunnerDropdown();
@@ -2904,6 +3016,7 @@
     renderDefensiveTable("Away");
     sortBoxScoreTables();
     renderGameLeaders();
+    renderTeamStats();
   }
 
   function renderPassingTable(team) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -788,6 +788,53 @@
     font-weight: 700;
   }
 
+  /* Team stats */
+  .team-stats-card {
+    margin-top: 5vw;
+    padding: 5vw;
+    background: var(--gray-medium);
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.4);
+  }
+  .team-stats-title {
+    font-weight: 700;
+    margin-bottom: 3.75vw;
+    text-align: center;
+    font-size: clamp(16px, 4.5vw, 28px);
+  }
+  .team-stats-table th {
+    background: var(--gray-light);
+    border-bottom: 2px solid var(--accent-red);
+    color: var(--text-light);
+    font-weight: 700;
+  }
+  .team-stats-table td:first-child {
+    text-align: left;
+  }
+  .team-stats-table .header-row td {
+    font-weight: 700;
+    color: var(--text-light);
+    font-size: clamp(14px, 4.5vw, 24px);
+  }
+  .team-stats-table .header2-row td {
+    font-weight: 700;
+    color: var(--text-light);
+  }
+  .team-stats-table .stat-row td {
+    color: var(--text-muted);
+  }
+  .team-stats-table .indent-1 td:first-child {
+    padding-left: 5vw;
+  }
+  .team-stats-table .indent-2 td:first-child {
+    padding-left: 10vw;
+  }
+  .team-stats-logo {
+    width: 10vw;
+    height: 10vw;
+    object-fit: contain;
+  }
+
   /* Play log */
   .play-log-card {
     margin-top: 5vw;


### PR DESCRIPTION
## Summary
- add team stats table with team logos
- style team stats table with alternating rows and headings
- compute and render team stats from play history, updating after every play

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b37849bab083249fb3fca5e9beff00