### PR TITLE
Add exit animation to loading screen

### DIFF
--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -45,22 +45,46 @@
     const away = document.getElementById('loadingAwayLogo');
     if (home) {
       home.src = homeLogo || '';
-      home.classList.remove('animate-left');
+      home.classList.remove('animate-left', 'unclash-left');
       void home.offsetWidth;
       home.classList.add('animate-left');
     }
     if (away) {
       away.src = awayLogo || '';
-      away.classList.remove('animate-right');
+      away.classList.remove('animate-right', 'unclash-right');
       void away.offsetWidth;
       away.classList.add('animate-right');
     }
-    screen.classList.remove('hidden');
+    screen.classList.remove('hidden', 'exit-zoom');
   }
 
   function hideLoadingScreen() {
     const screen = document.getElementById('loadingScreen');
-    if (screen) screen.classList.add('hidden');
+    if (!screen) return;
+    const home = document.getElementById('loadingHomeLogo');
+    const away = document.getElementById('loadingAwayLogo');
+
+    if (home) {
+      home.classList.remove('animate-left');
+      void home.offsetWidth;
+      home.classList.add('unclash-left');
+    }
+    if (away) {
+      away.classList.remove('animate-right');
+      void away.offsetWidth;
+      away.classList.add('unclash-right');
+    }
+
+    screen.classList.add('exit-zoom');
+    screen.addEventListener('animationend', function handler(e) {
+      if (e.target === screen && e.animationName === 'zoom-in') {
+        screen.classList.add('hidden');
+        screen.classList.remove('exit-zoom');
+        if (home) home.classList.remove('unclash-left');
+        if (away) away.classList.remove('unclash-right');
+        screen.removeEventListener('animationend', handler);
+      }
+    });
   }
 
   function updateStickyOffsets() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1723,6 +1723,7 @@
     background-position: center, center;  /* center both layers */
     background-repeat: no-repeat, no-repeat;
     background-color: #000;               /* fallback while GIF loads */
+    transform-origin: center;
   }
   .loading-screen.hidden {
     display: none;
@@ -1747,6 +1748,12 @@
   .animate-right {
     animation: clash-right 0.8s forwards;
   }
+  .unclash-left {
+    animation: unclash-left 0.6s forwards;
+  }
+  .unclash-right {
+    animation: unclash-right 0.6s forwards;
+  }
   @keyframes clash-left {
     from {
       transform: translateX(-200%);
@@ -1765,6 +1772,39 @@
     to {
       transform: translateX(0);
       opacity: 1;
+    }
+  }
+  @keyframes unclash-left {
+    from {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(-200%);
+      opacity: 0;
+    }
+  }
+  @keyframes unclash-right {
+    from {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(200%);
+      opacity: 0;
+    }
+  }
+  .exit-zoom {
+    animation: zoom-in 0.6s forwards;
+  }
+  @keyframes zoom-in {
+    from {
+      transform: scale(1);
+      opacity: 1;
+    }
+    to {
+      transform: scale(3);
+      opacity: 0;
     }
   }
   .loading-football {


### PR DESCRIPTION
## Summary
- Animate logos to slide apart and fade out when game load completes
- Zoom loading screen into the field before hiding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7147e28a08324b8c54e1753902fc0