### PR TITLE
Add main menu and remove in-page player list button

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,5 +1,7 @@
-function doGet() {
-  return HtmlService.createTemplateFromFile('PlayUI')
+function doGet(e) {
+  const view = e && e.parameter && e.parameter.view;
+  const page = (view === 'players' || view === 'games') ? 'PlayUI' : 'MainMenu';
+  return HtmlService.createTemplateFromFile(page)
     .evaluate()
     .setTitle('Football Game UI')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL); // optional

--- a/MainMenu.html
+++ b/MainMenu.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <?!= include('MenuStyle'); ?>
+  </head>
+  <body>
+    <div class="menu-container">
+      <button class="menu-button" onclick="window.location.href='?view=players'">View Players</button>
+      <button class="menu-button" onclick="window.location.href='?view=games'">Existing League</button>
+      <button class="menu-button" onclick="alert('New League coming soon!')">New League</button>
+    </div>
+  </body>
+</html>

--- a/MenuStyle.html
+++ b/MenuStyle.html
@@ -1,0 +1,43 @@
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+  :root {
+    --accent-red: #C10206;
+    --accent-red-dark: #A50113;
+    --gray-dark: #121212;
+    --gray-medium: #1e1e1e;
+    --text-light: #F5F5F5;
+  }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-family: 'Roboto', Arial, sans-serif;
+    background: linear-gradient(135deg, var(--gray-dark) 0%, var(--gray-medium) 100%);
+    color: var(--text-light);
+  }
+  .menu-container {
+    width: 100%;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+  }
+  .menu-button {
+    width: 100%;
+    margin: 10px 0;
+    padding: 15px;
+    font-size: clamp(18px, 5vw, 24px);
+    background: var(--accent-red);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .menu-button:active {
+    background: var(--accent-red-dark);
+  }
+</style>

--- a/PlayUI.html
+++ b/PlayUI.html
@@ -26,7 +26,6 @@
         class="loading-football"
       />
     </div>
-    <button id="playerListButton" class="player-list-btn">Player List</button>
     <div id="playerListView" style="display:none;">
       <button id="playerListBack" class="back-button">← Back</button>
       <table id="playerTable" class="player-table">

--- a/PlayUIScript.html
+++ b/PlayUIScript.html
@@ -141,6 +141,10 @@
       updateStickyOffsets();
       window.addEventListener('resize', updateStickyOffsets);
       loadGamesList();
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('view') === 'players') {
+        showPlayerList();
+      }
       const backBtn = document.getElementById('backButton');
       if (backBtn) {
         backBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Hide legacy player list button from existing UI
- Route web app to a new mobile-friendly main menu
- Allow direct links to player list via query parameter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b854a24ea08324b9f074bea9a0b233