### PR TITLE
feat: add loading screen when opening game

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -7,6 +7,17 @@
   </head>
   <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
+    <div id="loadingScreen" class="loading-screen hidden">
+      <div class="logo-container">
+        <img id="loadingHomeLogo" class="loading-logo" alt="Home Logo" />
+        <img id="loadingAwayLogo" class="loading-logo" alt="Away Logo" />
+      </div>
+      <img
+        src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/American_football_icon_%28flat%29.svg/128px-American_football_icon_%28flat%29.svg.png"
+        alt="Loading"
+        class="loading-football"
+      />
+    </div>
     <div id="gameList" class="game-list"></div>
     <div id="gameUI" style="display:none;">
       <button id="backButton" class="back-button">← Back</button>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -38,6 +38,30 @@
   let completionSeparationAdjustment = [];
   let yacBySeparation = {};
 
+  function showLoadingScreen(homeLogo, awayLogo) {
+    const screen = document.getElementById('loadingScreen');
+    if (!screen) return;
+    const home = document.getElementById('loadingHomeLogo');
+    const away = document.getElementById('loadingAwayLogo');
+    if (home) {
+      home.src = homeLogo || '';
+      home.classList.remove('animate-left');
+      void home.offsetWidth;
+      home.classList.add('animate-left');
+    }
+    if (away) {
+      away.src = awayLogo || '';
+      away.classList.remove('animate-right');
+      void away.offsetWidth;
+      away.classList.add('animate-right');
+    }
+    screen.classList.remove('hidden');
+  }
+
+  function hideLoadingScreen() {
+    const screen = document.getElementById('loadingScreen');
+    if (screen) screen.classList.add('hidden');
+  }
 
   function updateStickyOffsets() {
     const scoreboard = document.getElementById('scoreboard');
@@ -213,12 +237,18 @@
       }
       card.addEventListener('click', () => {
         gameId = id;
-        refreshUI(id);
         document.getElementById('gameList').style.display = 'none';
-        document.getElementById('gameUI').style.display = 'block';
-        const backBtn = document.getElementById('backButton');
-        if (backBtn) backBtn.style.display = 'block';
-        updateStickyOffsets();
+        showLoadingScreen(g.HomeLogo, g.AwayLogo);
+        refreshUI(id).then(() => {
+          hideLoadingScreen();
+          document.getElementById('gameUI').style.display = 'block';
+          const backBtn = document.getElementById('backButton');
+          if (backBtn) backBtn.style.display = 'block';
+          updateStickyOffsets();
+        }).catch(err => {
+          console.error(err);
+          hideLoadingScreen();
+        });
       });
       container.appendChild(card);
     });
@@ -254,6 +284,7 @@
 
   // === GAME SETUP ===
   function refreshUI(selectedGameId) {
+    return new Promise((resolve, reject) => {
     state = {};
     players = [];
     playerTraits = {};
@@ -272,6 +303,7 @@
       console.log("✅ Loaded game state");
       if (!gameState) {
         console.error(`❌ No game state returned for game ${gameId}`);
+        reject(new Error('No game state'));
         return;
       }
       state = gameState;
@@ -453,16 +485,20 @@
               updateFatigueBasedOnStatsOnInitialLoad();
               renderBoxScore();
               await animatePlay('Run');
+              resolve();
             })
             .withFailureHandler(function (error) {
               console.error("❌ Failed to load play history:", error.message);
+              reject(error);
             })
             .getPlayHistory(gameId);
         });
       });
     }).withFailureHandler(function (error) {
       console.error("❌ Failed to load game state:", error.message);
+      reject(error);
     }).getGameState(gameId);
+  });
 
   }
 
@@ -3940,5 +3976,5 @@
   }
 
   // On load
-  refreshUI();
+  refreshUI().catch(console.error);
 </script>

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1705,4 +1705,78 @@
     border-radius: 50%;
     transform: translate(-50%, -50%); /* center over coordinates */
   }
+
+  /* Loading screen */
+  .loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+  }
+  .loading-screen.hidden {
+    display: none;
+  }
+  .logo-container {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    height: 40vh;
+  }
+  .loading-logo {
+    width: 30vw;
+    max-width: 150px;
+    opacity: 0;
+  }
+  .animate-left {
+    animation: clash-left 0.8s forwards;
+  }
+  .animate-right {
+    animation: clash-right 0.8s forwards;
+  }
+  @keyframes clash-left {
+    from {
+      transform: translateX(-200%);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+  @keyframes clash-right {
+    from {
+      transform: translateX(200%);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+  .loading-football {
+    position: absolute;
+    bottom: 2vw;
+    right: 2vw;
+    width: 12vw;
+    max-width: 80px;
+    animation: spin 1s linear infinite;
+  }
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 </style>


### PR DESCRIPTION
## Summary
- Add full-screen loading overlay with team logos and spinning football
- Delay game UI until data and UI fully load
- Wrap refreshUI in a Promise and show loading feedback when selecting a game

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68b703cf78708324a4fc3a358ef8caaa