### PR TITLE
Add player stats sub tab

### DIFF
--- a/LeagueApp.html
+++ b/LeagueApp.html
@@ -55,7 +55,109 @@
           <button class="season-pill">Season 1 ▾</button>
         </div>
         <div id="stats-player" class="stats-content">
-          <div class="coming-soon">Player stats coming soon...</div>
+          <div class="stats-section">
+            <div class="stats-section-title">Offensive Leaders</div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>PASSING</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>RUSHING</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>RECEIVING</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">308.5</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">298.7</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">296.4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">294.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">291.7</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+          </div>
+
+          <div class="stats-section">
+            <div class="stats-section-title">Defensive Leaders</div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>TACKLES</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">67</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">65</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">50</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">49</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">44</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>SACKS</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">13.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">9.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">8.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">8.0</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">8.0</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+
+            <div class="leader-group">
+              <table class="leader-table">
+                <thead>
+                  <tr><th>INTERCEPTIONS</th><th>YDS/G</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td class="team-cell"><span class="rank">1</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">4</td></tr>
+                  <tr><td class="team-cell"><span class="rank">2</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">3</td></tr>
+                  <tr><td class="team-cell"><span class="rank">3</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">3</td></tr>
+                  <tr><td class="team-cell"><span class="rank">4</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">2</td></tr>
+                  <tr><td class="team-cell"><span class="rank">5</span><img class="team-logo" src="https://via.placeholder.com/24" alt="" /><a href="StatsPlayer.html" class="team-link">Player Name</a></td><td class="stat-value">1</td></tr>
+                </tbody>
+              </table>
+              <div class="complete-link"><a href="StatsComplete.html">Complete Leaders</a></div>
+            </div>
+          </div>
         </div>
         <div id="stats-team" class="stats-content active">
           <div class="stats-section">

--- a/StatsPlayer.html
+++ b/StatsPlayer.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <?!= include('LeagueAppStyle'); ?>
+  </head>
+  <body>
+    <button class="back-button" onclick="window.location.href='LeagueApp.html'">← Back</button>
+    <div class="coming-soon">Player stats coming soon...</div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated Player stats leaders to the Stats tab with offensive and defensive categories
- Stub player stats page for individual player links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bafbfa05948324bad032aed3b7cbbb