### PR TITLE
Add league landing page with navigation and rename PlayUI

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -20,10 +20,10 @@
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }**/
 
-//doGet For Testing PlayUI.html
+//doGet For Testing LeagueApp.html
 function doGet(e) {
   const view = (e && e.parameter && e.parameter.view) || 'menu';
-  const template = HtmlService.createTemplateFromFile('PlayUI');
+  const template = HtmlService.createTemplateFromFile('LeagueApp');
   template.view = view;
   return template
     .evaluate()
@@ -33,7 +33,7 @@ function doGet(e) {
 
 function onOpen() {
   SpreadsheetApp.getUi()
-    .addItem("Open Play UI", "showPlayUI")
+    .addItem("Open League App", "showLeagueApp")
     .addToUi();
 }
 
@@ -42,8 +42,8 @@ function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();
 }
 
-function showPlayUI() {
-  const html = HtmlService.createHtmlOutputFromFile("PlayUI")
+function showLeagueApp() {
+  const html = HtmlService.createHtmlOutputFromFile("LeagueApp")
     .setWidth(400)
     .setHeight(400);
 }

--- a/LeagueApp.html
+++ b/LeagueApp.html
@@ -7,9 +7,9 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
     />
-    <?!= include('PlayUIstyle'); ?>
+    <?!= include('LeagueAppStyle'); ?>
   </head>
-  <body>
+    <body>
     <audio id="crowdRoar" src="https://andrew-jacobson06.github.io/public-audio/crowd-cheering-379666.mp3" preload="auto"></audio>
     <div id="appLoading" class="app-loading">
       <div class="app-spinner"><span class="app-football">🏈</span></div>
@@ -26,7 +26,33 @@
         class="loading-football"
       />
     </div>
-    <div id="gameList" class="game-list"></div>
+    <div id="leagueHeader" class="league-header">
+      <div class="league-name">AFL League</div>
+      <nav class="nav-tabs">
+        <button class="nav-tab" data-tab="news">NEWS</button>
+        <button class="nav-tab active" data-tab="scores">SCORES</button>
+        <button class="nav-tab" data-tab="standings">STANDINGS</button>
+        <button class="nav-tab" data-tab="stats">STATS</button>
+        <button class="nav-tab" data-tab="draft">DRAFT</button>
+      </nav>
+    </div>
+    <div id="tabContents">
+      <div id="news" class="league-tab-content">
+        <div class="coming-soon">News coming soon...</div>
+      </div>
+      <div id="scores" class="league-tab-content active">
+        <div id="gameList" class="game-list"></div>
+      </div>
+      <div id="standings" class="league-tab-content">
+        <div class="coming-soon">Standings coming soon...</div>
+      </div>
+      <div id="stats" class="league-tab-content">
+        <div class="coming-soon">Stats coming soon...</div>
+      </div>
+      <div id="draft" class="league-tab-content">
+        <div class="coming-soon">Draft coming soon...</div>
+      </div>
+    </div>
     <div id="gameUI" style="display:none;">
       <button id="backButton" class="back-button">← Back</button>
       <div id="scoreboard" class="scoreboard">
@@ -517,6 +543,6 @@
       </div>
     </div>
 
-    <?!= include('PlayUIScript'); ?>
+    <?!= include('LeagueAppScript'); ?>
   </body>
 </html>

--- a/LeagueAppScript.html
+++ b/LeagueAppScript.html
@@ -105,6 +105,19 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.nav-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.league-tab-content').forEach(c => c.classList.remove('active'));
+        tab.classList.add('active');
+        const targetId = tab.getAttribute('data-tab');
+        const target = document.getElementById(targetId);
+        if (target) target.classList.add('active');
+        if (targetId === 'scores') {
+          loadGamesList();
+        }
+      });
+    });
     document.querySelectorAll('.tab-button').forEach(btn => {
       btn.addEventListener('click', () => {
         document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
@@ -145,6 +158,10 @@
         backBtn.addEventListener('click', () => {
           document.getElementById('gameUI').style.display = 'none';
           document.getElementById('gameList').style.display = 'block';
+          const header = document.getElementById('leagueHeader');
+          const tabs = document.getElementById('tabContents');
+          if (header) header.style.display = '';
+          if (tabs) tabs.style.display = '';
           backBtn.style.display = 'none';
           loadGamesList();
         });
@@ -286,6 +303,10 @@
       card.addEventListener('click', () => {
         gameId = id;
         document.getElementById('gameList').style.display = 'none';
+        const header = document.getElementById('leagueHeader');
+        const tabs = document.getElementById('tabContents');
+        if (header) header.style.display = 'none';
+        if (tabs) tabs.style.display = 'none';
         showLoadingScreen(g.HomeLogo, g.AwayLogo);
         refreshUI(id).then(() => {
           hideLoadingScreen();

--- a/LeagueAppStyle.html
+++ b/LeagueAppStyle.html
@@ -24,6 +24,59 @@
     color: var(--text-light);
   }
 
+  /* League header and navigation */
+  .league-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    background: var(--gray-medium);
+    border-bottom: 1px solid var(--gray-light);
+    padding: 1vw 2vw;
+  }
+
+  .league-name {
+    font-weight: 700;
+    margin-right: 2vw;
+  }
+
+  .nav-tabs {
+    display: flex;
+    gap: 1vw;
+  }
+
+  .nav-tab {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    padding: 1vw 2vw;
+    cursor: pointer;
+    font-size: clamp(14px, 3vw, 24px);
+    border-bottom: 0.6vw solid transparent;
+  }
+
+  .nav-tab.active {
+    color: var(--text-light);
+    border-bottom-color: var(--text-light);
+    font-weight: 700;
+  }
+
+  .league-tab-content {
+    display: none;
+  }
+
+  .league-tab-content.active {
+    display: block;
+  }
+
+  .coming-soon {
+    text-align: center;
+    padding: 5vw 0;
+    color: var(--text-muted);
+    font-size: clamp(16px, 4vw, 24px);
+  }
+
   /* Game list */
   .game-list {
     padding: 2.5vw;


### PR DESCRIPTION
## Summary
- Rename PlayUI files to LeagueApp and update references
- Add sticky league header with NEWS, SCORES, STANDINGS, STATS, and DRAFT tabs
- Show game list under Scores tab and hide header when entering a game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9f3f538f88324b60321e61179e4dc