### PR TITLE
Ensure plays save before next snap

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -542,6 +542,22 @@ function pushGameState({ gameId, quarter, time, down, distance, ballOn, homeScor
   });
 }
 
+function savePlayAndGame(data) {
+  const lock = LockService.getDocumentLock();
+  lock.waitLock(30000);
+  try {
+    if (data.play) {
+      logPlayHistory(data.play);
+    }
+    if (data.game) {
+      pushGameState(data.game);
+    }
+    SpreadsheetApp.flush();
+  } finally {
+    lock.releaseLock();
+  }
+}
+
 function logPlayResult({ player, playType, yards, down, distance, ballOn, time }) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("PlayHistory");
   sheet.appendRow([time, down, distance, playType, player, yards]);

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -2909,7 +2909,7 @@
       };
       playHistory.push(localPlay);
 
-      google.script.run.logPlayHistory({
+      return {
         gameid: gameId,
         time: time,
         qtr: qtr,
@@ -2933,7 +2933,7 @@
         drivestart: state.DriveStart,
         homescore: state.HomeScore,
         awayscore: state.AwayScore
-      });
+      };
     }
 
   function updateRunningClock(result) {//MAKE PASS UPDATES
@@ -2943,7 +2943,7 @@
     }
   }
 
-  function updateGameState(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, recName, yards, tackler, result, predicted, timeTaken, recoveredBy) {
+  function updateGameState(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, recName, yards, tackler, result, predicted, timeTaken, recoveredBy, playData) {
     let playQuarter = state.Qtr;//COMPLETED PASS UPDATES
     let newTime = state.Time;
     if (typeof timeTaken === 'number') {
@@ -2953,8 +2953,9 @@
       newTime = state.Time - timeTaken;
     }
     const logTime = Math.max(newTime, 0);
-    if (result != null) {
-      logPlayToDB(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, recName, yards, tackler, result, predicted, playQuarter, logTime, recoveredBy);
+    let playLog = playData || null;
+    if (!playLog && result != null) {
+      playLog = logPlayToDB(down, distance, poss, ballOn, previousBallOn, driveStart, playerName, recName, yards, tackler, result, predicted, playQuarter, logTime, recoveredBy);
     }
 
     let nextDown = down;
@@ -3017,7 +3018,7 @@
     }
     renderPlayTimeline();
 
-    google.script.run.pushGameState({
+    const gameData = {
       gameId: gameId,
       quarter: state.Qtr,
       time: state.Time,
@@ -3029,7 +3030,14 @@
       driveStart: state.DriveStart,
       previous: state.Previous,
       possession: state.Possession
-    });
+    };
+
+    const buttons = Array.from(document.querySelectorAll('button'));
+    buttons.forEach(b => b.disabled = true);
+
+    google.script.run.withSuccessHandler(() => {
+      buttons.forEach(b => b.disabled = false);
+    }).savePlayAndGame({ play: playLog, game: gameData });
   }
 
   function nextDrive() {
@@ -3049,9 +3057,9 @@
       } else {
         state.AwayScore = (parseInt(state.AwayScore, 10) || 0) + 1;
       }
-      logFieldGoalPlay(team, true);
+      const playLog = logFieldGoalPlay(team, true);
       pendingFGTeam = null;
-      google.script.run.pushGameState({
+      const gameData = {
         gameId: gameId,
         quarter: state.Qtr,
         time: state.Time,
@@ -3063,7 +3071,12 @@
         driveStart: state.DriveStart,
         previous: state.Previous,
         possession: state.Possession
-      });
+      };
+      const buttons = Array.from(document.querySelectorAll('button'));
+      buttons.forEach(b => b.disabled = true);
+      google.script.run.withSuccessHandler(() => {
+        buttons.forEach(b => b.disabled = false);
+      }).savePlayAndGame({ play: playLog, game: gameData });
       document.getElementById('result').innerHTML = '<strong>Extra Point is Good!</strong>';
       updateStateUI();
       afterPlayComplete();
@@ -3082,11 +3095,11 @@
     } else {
       state.AwayScore = (parseInt(state.AwayScore, 10) || 0) + 3;
     }
-    logFieldGoalPlay(scoringTeam);
+    const playLog = logFieldGoalPlay(scoringTeam);
     const newPossession = scoringTeam === 'Home' ? 'Away' : 'Home';
     const newBallOn = newPossession === 'Home' ? 25 : 75;
     pendingFGTeam = null;
-    updateGameState(1, 10, newPossession, newBallOn, newBallOn, newBallOn, '', '', 0, null, null);
+    updateGameState(1, 10, newPossession, newBallOn, newBallOn, newBallOn, '', '', 0, null, null, '', undefined, undefined, playLog);
     updateStateUI();
     document.getElementById('result').innerHTML = '<strong>Field Goal is Good!</strong>';
     afterPlayComplete();
@@ -3103,9 +3116,9 @@
     const newPossession = kickingTeam === 'Home' ? 'Away' : 'Home';
     let newBallOn = kickingTeam === 'Home' ? state.BallOn + 40 : state.BallOn - 40;
     newBallOn = Math.max(1, Math.min(99, newBallOn));
-    logPuntPlay(kickingTeam, newBallOn);
+    const playLog = logPuntPlay(kickingTeam, newBallOn);
     updateRunningClock('Punt');
-    updateGameState(1, 10, newPossession, newBallOn, newBallOn, newBallOn, '', '', 0, null, null, '', 6);
+    updateGameState(1, 10, newPossession, newBallOn, newBallOn, newBallOn, '', '', 0, null, null, '', 6, undefined, playLog);
     updateStateUI();
     document.getElementById('result').innerHTML = '<strong>Punt.</strong>';
     afterPlayComplete();
@@ -3135,7 +3148,7 @@
     };
     playHistory.push(localPlay);
     renderPlayTimeline();
-    google.script.run.logPlayHistory({
+    return {
       gameid: gameId,
       time: state.Time,
       qtr: state.Qtr,
@@ -3159,7 +3172,7 @@
       drivestart: state.DriveStart,
       homescore: state.HomeScore,
       awayscore: state.AwayScore
-    });
+    };
   }
 
   function logPuntPlay(poss, newBallOn) {
@@ -3184,7 +3197,7 @@
     };
     playHistory.push(localPlay);
     renderPlayTimeline();
-    google.script.run.logPlayHistory({
+    return {
       gameid: gameId,
       time: state.Time,
       qtr: state.Qtr,
@@ -3208,7 +3221,7 @@
       drivestart: state.DriveStart,
       homescore: state.HomeScore,
       awayscore: state.AwayScore
-    });
+    };
   }
 
   function updateKickButton() {


### PR DESCRIPTION
## Summary
- Bundle play logging and game state update into a single Apps Script call with locking
- Disable UI buttons until save completes to prevent overlapping plays
- Capture field goal and punt logs and send with game updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7a1dfb2608324b70abd02820db638