### PR TITLE
Add toggle controls for clock management

### DIFF
--- a/LeagueApp.html
+++ b/LeagueApp.html
@@ -644,8 +644,8 @@
     <div id="clockModal" class="modal">
       <div class="formation-panel clock-panel">
         <span class="close-button" onclick="closeClockModal()">&times;</span>
-        <button class="clock-option" onclick="hurryUp()">Hurry Up</button>
-        <button class="clock-option" onclick="chewClock()">Chew Clock</button>
+        <button id="hurryUpToggle" class="clock-option" onclick="toggleHurryUp()">Hurry Up: Off</button>
+        <button id="chewClockToggle" class="clock-option" onclick="toggleChewClock()">Chew Clock: Off</button>
         <button class="clock-option" onclick="spikeBall()">Spike Ball</button>
         <button class="clock-option" onclick="kneel()">Kneel</button>
       </div>

--- a/LeagueAppScript.html
+++ b/LeagueAppScript.html
@@ -4518,6 +4518,7 @@
   function openClockModal() {
     const modal = document.getElementById('clockModal');
     if (modal) modal.classList.add('open');
+    updateClockToggles();
   }
 
   function closeClockModal() {
@@ -4525,18 +4526,33 @@
     if (modal) modal.classList.remove('open');
   }
 
-  function hurryUp() {
-    console.log('Hurry Up selected');
-    chewClock = false;
-    hurryUp = true;
-    closeClockModal();
+  function updateClockToggles() {
+    const hurryBtn = document.getElementById('hurryUpToggle');
+    const chewBtn = document.getElementById('chewClockToggle');
+    if (hurryBtn) {
+      hurryBtn.classList.toggle('active', hurryUp);
+      hurryBtn.textContent = `Hurry Up: ${hurryUp ? 'On' : 'Off'}`;
+    }
+    if (chewBtn) {
+      chewBtn.classList.toggle('active', chewClock);
+      chewBtn.textContent = `Chew Clock: ${chewClock ? 'On' : 'Off'}`;
+    }
   }
 
-  function chewClock() {
-    console.log('Chew Clock selected');
-    chewClock = true;
-    hurryUp = false;
-    closeClockModal();
+  function toggleHurryUp() {
+    hurryUp = !hurryUp;
+    if (hurryUp) {
+      chewClock = false;
+    }
+    updateClockToggles();
+  }
+
+  function toggleChewClock() {
+    chewClock = !chewClock;
+    if (chewClock) {
+      hurryUp = false;
+    }
+    updateClockToggles();
   }
 
   async function spikeBall() {

--- a/LeagueAppStyle.html
+++ b/LeagueAppStyle.html
@@ -1219,6 +1219,10 @@
     cursor: pointer;
   }
 
+  .clock-option.active {
+    background: var(--accent-red);
+  }
+
   .formation-field {
     margin-bottom: 4vw;
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- Convert Hurry Up and Chew Clock buttons into mutually-exclusive toggles
- Indicate active clock option via button text and styling
- Highlight selected clock option with new CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bb7522f82c83249a1af4e6dff6625d