### PR TITLE
Add initial stats tab with team leaders table

### DIFF
--- a/LeagueApp.html
+++ b/LeagueApp.html
@@ -47,7 +47,70 @@
         <div class="coming-soon">Standings coming soon...</div>
       </div>
       <div id="stats" class="league-tab-content">
-        <div class="coming-soon">Stats coming soon...</div>
+        <div class="stats-tabs">
+          <button class="stats-tab" data-tab="stats-player">Player</button>
+          <button class="stats-tab active" data-tab="stats-team">Team</button>
+        </div>
+        <div class="season-row">
+          <button class="season-pill">Season 1 ▾</button>
+        </div>
+        <div id="stats-player" class="stats-content">
+          <div class="coming-soon">Player stats coming soon...</div>
+        </div>
+        <div id="stats-team" class="stats-content active">
+          <div class="stats-section">
+            <div class="stats-section-title">Offensive Leaders</div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>TOTAL YARDS</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>PASSING</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>RUSHING</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsTeam.html" class="team-link">Team Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+          </div>
+        </div>
       </div>
       <div id="draft" class="league-tab-content">
         <div class="coming-soon">Draft coming soon...</div>

--- a/LeagueAppScript.html
+++ b/LeagueAppScript.html
@@ -128,6 +128,16 @@
         if (target) target.classList.add('active');
       });
     });
+    document.querySelectorAll('.stats-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.stats-tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.stats-content').forEach(c => c.classList.remove('active'));
+        tab.classList.add('active');
+        const targetId = tab.getAttribute('data-tab');
+        const target = document.getElementById(targetId);
+        if (target) target.classList.add('active');
+      });
+    });
     document.querySelectorAll('.boxscore-pill').forEach(btn => {
       btn.addEventListener('click', () => {
         document.querySelectorAll('.boxscore-pill').forEach(b => b.classList.remove('active'));

--- a/LeagueAppStyle.html
+++ b/LeagueAppStyle.html
@@ -1915,4 +1915,107 @@
   .disabled-play-control {
     opacity: 0.5;
   }
+
+  /* Stats Tab */
+  .stats-tabs {
+    display: flex;
+    gap: 2vw;
+    padding: 2vw;
+  }
+
+  .stats-tab {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    padding: 1vw 2vw;
+    cursor: pointer;
+    font-size: clamp(14px, 3vw, 24px);
+    border-bottom: 0.6vw solid transparent;
+  }
+
+  .stats-tab.active {
+    color: var(--text-light);
+    border-bottom-color: var(--text-light);
+    font-weight: 700;
+  }
+
+  .season-row {
+    padding: 0 2vw 2vw 2vw;
+  }
+
+  .season-pill {
+    background: var(--gray-medium);
+    border: 1px solid var(--gray-light);
+    border-radius: 20px;
+    padding: 1vw 3vw;
+    color: var(--text-light);
+    cursor: pointer;
+  }
+
+  .stats-content {
+    display: none;
+  }
+
+  .stats-content.active {
+    display: block;
+  }
+
+  .stats-section {
+    padding: 2vw;
+  }
+
+  .stats-section-title {
+    font-weight: 700;
+    font-size: clamp(18px, 4vw, 28px);
+    margin-bottom: 2vw;
+    color: var(--text-light);
+  }
+
+  .leader-group {
+    margin-bottom: 4vw;
+  }
+
+  .leader-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .leader-table th {
+    text-align: left;
+    font-weight: 700;
+    color: var(--text-light);
+    padding-bottom: 1vw;
+  }
+
+  .leader-table td {
+    color: var(--text-muted);
+    padding: 0.5vw 0;
+  }
+
+  .team-cell {
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+  }
+
+  .team-cell .rank {
+    width: 2vw;
+  }
+
+  .team-cell .team-logo {
+    width: 5vw;
+    height: 5vw;
+    object-fit: contain;
+  }
+
+  .complete-link {
+    text-align: right;
+    margin-top: 1vw;
+  }
+
+  .complete-link a,
+  .team-cell .team-link {
+    color: var(--text-light);
+    text-decoration: underline;
+  }
 </style>

--- a/StatsComplete.html
+++ b/StatsComplete.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <?!= include('LeagueAppStyle'); ?>
+  </head>
+  <body>
+    <button class="back-button" onclick="window.location.href='LeagueApp.html'">← Back</button>
+    <div class="coming-soon">Complete stats coming soon...</div>
+  </body>
+</html>

--- a/StatsTeam.html
+++ b/StatsTeam.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <?!= include('LeagueAppStyle'); ?>
+  </head>
+  <body>
+    <button class="back-button" onclick="window.location.href='LeagueApp.html'">← Back</button>
+    <div class="coming-soon">Team page coming soon...</div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Implement basic Stats tab with Player and Team subtabs
- Display placeholder offensive leader tables and season dropdown
- Add stub pages for team view and complete leaders with back navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68baf8c056fc8324a397bee4a579fc0b