### PR TITLE
feat: add team-filtered player list with traits

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -94,8 +94,8 @@ function getPlayerTraits() {
     throw new Error("Sheet 'Players' not found.");
   }
 
-  // Pull columns A through AI (0 - 34) to include BallSecurity, DefPos, and Image
-  const numCols = 35;
+  // Pull columns A through AL (0 - 37) to include BallSecurity, DefPos, Image, and transform values
+  const numCols = 38;
   const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, numCols).getValues();
   Logger.log(data);
   const result = data
@@ -136,6 +136,9 @@ function getPlayerTraits() {
       coverage: row[32],
       defPos: row[33],
       image: row[34],
+      translateX: row[35],
+      translateY: row[36],
+      scale: row[37],
       // Local tracking only
       carries: 0,
       fatigue: row[8]

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -25,14 +25,21 @@
     <button id="playerListButton" class="player-list-btn">Player List</button>
     <div id="playerListView" style="display:none;">
       <button id="playerListBack" class="back-button">← Back</button>
-      <div class="player-list-card">
-        <div class="player-list-container">
-          <img id="player-list" src="https://andrew-jacobson06.github.io/public-audio/baby.png" alt="Player"/>
-          <div id="jersey-wrapper">
-            <img id="jersey" src="" alt="Jersey Overlay"/>
+      <div class="player-list-layout">
+        <div class="player-list-card">
+          <div class="player-list-container">
+            <img id="player-list" src="https://andrew-jacobson06.github.io/public-audio/baby.png" alt="Player"/>
+            <div id="jersey-wrapper">
+              <img id="jersey" src="" alt="Jersey Overlay"/>
+            </div>
           </div>
         </div>
+        <div id="playerInfo" class="player-info">
+          <div id="playerSummary" class="player-summary"></div>
+          <div id="playerTraits" class="player-traits"></div>
+        </div>
       </div>
+      <select id="teamSelect" class="team-select"></select>
       <table id="playerTable" class="player-table">
         <thead>
           <tr><th>Name</th><th>Offensive Pos</th><th>Defensive Pos</th></tr>

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -37,6 +37,7 @@
   let timeNeededToOpen = [];
   let completionSeparationAdjustment = [];
   let yacBySeparation = {};
+  let playerListData = [];
 
   function showLoadingScreen(homeLogo, awayLogo) {
     const screen = document.getElementById('loadingScreen');
@@ -319,19 +320,31 @@
       .getPlayerTraits();
   }
 
-  
-
   function renderPlayerList(players) {
+    playerListData = players;
+    const teamSelect = document.getElementById('teamSelect');
+    if (!teamSelect) return;
+    const teams = [...new Set(playerListData.map(p => p.team))].sort();
+    teamSelect.innerHTML = teams.map(t => `<option value="${t}">${t}</option>`).join('');
+    teamSelect.addEventListener('change', () => populatePlayerTable(teamSelect.value));
+    if (teams.length) {
+      teamSelect.value = teams[0];
+      populatePlayerTable(teams[0]);
+    }
+  }
+
+  function populatePlayerTable(team) {
     const tbody = document.querySelector('#playerTable tbody');
     if (!tbody) return;
     tbody.innerHTML = '';
-    players.forEach(p => {
+    const teamPlayers = playerListData.filter(p => p.team === team);
+    teamPlayers.forEach(p => {
       const tr = document.createElement('tr');
       tr.innerHTML = `<td>${p.name}</td><td>${p.position}</td><td>${p.defPos}</td>`;
       tr.addEventListener('click', () => updatePlayerDisplay(p));
       tbody.appendChild(tr);
     });
-    if (players.length) updatePlayerDisplay(players[0]);
+    if (teamPlayers.length) updatePlayerDisplay(teamPlayers[0]);
   }
 
   function updatePlayerDisplay(p) {
@@ -339,10 +352,37 @@
       CLT: "https://andrew-jacobson06.github.io/public-audio/kingsmen-jeresey-cropped.png",
       POR: "https://andrew-jacobson06.github.io/public-audio/wildfire-jersey-cropped.png"
     };
-    const playerImg = document.getElementById('player');
+    const playerImg = document.getElementById('player-list');
     const jerseyImg = document.getElementById('jersey');
-    if (playerImg) playerImg.src = p.image || playerImg.src;
+    if (playerImg) {
+      playerImg.src = p.image || playerImg.src;
+      playerImg.style.transform = `translate(${p.translateX || 0}px, ${p.translateY || 0}px) scale(${p.scale || 1})`;
+    }
     if (jerseyImg) jerseyImg.src = jerseyImages[p.team] || '';
+
+    const summary = document.getElementById('playerSummary');
+    if (summary) {
+      summary.innerHTML = `
+        <div><strong>Name:</strong> ${p.name}</div>
+        <div><strong>Team:</strong> ${p.team}</div>
+        <div><strong>Position:</strong> ${p.position}</div>
+        <div><strong>Defensive Pos:</strong> ${p.defPos}</div>
+        <div><strong>Off Stars:</strong> ${p.offStars}</div>
+        <div><strong>Def Stars:</strong> ${p.defStars}</div>
+      `;
+    }
+
+    const traitsDiv = document.getElementById('playerTraits');
+    if (traitsDiv) {
+      const traitKeys = [
+        'size','strength','speed','stamina','poise','accuracy','armStrength','readDefense','juke','vision','acceleration','routeRunning','jump','hands','ballsecurity','qbFavorite','runBlocking','passProtect','runStop','tackling','runDef','tackleChance','strip','passRush','sackChance','ballHawk','readQB','coverage'
+      ];
+      traitsDiv.innerHTML = traitKeys.map(k => `<div class="trait"><span class="trait-name">${toTitleCase(k)}</span><span class="trait-value">${p[k]}</span></div>`).join('');
+    }
+  }
+
+  function toTitleCase(str) {
+    return str.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
   }
 
   function toggleMenu() {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1900,7 +1900,45 @@
     height: 100%;
     object-fit: contain;
     z-index: 3;
-    transform: translateY(22px) translateX(-1px) scale(0.9);
+  }
+
+  .player-list-layout {
+    display: flex;
+    gap: 2vw;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .player-info {
+    flex: 1;
+    color: #fff;
+  }
+
+  .player-summary > div {
+    margin-bottom: 0.5vw;
+    font-size: clamp(12px, 3vw, 18px);
+  }
+
+  .player-traits {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.5vw;
+    margin-top: 1vw;
+  }
+
+  .trait {
+    background: #1e1e1e;
+    padding: 0.5vw;
+    border-radius: 6px;
+    display: flex;
+    justify-content: space-between;
+    font-size: clamp(10px, 2.5vw, 16px);
+  }
+
+  .team-select {
+    margin-top: 2vw;
+    padding: 1vw;
+    font-size: clamp(14px, 3vw, 20px);
   }
 
   #jersey-wrapper {


### PR DESCRIPTION
## Summary
- group players by team with a team selector and per-player detail view
- display player summary and traits alongside the existing player card
- load translateX/translateY/scale fields and apply to player image transform

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b76762ab7c8324aadaeb3c5d506014