### PR TITLE
Display player images in Game Leaders

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -94,8 +94,8 @@ function getPlayerTraits() {
     throw new Error("Sheet 'Players' not found.");
   }
 
-  // Pull columns A through AH (0 - 33) to include BallSecurity and DefPos
-  const numCols = 34;
+  // Pull columns A through AI (0 - 34) to include BallSecurity, DefPos, and Image
+  const numCols = 35;
   const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, numCols).getValues();
   Logger.log(data);
   const result = data
@@ -135,6 +135,7 @@ function getPlayerTraits() {
       readQB: row[31],
       coverage: row[32],
       defPos: row[33],
+      image: row[34],
       // Local tracking only
       carries: 0,
       fatigue: row[8]

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -822,7 +822,15 @@
 
     const homeTeam = state.Home || '';
     const awayTeam = state.Away || '';
-    const placeholder = '<div class="player-placeholder"><span>👤</span></div>';
+    const emptyPfp = '<div class="player-placeholder"><span>👤</span></div>';
+
+    function playerImage(player){
+      const name = player ? player.playername : '';
+      const trait = name && playerTraits[name];
+      const img = trait && trait.image;
+      if (!img) return emptyPfp;
+      return `<div class="player-placeholder"><img src="${img}" class="player-img" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"><span style="display:none;">👤</span></div>`;
+    }
 
     function leader(arr, team, stat, hasStatsFn) {
       const players = arr.filter(p => p.team === team && (hasStatsFn ? hasStatsFn(p) : (p[stat] || 0) > 0));
@@ -858,11 +866,13 @@
       const awayPos = awayPlayer && playerTraits[awayName] ? playerTraits[awayName].position : '';
       const homeVal = homePlayer ? homePlayer[statField] : '--';
       const awayVal = awayPlayer ? awayPlayer[statField] : '--';
+      const homeImg = playerImage(homePlayer);
+      const awayImg = playerImage(awayPlayer);
       let html = `
         <div class="leader-row values">
-          <div class="leader-left">${placeholder}<span class="leader-value">${homeVal}</span></div>
+          <div class="leader-left">${homeImg}<span class="leader-value">${homeVal}</span></div>
           <div class="leader-center"></div>
-          <div class="leader-right"><span class="leader-value">${awayVal}</span>${placeholder}</div>
+          <div class="leader-right"><span class="leader-value">${awayVal}</span>${awayImg}</div>
         </div>
         <div class="leader-row names">
           <div class="leader-left">${homePlayer ? `<span class="leader-name">${homeName}</span><span class="leader-pos">${homePos}</span>` : ''}</div>

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -638,6 +638,12 @@
     font-size: 5vw;
     color: var(--gray-dark);
   }
+  .player-placeholder img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+  }
   .leader-value,
   .leader-name,
   .leader-label {


### PR DESCRIPTION
## Summary
- load player image URL from Players sheet
- show player headshots in Game Leaders with fallback to placeholder
- style leader images to match existing placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b37feadfcc83248b1f385c769f64ad