### PR TITLE
Implement full URL navigation

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,10 +1,11 @@
 function doGet(e) {
-  const view = e && e.parameter && e.parameter.view;
-  const page = (view === 'players' || view === 'games') ? 'PlayUI' : 'MainMenu';
-  return HtmlService.createTemplateFromFile(page)
+  const view = (e && e.parameter && e.parameter.view) || 'menu';
+  const template = HtmlService.createTemplateFromFile('MainMenu');
+  template.view = view;
+  return template
     .evaluate()
     .setTitle('Football Game UI')
-    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL); // optional
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 function onOpen() {
   SpreadsheetApp.getUi()

--- a/Games.html
+++ b/Games.html
@@ -1,0 +1,1 @@
+<div>Games section placeholder</div>

--- a/MainMenu.html
+++ b/MainMenu.html
@@ -7,10 +7,22 @@
     <?!= include('MenuStyle'); ?>
   </head>
   <body>
-    <div class="menu-container">
-      <button class="menu-button" onclick="window.location.href='?view=players'">View Players</button>
-      <button class="menu-button" onclick="window.location.href='?view=games'">Existing League</button>
-      <button class="menu-button" onclick="alert('New League coming soon!')">New League</button>
-    </div>
+    <script>
+      function go(view) {
+        const baseUrl = '<?= ScriptApp.getService().getUrl() ?>';
+        window.location.href = baseUrl + '?view=' + view;
+      }
+    </script>
+    <? if (view === 'players') { ?>
+      <?!= include('Players'); ?>
+    <? } else if (view === 'games') { ?>
+      <?!= include('Games'); ?>
+    <? } else { ?>
+      <div class="menu-container">
+        <button class="menu-button" onclick="go('players')">View Players</button>
+        <button class="menu-button" onclick="go('games')">Existing League</button>
+        <button class="menu-button" onclick="alert('New League coming soon!')">New League</button>
+      </div>
+    <? } ?>
   </body>
 </html>

--- a/Players.html
+++ b/Players.html
@@ -1,0 +1,1 @@
+<div>Players section placeholder</div>


### PR DESCRIPTION
## Summary
- Handle `view` parameter in `doGet` and pass to HTML template so server can swap partials.
- Add client-side navigation helper to build full URLs and render correct sections.
- Include placeholder partials for player and game sections.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/football-game/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68b857dc0c2c8324902413b135885fb9