### PR TITLE
Fix player and jersey image mapping (include column AM and preserve AI image)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -147,7 +147,7 @@ function getPlayerTraits() {
     throw new Error("Sheet 'Players' not found.");
   }
 
-  // Pull columns A through AL (0 - 38) to include BallSecurity, DefPos, Image, and transform values
+  // Pull columns A through AM (0 - 38) to include BallSecurity, DefPos, the Player Image from AI, transform values, and jersey image.
   const numCols = 39;
   const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, numCols).getValues();
   Logger.log(data);

--- a/PlayersScript.html
+++ b/PlayersScript.html
@@ -1,4 +1,5 @@
 <script>
+  const FALLBACK_PLAYER_IMAGE = "https://andrew-jacobson06.github.io/public-audio/baby.png";
   let playerListData = [];
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -35,7 +36,7 @@
     const playerImg = document.getElementById('player-card-image');
     const jerseyImg = document.getElementById('jersey');
     if (playerImg) {
-      playerImg.src = p.image || playerImg.src;
+      playerImg.src = p.image || FALLBACK_PLAYER_IMAGE;
       playerImg.style.transform = `translate(${p.translateX || 0}px, ${p.translateY || 0}px) scale(${p.scale || 1})`;
     }
     if (jerseyImg) jerseyImg.src = p.jersey || '';

--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -13,7 +13,7 @@ gameRoutes.get("/health", (_req, res) => {
 
 gameRoutes.get("/players", async (_req, res, next) => {
   try {
-    const players = await readSheetObjects("Players!A1:AL");
+    const players = await readSheetObjects("Players!A1:AM");
     res.json({ players });
   } catch (error) {
     next(error);

--- a/apps/web/src/components/players/PlayerCard.tsx
+++ b/apps/web/src/components/players/PlayerCard.tsx
@@ -55,12 +55,27 @@ function numberValue(value: string | number | undefined, fallback = 0) {
   return Number.isFinite(result) ? result : fallback;
 }
 
+function firstNonEmpty(...values: Array<string | undefined>) {
+  return values.find((value) => value && value.trim() !== "") ?? "";
+}
+
+function getPlayerImage(player: Player) {
+  return firstNonEmpty(player["Player Image from AI"], player.Image) || FALLBACK_PLAYER_IMAGE;
+}
+
+function getJerseyImage(player: Player) {
+  return firstNonEmpty(player.jersey, player.Jersey, player["Jersey Image"]);
+}
+
 type PlayerCardProps = {
   player: Player;
   onBack: () => void;
 };
 
 export function PlayerCard({ player, onBack }: PlayerCardProps) {
+  const playerImage = getPlayerImage(player);
+  const jerseyImage = getJerseyImage(player);
+
   return (
     <div id="playerCardView">
       <button id="playerCardBack" className="back-button" type="button" onClick={onBack}>← Back</button>
@@ -68,14 +83,14 @@ export function PlayerCard({ player, onBack }: PlayerCardProps) {
         <div id="playerImageContainer" className="player-image-container">
           <img
             id="player-card-image"
-            src={player.Image || FALLBACK_PLAYER_IMAGE}
+            src={playerImage}
             alt="Player"
             style={{
               transform: `translate(${numberValue(player.translateX)}px, ${numberValue(player.translateY)}px) scale(${numberValue(player.scale, 1)})`
             }}
           />
           <div id="jersey-wrapper">
-            {player.jersey && <img id="jersey" src={player.jersey} alt="Jersey Overlay" />}
+            {jerseyImage && <img id="jersey" src={jerseyImage} alt="Jersey Overlay" />}
           </div>
         </div>
         <div id="playerDetails" className="player-details">

--- a/apps/web/src/components/players/types.ts
+++ b/apps/web/src/components/players/types.ts
@@ -34,8 +34,11 @@ export type Player = {
   Coverage?: string | number;
   DefPos?: string;
   Image?: string;
+  "Player Image from AI"?: string;
   translateX?: string | number;
   translateY?: string | number;
   scale?: string | number;
   jersey?: string;
+  Jersey?: string;
+  "Jersey Image"?: string;
 };


### PR DESCRIPTION
### Motivation
- Ensure the Players data includes the jersey image in column AM and that the client receives it.  
- Preserve usage of the `Player Image from AI` column when present while still supporting the legacy `Image` field.  
- Prevent the Baby George fallback image from appearing for every player by fixing fallback selection logic.

### Description
- Updated the backend players range from `Players!A1:AL` to `Players!A1:AM` so column AM is returned to clients.  
- Adjusted Apps Script `getPlayerTraits` comment to reflect inclusion of AM and confirmed `jersey` is read from the extended range.  
- Modified the Apps Script player UI (`PlayersScript.html`) to declare `FALLBACK_PLAYER_IMAGE` and only use it when a player has no image.  
- Extended the React `Player` type with `"Player Image from AI"`, `Jersey`, and `"Jersey Image"`, and updated `PlayerCard.tsx` to prefer `Player Image from AI` then `Image`, and to resolve jersey from multiple possible fields before rendering the overlay.

### Testing
- Ran `npm install` in `apps/web`, which completed successfully.  
- Ran `npm run build` in `apps/web`, which completed successfully and produced the production `dist` build.  
- No additional automated tests were present for the API change, but the UI build validated the type and component changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a403367cb2083249fab5f82c89f5249)