### PR TITLE
Revamp player list and player card layout

### DIFF
--- a/PlayUI.html
+++ b/PlayUI.html
@@ -29,27 +29,25 @@
     <button id="playerListButton" class="player-list-btn">Player List</button>
     <div id="playerListView" style="display:none;">
       <button id="playerListBack" class="back-button">← Back</button>
-      <div class="player-list-layout">
-        <div class="player-list-card">
-          <div class="player-list-container">
-            <img id="player-list" src="https://andrew-jacobson06.github.io/public-audio/baby.png" alt="Player"/>
-            <div id="jersey-wrapper">
-              <img id="jersey" src="" alt="Jersey Overlay"/>
-            </div>
-          </div>
-        </div>
-        <div id="playerInfo" class="player-info">
-          <div id="playerSummary" class="player-summary"></div>
-          <div id="playerTraits" class="player-traits"></div>
-        </div>
-      </div>
-      <select id="teamSelect" class="team-select"></select>
       <table id="playerTable" class="player-table">
         <thead>
-          <tr><th>Name</th><th>Offensive Pos</th><th>Defensive Pos</th></tr>
+          <tr><th>Name</th><th>Positions</th><th>Stars</th><th>Team</th></tr>
         </thead>
         <tbody></tbody>
       </table>
+    </div>
+    <div id="playerCardView" style="display:none;">
+      <button id="playerCardBack" class="back-button">← Back</button>
+      <div class="player-card-layout">
+        <div id="playerImageContainer" class="player-image-container">
+          <img id="player-card-image" src="https://andrew-jacobson06.github.io/public-audio/baby.png" alt="Player"/>
+          <div id="jersey-wrapper">
+            <img id="jersey" src="" alt="Jersey Overlay"/>
+          </div>
+        </div>
+        <div id="playerDetails" class="player-details"></div>
+        <div id="playerTraitBars" class="player-trait-bars"></div>
+      </div>
     </div>
     <div id="gameList" class="game-list"></div>
     <div id="gameUI" style="display:none;">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -154,6 +154,8 @@
       if (playerListBtn) playerListBtn.addEventListener('click', showPlayerList);
       const playerListBack = document.getElementById('playerListBack');
       if (playerListBack) playerListBack.addEventListener('click', hidePlayerList);
+      const playerCardBack = document.getElementById('playerCardBack');
+      if (playerCardBack) playerCardBack.addEventListener('click', backToList);
       document.querySelectorAll('.formation-slot').forEach(slot => {
         slot.addEventListener('dragover', allowDrop);
         slot.addEventListener('drop', handleDrop);
@@ -305,13 +307,20 @@
 
   function showPlayerList() {
     document.getElementById('gameList').style.display = 'none';
+    document.getElementById('playerCardView').style.display = 'none';
     document.getElementById('playerListView').style.display = 'block';
     loadPlayerList();
   }
 
   function hidePlayerList() {
+    document.getElementById('playerCardView').style.display = 'none';
     document.getElementById('playerListView').style.display = 'none';
     document.getElementById('gameList').style.display = 'block';
+  }
+
+  function backToList() {
+    document.getElementById('playerCardView').style.display = 'none';
+    document.getElementById('playerListView').style.display = 'block';
   }
 
   function loadPlayerList() {
@@ -322,63 +331,79 @@
 
   function renderPlayerList(players) {
     playerListData = players;
-    const teamSelect = document.getElementById('teamSelect');
-    if (!teamSelect) return;
-    const teams = [...new Set(playerListData.map(p => p.team))].sort();
-    teamSelect.innerHTML = teams.map(t => `<option value="${t}">${t}</option>`).join('');
-    teamSelect.addEventListener('change', () => populatePlayerTable(teamSelect.value));
-    if (teams.length) {
-      teamSelect.value = teams[0];
-      populatePlayerTable(teams[0]);
-    }
-  }
-
-  function populatePlayerTable(team) {
     const tbody = document.querySelector('#playerTable tbody');
     if (!tbody) return;
     tbody.innerHTML = '';
-    const teamPlayers = playerListData.filter(p => p.team === team);
-    teamPlayers.forEach(p => {
+    players.forEach(p => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${p.name}</td><td>${p.position}</td><td>${p.defPos}</td>`;
-      tr.addEventListener('click', () => updatePlayerDisplay(p));
+      const pos = `${p.position}/${p.defPos}`;
+      const stars = `O:${renderStars(p.offStars)} D:${renderStars(p.defStars)}`;
+      tr.innerHTML = `<td>${p.name}</td><td>${pos}</td><td>${stars}</td><td>${p.team}</td>`;
+      tr.addEventListener('click', () => showPlayerCard(p));
       tbody.appendChild(tr);
     });
-    if (teamPlayers.length) updatePlayerDisplay(teamPlayers[0]);
   }
 
-  function updatePlayerDisplay(p) {
-    /**const jerseyImages = {
-      CLT: "https://andrew-jacobson06.github.io/public-audio/kingsmen-jeresey-cropped.png",
-      POR: "https://andrew-jacobson06.github.io/public-audio/wildfire-jersey-cropped.png"
-    };**/
-    const playerImg = document.getElementById('player-list');
+  function showPlayerCard(p) {
+    document.getElementById('playerListView').style.display = 'none';
+    document.getElementById('playerCardView').style.display = 'block';
+
+    const playerImg = document.getElementById('player-card-image');
     const jerseyImg = document.getElementById('jersey');
     if (playerImg) {
       playerImg.src = p.image || playerImg.src;
       playerImg.style.transform = `translate(${p.translateX || 0}px, ${p.translateY || 0}px) scale(${p.scale || 1})`;
     }
-    jerseyImg.src = p.jersey;
+    if (jerseyImg) jerseyImg.src = p.jersey || '';
 
-    const summary = document.getElementById('playerSummary');
-    if (summary) {
-      summary.innerHTML = `
-        <div><strong>Name:</strong> ${p.name}</div>
-        <div><strong>Team:</strong> ${p.team}</div>
-        <div><strong>Position:</strong> ${p.position}</div>
-        <div><strong>Defensive Pos:</strong> ${p.defPos}</div>
-        <div><strong>Off Stars:</strong> ${p.offStars}</div>
-        <div><strong>Def Stars:</strong> ${p.defStars}</div>
+    const details = document.getElementById('playerDetails');
+    if (details) {
+      details.innerHTML = `
+        <div><strong>${p.name}</strong></div>
+        <div>${p.team}</div>
+        <div>${p.position} / ${p.defPos}</div>
+        <div>Off: ${renderStars(p.offStars)} Def: ${renderStars(p.defStars)}</div>
       `;
     }
 
-    const traitsDiv = document.getElementById('playerTraits');
+    const traitsDiv = document.getElementById('playerTraitBars');
     if (traitsDiv) {
       const traitKeys = [
         'size','strength','speed','stamina','poise','accuracy','armStrength','readDefense','juke','vision','acceleration','routeRunning','jump','hands','ballsecurity','qbFavorite','runBlocking','passProtect','runStop','tackling','runDef','tackleChance','strip','passRush','sackChance','ballHawk','readQB','coverage'
       ];
-      traitsDiv.innerHTML = traitKeys.map(k => `<div class="trait"><span class="trait-name">${toTitleCase(k)}</span><span class="trait-value">${p[k]}</span></div>`).join('');
+      traitsDiv.innerHTML = '';
+      traitKeys.forEach(k => {
+        const val = p[k] || 0;
+        const card = document.createElement('div');
+        card.className = 'trait-bar-card';
+        card.innerHTML = `
+          <div class="trait-bar-header"><span class="trait-name">${toTitleCase(k)}</span><span class="trait-value">${val}</span></div>
+          <div class="progress"><div class="progress-bar ${getBarColor(val)}" style="width:0%"></div></div>`;
+        traitsDiv.appendChild(card);
+        requestAnimationFrame(() => {
+          const bar = card.querySelector('.progress-bar');
+          if (bar) bar.style.width = val + '%';
+        });
+      });
     }
+  }
+
+  function renderStars(value) {
+    const full = Math.floor(value);
+    const half = value - full >= 0.5;
+    let html = '';
+    for (let i = 0; i < full; i++) html += '<span class="star full">★</span>';
+    if (half) html += '<span class="star half">★</span>';
+    for (let i = 0; i < 5 - full - (half ? 1 : 0); i++) html += '<span class="star empty">★</span>';
+    return `<span class="stars">${html}</span>`;
+  }
+
+  function getBarColor(val) {
+    if (val <= 30) return 'red';
+    if (val <= 50) return 'orange';
+    if (val <= 70) return 'yellow';
+    if (val <= 90) return 'light-green';
+    return 'dark-green';
   }
 
   function toTitleCase(str) {

--- a/PlayUIstyle.html
+++ b/PlayUIstyle.html
@@ -1874,27 +1874,44 @@
     border-bottom: 1px solid var(--gray-light);
     text-align: left;
   }
-
-  .player-list-card {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .stars {
+    display: inline-block;
+  }
+  .star {
+    color: #555;
+    font-size: clamp(10px, 2vw, 16px);
     position: relative;
-    max-width: 50%;
+  }
+  .star.full {
+    color: gold;
+  }
+  .star.half::before {
+    content: '★';
+    color: gold;
+    position: absolute;
+    left: 0;
     width: 50%;
-    background: #1e1e1e;
-    border-radius: 12px;
-    box-shadow: 0 0 30px rgba(255,255,255,0.1);
-    margin: 0;
+    overflow: hidden;
   }
 
-  .player-list-container {
+  .player-card-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    gap: 2vw;
+    align-items: flex-start;
+    color: #fff;
+  }
+
+  .player-image-container {
     position: relative;
-    width: 90%;
-    height: 500px;
+    width: 100%;
+    height: 400px;
+    grid-column: 1;
+    grid-row: 1;
   }
 
-  #player-list {
+  #player-card-image {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -1902,44 +1919,51 @@
     z-index: 3;
   }
 
-  .player-list-layout {
+  .player-details {
+    grid-column: 1;
+    grid-row: 2;
+    text-align: center;
+  }
+
+  .player-trait-bars {
+    grid-column: 2;
+    grid-row: 1 / span 2;
     display: flex;
-    gap: 2vw;
-    align-items: flex-start;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 1vw;
   }
 
-  .player-info {
-    flex: 1;
-    color: #fff;
-  }
-
-  .player-summary > div {
-    margin-bottom: 0.5vw;
-    font-size: clamp(12px, 3vw, 18px);
-  }
-
-  .player-traits {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 0.5vw;
-    margin-top: 1vw;
-  }
-
-  .trait {
+  .trait-bar-card {
     background: #1e1e1e;
     padding: 0.5vw;
     border-radius: 6px;
+  }
+
+  .trait-bar-header {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 0.5vw;
     font-size: clamp(10px, 2.5vw, 16px);
   }
 
-  .team-select {
-    margin-top: 2vw;
-    padding: 1vw;
-    font-size: clamp(14px, 3vw, 20px);
+  .progress {
+    background: #333;
+    height: 10px;
+    border-radius: 4px;
+    overflow: hidden;
   }
+
+  .progress-bar {
+    height: 100%;
+    width: 0;
+    transition: width 1s ease;
+  }
+
+  .progress-bar.red { background: #e74c3c; }
+  .progress-bar.orange { background: #e67e22; }
+  .progress-bar.yellow { background: #f1c40f; }
+  .progress-bar.light-green { background: #2ecc71; }
+  .progress-bar.dark-green { background: #27ae60; }
 
   #jersey-wrapper {
     position: absolute;


### PR DESCRIPTION
## Summary
- Add dedicated player list table with back navigation
- Show detailed player card with star ratings and animated trait progress bars
- Include color-coded progress bar styles and star icon rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b844cb23c483248271af524f013a6d