### PR TITLE
Add clock management modal

### DIFF
--- a/LeagueApp.html
+++ b/LeagueApp.html
@@ -640,6 +640,18 @@
       </div>
     </div>
 
+    <button id="clockButton" class="clock-button" onclick="openClockModal()">Clock Management</button>
+
+    <div id="clockModal" class="modal">
+      <div class="formation-panel clock-panel">
+        <span class="close-button" onclick="closeClockModal()">&times;</span>
+        <button class="clock-option" onclick="hurryUp()">Hurry Up</button>
+        <button class="clock-option" onclick="chewClock()">Chew Clock</button>
+        <button class="clock-option" onclick="spikeBall()">Spike Ball</button>
+        <button class="clock-option" onclick="kneel()">Kneel</button>
+      </div>
+    </div>
+
     <div id="formationModal" class="modal">
       <div id="formationPanel" class="formation-panel">
         <span id="closeFormation" class="close-button">&times;</span>

--- a/LeagueAppScript.html
+++ b/LeagueAppScript.html
@@ -4501,6 +4501,36 @@
     }
   }
 
+  function openClockModal() {
+    const modal = document.getElementById('clockModal');
+    if (modal) modal.classList.add('open');
+  }
+
+  function closeClockModal() {
+    const modal = document.getElementById('clockModal');
+    if (modal) modal.classList.remove('open');
+  }
+
+  function hurryUp() {
+    console.log('Hurry Up selected');
+    closeClockModal();
+  }
+
+  function chewClock() {
+    console.log('Chew Clock selected');
+    closeClockModal();
+  }
+
+  function spikeBall() {
+    console.log('Spike Ball selected');
+    closeClockModal();
+  }
+
+  function kneel() {
+    console.log('Kneel selected');
+    closeClockModal();
+  }
+
   // On load
   refreshUI().catch(console.error);
 </script>

--- a/LeagueAppStyle.html
+++ b/LeagueAppStyle.html
@@ -1184,6 +1184,39 @@
     z-index: 10;
   }
 
+  .clock-button {
+    position: fixed;
+    bottom: 4vw;
+    right: 4vw;
+    padding: 3vw 4vw;
+    background: var(--accent-red);
+    color: var(--text-light);
+    border: none;
+    border-radius: 8px;
+    font-size: 3.5vw;
+    z-index: 1100;
+    cursor: pointer;
+  }
+
+  .clock-panel {
+    width: 90vw;
+    max-width: 90vw;
+    display: flex;
+    flex-direction: column;
+    gap: 4vw;
+  }
+
+  .clock-option {
+    width: 100%;
+    padding: 4vw;
+    font-size: 5vw;
+    background: var(--gray-medium);
+    color: var(--text-light);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+
   .formation-field {
     margin-bottom: 4vw;
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- Add always-visible Clock Management button
- Introduce modal with Hurry Up, Chew Clock, Spike Ball, and Kneel options
- Stub out handlers for future clock control logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bb60fec9748324b44c0e1f4cb397ba