### PR TITLE
Add app-wide loading screen

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -7,6 +7,10 @@
   </head>
   <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
+    <div id="appLoading" class="app-loading">
+      <div class="app-spinner"><span class="app-football">🏈</span></div>
+      <div class="loading-text">Loading Games...</div>
+    </div>
     <div id="loadingScreen" class="loading-screen hidden">
       <div class="logo-container">
         <img id="loadingHomeLogo" class="loading-logo" alt="Home Logo" />

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -87,6 +87,16 @@
     });
   }
 
+  function showAppLoading() {
+    const screen = document.getElementById('appLoading');
+    if (screen) screen.classList.remove('hidden');
+  }
+
+  function hideAppLoading() {
+    const screen = document.getElementById('appLoading');
+    if (screen) screen.classList.add('hidden');
+  }
+
   function updateStickyOffsets() {
     const scoreboard = document.getElementById('scoreboard');
     if (!scoreboard) return;
@@ -205,7 +215,17 @@
       });
 
   function loadGamesList() {
-    google.script.run.withSuccessHandler(renderGameCards).getGamesList();
+    showAppLoading();
+    google.script.run
+      .withSuccessHandler(games => {
+        renderGameCards(games);
+        hideAppLoading();
+      })
+      .withFailureHandler(err => {
+        console.error(err);
+        hideAppLoading();
+      })
+      .getGamesList();
   }
 
   function renderGameCards(games) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1815,4 +1815,41 @@
     max-width: 200px;
     transform: rotate(-45deg);
   }
+  .app-loading {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #0b0b0b, #1c1c1c);
+    z-index: 300;
+    color: #fff;
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+  }
+  .app-loading.hidden {
+    display: none;
+  }
+  .app-spinner {
+    width: 80px;
+    height: 80px;
+    border: 6px solid rgba(255, 255, 255, 0.2);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: spin 1s linear infinite;
+    margin-bottom: 20px;
+  }
+  .app-football {
+    font-size: 32px;
+  }
+  .loading-text {
+    font-size: 1.2em;
+    letter-spacing: 2px;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
 </style>


### PR DESCRIPTION
## Summary
- add full-screen app loader shown while fetching game list
- style loader with modern spinner and football icon
- wire loader into game list fetch lifecycle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b748cead5c8324b4d7d5c10fd425fe