### PR TITLE
Prevent repeated game list reload on scores tab

### DIFF
--- a/LeagueAppScript.html
+++ b/LeagueAppScript.html
@@ -37,6 +37,7 @@
   let timeNeededToOpen = [];
   let completionSeparationAdjustment = [];
   let yacBySeparation = {};
+  let gamesListLoaded = false;
 
   function showLoadingScreen(homeLogo, awayLogo) {
     const screen = document.getElementById('loadingScreen');
@@ -113,7 +114,7 @@
         const targetId = tab.getAttribute('data-tab');
         const target = document.getElementById(targetId);
         if (target) target.classList.add('active');
-        if (targetId === 'scores') {
+        if (targetId === 'scores' && !gamesListLoaded) {
           loadGamesList();
         }
       });
@@ -251,6 +252,7 @@
       .withSuccessHandler(games => {
         renderGameCards(games);
         hideAppLoading();
+        gamesListLoaded = true;
       })
       .withFailureHandler(err => {
         console.error(err);


### PR DESCRIPTION
## Summary
- Cache the game list after first load and skip reloads when revisiting the Scores tab
- Flag completion of initial load to keep spinner from reappearing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bb165065ac832483832027c0c05281