### PR TITLE
Position QB read badges outside player circles

### DIFF
--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1164,7 +1164,7 @@
     text-align: center;
     touch-action: none;
     z-index: 2;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .player-circle:active {
@@ -1175,16 +1175,19 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border-radius: 50%;
   }
   .player-circle .read-badge {
     position: absolute;
-    top: 0.5vw;
-    right: 0.5vw;
+    top: 0;
+    right: 0;
+    transform: translate(50%, -50%);
     background: var(--accent-red);
     color: #fff;
     border-radius: 4px;
     padding: 0.3vw 0.6vw;
     font-size: 2vw;
+    z-index: 3;
   }
 
   .route-row {


### PR DESCRIPTION
## Summary
- Allow player-circle badges to overflow and appear above the circle
- Position QB read badges at top-right outside circle with proper z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d391212c8324b5bb10be337d689a