### PR TITLE
Handle sack fumbles and adjust interception spot

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -300,6 +300,7 @@
                 const yards = parseFloat(play.Yards) || 0;
                 if (play.Result === 'Sack') {
                   const qb = play.Passer || play.Player || '';
+                  const recoveredBy = play.RecoveredBy || play.recoveredby;
                   if (qb) {
                     let ps = passingStats.find(s => s.playername === qb && s.team === team);
                     if (!ps) {
@@ -319,6 +320,33 @@
                     d.tackles++;
                     d.tfl++;
                     d.sacks = (d.sacks || 0) + 1;
+                  }
+                  if (recoveredBy) {
+                    let p = frontendStats.find(s => s.playername === qb && s.team === team);
+                    if (!p) {
+                      p = { playername: qb, team, carries: 0, yards: 0, tds: 0, fumbles: 0, long: 0 };
+                      frontendStats.push(p);
+                    }
+                    p.fumbles = (p.fumbles || 0) + 1;
+
+                    const recTeam = playerTraits[recoveredBy]?.team;
+                    if (recTeam && recTeam !== team) {
+                      let dRec = defensiveStats.find(s => s.playername === recoveredBy && s.team === recTeam);
+                      if (!dRec) {
+                        dRec = { playername: recoveredBy, team: recTeam, tackles: 0, tfl: 0, ff: 0, fr: 0, deflections: 0, ints: 0, sacks: 0 };
+                        defensiveStats.push(dRec);
+                      }
+                      dRec.ff = (dRec.ff || 0) + 1;
+                      dRec.fr = (dRec.fr || 0) + 1;
+                    } else if (play.Tackler && play.Tackler !== 'NA') {
+                      const defTeam = team === 'Home' ? 'Away' : 'Home';
+                      let dFf = defensiveStats.find(s => s.playername === play.Tackler && s.team === defTeam);
+                      if (!dFf) {
+                        dFf = { playername: play.Tackler, team: defTeam, tackles: 0, tfl: 0, ff: 0, fr: 0, deflections: 0, ints: 0, sacks: 0 };
+                        defensiveStats.push(dFf);
+                      }
+                      dFf.ff = (dFf.ff || 0) + 1;
+                    }
                   }
                   return;
                 }
@@ -2007,19 +2035,22 @@
     let newDown = state.Down;
     let newDist = state.Distance;
 
-    //HandleSack
-    if (resultArray.sack){
-      newBall = state.Possession === 'Home' ? newBall + yards : newBall - yards;
-      const fum = checkForFumble(qbName, resultArray.sackBy, resultArray.sack);
-      if (fum.fumble) {
-        fumble = true;
-        recoveredBy = fum.recoveredBy;
+      //HandleSack
+      if (resultArray.sack){
+        newBall = state.Possession === 'Home' ? newBall + yards : newBall - yards;
+        const fum = checkForFumble(qbName, resultArray.sackBy, resultArray.sack);
+        if (fum.fumble) {
+          fumble = true;
+          recoveredBy = fum.recoveredBy;
+        }
+        tackler = resultArray.sackBy;
+        updateDefensiveStatsPass(tackler, { tackle: true, yards: yards, sack: true, fumble: fumble, recoveredBy: recoveredBy});
+      } else if (resultArray.intercepted) {
+        const airYards = Number(target?.routeInfo?.airYards) || 0;
+        newBall = state.Possession === 'Home' ? newBall + airYards : newBall - airYards;
       }
-      tackler = resultArray.sackBy;
-      updateDefensiveStatsPass(tackler, { tackle: true, yards: yards, sack: true, fumble: fumble, recoveredBy: recoveredBy});
-    }
-    //Handle Completed Pass
-    if (resultArray.completed){
+      //Handle Completed Pass
+      if (resultArray.completed){
       newBall = state.Possession === 'Home' ? newBall + yards : newBall - yards;
       touchdown = state.Possession === 'Home' ? newBall >= 100 : newBall <= 0;
       if(touchdown){


### PR DESCRIPTION
## Summary
- Treat sacks with recoveries as strip sacks, crediting fumbles and appropriate forced/recovery stats
- Place interceptions at the pass's air-yards so the defense takes over at the pick spot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5f7baef4c8324b89d597ad29523a5