### PR TITLE
Add collapsible control panel below last play description

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -113,28 +113,29 @@
         </div>
       </div>
       
-      <div id="lastPlayDesc" class="last-play-desc"></div>
+        <div id="lastPlayDesc" class="last-play-desc"></div>
 
-      <div id="scoreChart" class="score-chart"></div>
-
-      <div id="leadersCard" class="leaders-card"></div>
-
-      <div class="control-panel">
-        <button id="openFormation">Edit Formation</button>
-        <button id="viewLOS">View LOS</button>
-        <button id="openRoutes">Set Receiver Routes</button>
-        <label for="playerDropdown">Select Player:</label>
-        <select id="playerDropdown"></select>
-        <div class="button-row">
-          <button onclick="runPlay()">▶️ Run Play</button>
-          <button onclick="passPlay(document.getElementById('playerDropdown').value)">🏈 Pass Play</button>
-          <button id="kickFGButton" onclick="kickFG()" style="display:none;">🎯 Kick FG</button>
-          <button onclick="nextDrive()">🔁 Next Drive</button>
+        <button id="toggleControlPanel" class="control-toggle">Show Control Panel</button>
+        <div id="controlPanel" class="control-panel collapsed">
+          <button id="openFormation">Edit Formation</button>
+          <button id="viewLOS">View LOS</button>
+          <button id="openRoutes">Set Receiver Routes</button>
+          <label for="playerDropdown">Select Player:</label>
+          <select id="playerDropdown"></select>
+          <div class="button-row">
+            <button onclick="runPlay()">▶️ Run Play</button>
+            <button onclick="passPlay(document.getElementById('playerDropdown').value)">🏈 Pass Play</button>
+            <button id="kickFGButton" onclick="kickFG()" style="display:none;">🎯 Kick FG</button>
+            <button onclick="nextDrive()">🔁 Next Drive</button>
+          </div>
+          <div id="result" class="result-box"></div>
         </div>
-        <div id="result" class="result-box"></div>
-      </div>
 
-    </div>
+        <div id="scoreChart" class="score-chart"></div>
+
+        <div id="leadersCard" class="leaders-card"></div>
+
+      </div>
 
     <div id="playbyplay" class="tab-content">
       <div class="playbyplay-pill-container">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -135,11 +135,17 @@
       });
       const clearRoutesBtn = document.getElementById('clearRoutes');
       if (clearRoutesBtn) clearRoutesBtn.addEventListener('click', clearRoutes);
-      const saveRoutesBtn = document.getElementById('saveRoutes');
-      if (saveRoutesBtn) saveRoutesBtn.addEventListener('click', () => {
-        document.getElementById('routesModal').classList.remove('open');
+        const saveRoutesBtn = document.getElementById('saveRoutes');
+        if (saveRoutesBtn) saveRoutesBtn.addEventListener('click', () => {
+          document.getElementById('routesModal').classList.remove('open');
+        });
+        const togglePanelBtn = document.getElementById('toggleControlPanel');
+        if (togglePanelBtn) togglePanelBtn.addEventListener('click', () => {
+          const panel = document.getElementById('controlPanel');
+          const collapsed = panel.classList.toggle('collapsed');
+          togglePanelBtn.textContent = collapsed ? 'Show Control Panel' : 'Hide Control Panel';
+        });
       });
-    });
 
   function loadGamesList() {
     google.script.run.withSuccessHandler(renderGameCards).getGamesList();

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -470,6 +470,13 @@
     padding: 5vw;
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
   }
+  .control-panel.collapsed {
+    display: none;
+  }
+  .control-toggle {
+    display: block;
+    margin: 3vw auto;
+  }
   .control-panel label {
     display: block;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- Place control panel directly below last play description with a toggle button
- Add styles for hidden/visible states and a control-panel toggle
- Implement JS to show or hide the panel on demand

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b383dfe1c08324ae302f12e5cecaf2