### PR TITLE
Migrate Apps Script main menu to React

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -237,3 +237,109 @@ body {
 .players-message--error {
   color: #fecaca;
 }
+
+.migration-nav {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.migration-nav__button--active {
+  background: var(--accent-red-dark);
+  box-shadow: 0 0 12px rgba(255, 59, 59, 0.45);
+}
+
+.debug-status-screen {
+  min-height: 100vh;
+  padding: 8rem 2rem 2rem;
+  box-sizing: border-box;
+}
+
+.debug-status-screen__back {
+  position: static;
+  margin-top: 1rem;
+}
+
+.main-menu-screen {
+  position: relative;
+  min-height: 100vh;
+  background: url("https://andrew-jacobson06.github.io/public-audio/stadium-menu.png") center/cover no-repeat;
+  font-family: "Segoe UI", system-ui, -apple-system, Roboto, Arial, sans-serif;
+  color: #fff;
+  overflow: hidden;
+}
+
+.main-menu-screen .brand {
+  position: absolute;
+  top: 2.2vw;
+  left: 2.2vw;
+  z-index: 3;
+  text-transform: uppercase;
+  letter-spacing: 0.32rem;
+  font-weight: 900;
+  font-size: clamp(28px, 8vw, 100px);
+  line-height: 1;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5), 0 0 18px rgba(255, 59, 59, 0.6), 0 0 42px rgba(255, 59, 59, 0.25);
+}
+
+.main-menu-screen .corner { position: absolute; width: 3.6vw; height: 3.6vw; border: 2px solid rgba(255, 255, 255, 0.18); z-index: 2; pointer-events: none; }
+.main-menu-screen .corner.tl { top: 1.6vw; left: 1.6vw; border-right: none; border-bottom: none; }
+.main-menu-screen .corner.tr { top: 1.6vw; right: 1.6vw; border-left: none; border-bottom: none; }
+.main-menu-screen .corner.bl { bottom: 1.6vw; left: 1.6vw; border-right: none; border-top: none; }
+.main-menu-screen .corner.br { bottom: 1.6vw; right: 1.6vw; border-left: none; border-top: none; }
+
+.main-menu-screen .menu-wrap { position: absolute; left: 4vw; bottom: 6vh; z-index: 4; display: grid; gap: 1rem; width: 50%; }
+.main-menu-screen .panel { position: relative; padding: 2.6rem 1.2rem 1.2rem; border-radius: 14px; background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.12); outline: 1px solid rgba(255, 59, 59, 0.22); box-shadow: 0 0 0 1px rgba(255, 59, 59, 0.12) inset, 0 12px 30px rgba(0, 0, 0, 0.35), 0 0 28px rgba(255, 59, 59, 0.12); backdrop-filter: blur(3px); display: grid; gap: 0.8rem; max-width: min(92vw, 520px); overflow: hidden; }
+.main-menu-screen .panel::before { content: ""; position: absolute; inset: 0; background: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.03) 0 2px, transparent 2px 12px), repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.02) 0 2px, transparent 2px 16px); transform: translateY(0); animation: scanY 12s linear infinite; pointer-events: none; }
+@keyframes scanY { 0% { transform: translateY(0); } 100% { transform: translateY(-60px); } }
+
+.main-menu-screen .ticker { position: absolute; left: 0; right: 0; top: 0; height: 2.2rem; display: flex; align-items: center; background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)); border-bottom: 1px solid rgba(255, 255, 255, 0.12); box-shadow: inset 0 -1px 0 rgba(255, 59, 59, 0.22); overflow: hidden; }
+.main-menu-screen .ticker::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: linear-gradient(180deg, transparent, var(--accent-red-dark), transparent); filter: drop-shadow(0 0 8px var(--accent-red-dark)); }
+.main-menu-screen .track { white-space: nowrap; display: inline-block; padding-left: 100%; animation: marquee 16s linear infinite; font-size: 0.95rem; letter-spacing: 0.14rem; text-transform: uppercase; opacity: 0.92; }
+.main-menu-screen .sep { margin: 0 0.9rem; opacity: 0.6; }
+@keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-100%); } }
+
+.main-menu-screen .rail { position: absolute; pointer-events: none; }
+.main-menu-screen .rail.top, .main-menu-screen .rail.bottom { left: 10px; right: 10px; height: 2px; }
+.main-menu-screen .rail.left, .main-menu-screen .rail.right { top: 10px; bottom: 10px; width: 2px; }
+.main-menu-screen .runnerX, .main-menu-screen .runnerY { position: absolute; background: linear-gradient(90deg, transparent, var(--accent-red-dark), transparent); filter: drop-shadow(0 0 8px var(--accent-red-dark)); }
+.main-menu-screen .rail.top .runnerX { top: 0; left: -30%; height: 2px; width: 30%; animation: runX 3s linear infinite; }
+.main-menu-screen .rail.bottom .runnerX { bottom: 0; left: 100%; height: 2px; width: 30%; animation: runXRev 3s linear infinite; opacity: 0.7; }
+.main-menu-screen .rail.left .runnerY { left: 0; top: -30%; width: 2px; height: 30%; animation: runY 2.4s linear infinite; opacity: 0.75; }
+.main-menu-screen .rail.right .runnerY { right: 0; top: 100%; width: 2px; height: 30%; animation: runYRev 2.4s linear infinite; opacity: 0.6; }
+@keyframes runX { 0% { transform: translateX(0); } 100% { transform: translateX(450%); } }
+@keyframes runXRev { 0% { transform: translateX(0); } 100% { transform: translateX(-450%); } }
+@keyframes runY { 0% { transform: translateY(0); } 100% { transform: translateY(450%); } }
+@keyframes runYRev { 0% { transform: translateY(0); } 100% { transform: translateY(-450%); } }
+
+.main-menu-screen .node { position: absolute; width: 8px; height: 8px; border-radius: 50%; background: var(--accent-red-dark); box-shadow: 0 0 12px var(--accent-red-dark), 0 0 28px rgba(255, 59, 59, 0.35); animation: pulse 2.2s ease-in-out infinite; pointer-events: none; }
+.main-menu-screen .node.n1 { top: 10px; left: 10px; }
+.main-menu-screen .node.n2 { top: 10px; right: 10px; animation-delay: 0.25s; }
+.main-menu-screen .node.n3 { bottom: 10px; left: 10px; animation-delay: 0.5s; }
+.main-menu-screen .node.n4 { bottom: 10px; right: 10px; animation-delay: 0.75s; }
+@keyframes pulse { 0%, 100% { transform: scale(1); opacity: 0.85; } 50% { transform: scale(1.25); opacity: 0.55; } }
+
+.main-menu-screen .tick { position: absolute; width: 34px; height: 2px; background: linear-gradient(90deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); filter: drop-shadow(0 0 6px var(--accent-red-dark)); opacity: 0.9; animation-duration: 2.8s; animation-iteration-count: infinite; animation-timing-function: linear; }
+.main-menu-screen .tick.t1 { top: 10px; left: 10px; animation-name: tMoveX; }
+.main-menu-screen .tick.t2 { bottom: 10px; right: 10px; animation-name: tMoveXRev; }
+.main-menu-screen .tick.t3 { left: 10px; top: 10px; width: 2px; height: 34px; background: linear-gradient(0deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); animation-name: tMoveY; }
+.main-menu-screen .tick.t4 { right: 10px; bottom: 10px; width: 2px; height: 34px; background: linear-gradient(0deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); animation-name: tMoveYRev; }
+@keyframes tMoveX { 0% { transform: translateX(0); } 100% { transform: translateX(calc(100% - 34px)); } }
+@keyframes tMoveXRev { 0% { transform: translateX(0); } 100% { transform: translateX(calc(-100% + 34px)); } }
+@keyframes tMoveY { 0% { transform: translateY(0); } 100% { transform: translateY(calc(100% - 34px)); } }
+@keyframes tMoveYRev { 0% { transform: translateY(0); } 100% { transform: translateY(calc(-100% + 34px)); } }
+
+.main-menu-screen .menu-button { position: relative; isolation: isolate; border: none; color: #fff; cursor: pointer; text-transform: uppercase; letter-spacing: 0.18rem; font-weight: 800; font-size: clamp(14px, 1.2vw, 18px); padding: 1rem 1.4rem 1rem 1.8rem; background: linear-gradient(135deg, rgba(255, 59, 59, 0.22), rgba(255, 59, 59, 0.08) 40%, rgba(255, 255, 255, 0.05) 100%); box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 14px rgba(255, 59, 59, 0.55), 0 0 40px rgba(255, 59, 59, 0.25); clip-path: polygon(0% 0%, 87% 0%, 100% 25%, 100% 100%, 13% 100%, 0% 75%); border-radius: 4px; transition: transform 0.18s ease, box-shadow 0.22s ease, letter-spacing 0.22s ease, filter 0.22s ease; }
+.main-menu-screen .menu-button::before { content: ""; position: absolute; inset: 0; pointer-events: none; clip-path: inherit; background: linear-gradient(135deg, transparent 0 40%, rgba(255, 255, 255, 0.08) 60%, transparent 100%); mix-blend-mode: screen; z-index: -1; }
+.main-menu-screen .menu-button::after { content: ""; position: absolute; top: 0; bottom: 0; left: -30%; width: 30%; background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.34), transparent); transform: skewX(-22deg); filter: blur(4px); transition: left 0.45s ease; }
+.main-menu-screen .menu-button:hover { transform: translateY(-3px) scale(1.02); letter-spacing: 0.22rem; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1), 0 0 18px rgba(255, 59, 59, 0.75), 0 0 60px rgba(255, 59, 59, 0.35); filter: saturate(1.1); }
+.main-menu-screen .menu-button:hover::after { left: 110%; }
+.main-menu-screen .menu-button .underline { position: absolute; left: 10px; right: 18%; bottom: -6px; height: 2px; overflow: hidden; }
+.main-menu-screen .menu-button .underline::before { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, rgba(255, 59, 59, 0.2), rgba(255, 59, 59, 0.9), rgba(255, 59, 59, 0.2)); transform: translateX(-100%); animation: slide 2.2s cubic-bezier(0.35, 0.05, 0.2, 0.95) infinite; }
+@keyframes slide { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+
+.main-menu-placeholder { max-width: min(92vw, 520px); box-sizing: border-box; border: 1px solid rgba(255, 59, 59, 0.5); background: rgba(0, 0, 0, 0.55); color: #fff; padding: 0.85rem 1rem; border-radius: 8px; letter-spacing: 0.05rem; box-shadow: 0 0 20px rgba(255, 59, 59, 0.25); }
+
+@media (max-width: 780px) {
+  .main-menu-screen .brand { left: 4vw; font-size: clamp(26px, 7vw, 54px); }
+  .main-menu-screen .menu-wrap { left: 4vw; bottom: 6vh; width: 50%; }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,22 +1,51 @@
 import { useState } from "react";
 import { BackendStatus } from "./components/BackendStatus";
+import { MainMenuScreen } from "./components/mainMenu/MainMenuScreen";
 import { PlayersScreen } from "./components/players/PlayersScreen";
 import "./App.css";
 
-type Screen = "players";
+export type Screen = "mainMenu" | "players" | "debug";
 
 function App() {
-  const [screen] = useState<Screen>("players");
+  const [screen, setScreen] = useState<Screen>("mainMenu");
 
   return (
     <main className="app">
       <BackendStatus />
       <nav className="migration-nav" aria-label="Migration screens">
-        <button className="migration-nav__button migration-nav__button--active" type="button">
+        <button
+          className={`migration-nav__button ${screen === "mainMenu" ? "migration-nav__button--active" : ""}`}
+          type="button"
+          onClick={() => setScreen("mainMenu")}
+        >
+          Main Menu
+        </button>
+        <button
+          className={`migration-nav__button ${screen === "players" ? "migration-nav__button--active" : ""}`}
+          type="button"
+          onClick={() => setScreen("players")}
+        >
           Players
         </button>
+        <button
+          className={`migration-nav__button ${screen === "debug" ? "migration-nav__button--active" : ""}`}
+          type="button"
+          onClick={() => setScreen("debug")}
+        >
+          Backend Status
+        </button>
       </nav>
-      {screen === "players" && <PlayersScreen />}
+      {screen === "mainMenu" && <MainMenuScreen onNavigate={(nextScreen) => nextScreen && setScreen(nextScreen)} />}
+      {screen === "players" && <PlayersScreen onBack={() => setScreen("mainMenu")} />}
+      {screen === "debug" && (
+        <section className="debug-status-screen">
+          <h1>Backend / Debug Status</h1>
+          <p>The backend connection indicator remains visible in the top-right corner.</p>
+          <button className="back-button debug-status-screen__back" type="button" onClick={() => setScreen("mainMenu")}>
+            ← Back
+          </button>
+        </section>
+      )}
     </main>
   );
 }

--- a/apps/web/src/components/mainMenu/MainMenuButton.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuButton.tsx
@@ -1,0 +1,15 @@
+import type { MainMenuItem } from "./types";
+
+type MainMenuButtonProps = {
+  item: MainMenuItem;
+  onSelect: (item: MainMenuItem) => void;
+};
+
+export function MainMenuButton({ item, onSelect }: MainMenuButtonProps) {
+  return (
+    <button className="menu-button" type="button" onClick={() => onSelect(item)}>
+      <span>{item.label}</span>
+      <span className="underline" />
+    </button>
+  );
+}

--- a/apps/web/src/components/mainMenu/MainMenuScreen.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuScreen.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from "react";
+import { MainMenuButton } from "./MainMenuButton";
+import type { MainMenuItem } from "./types";
+
+const MENU_AMBIENCE_URL = "https://andrew-jacobson06.github.io/public-audio/stadiumNoise-menu.mp3";
+
+const menuItems: MainMenuItem[] = [
+  { label: "View Players", screen: "players" },
+  {
+    label: "Existing League",
+    placeholderMessage: "Existing League has not been migrated yet. TODO: connect this button when the Games/League screen is ported."
+  },
+  {
+    label: "New League",
+    placeholderMessage: "New League coming soon! TODO: port the old league creation flow when its backend/API behavior is available."
+  }
+];
+
+type MainMenuScreenProps = {
+  onNavigate: (screen: MainMenuItem["screen"]) => void;
+};
+
+export function MainMenuScreen({ onNavigate }: MainMenuScreenProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const tickerRef = useRef<HTMLDivElement | null>(null);
+  const [placeholderMessage, setPlaceholderMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const track = tickerRef.current;
+    if (!track?.parentElement) return;
+
+    const textWidth = track.scrollWidth;
+    const containerWidth = track.parentElement.offsetWidth;
+    if (textWidth < containerWidth * 2) {
+      track.innerHTML = track.innerHTML + track.innerHTML;
+    }
+  }, []);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    audio.volume = 0.88;
+    audio.play().catch(() => undefined);
+
+    const unlock = () => {
+      audio.muted = false;
+      audio.volume = 0.88;
+      audio.play().catch(() => undefined);
+      window.removeEventListener("pointerdown", unlock);
+      window.removeEventListener("keydown", unlock);
+      window.removeEventListener("touchstart", unlock);
+    };
+
+    const resumeWhenVisible = () => {
+      if (document.visibilityState === "visible") {
+        audio.play().catch(() => undefined);
+      }
+    };
+
+    const toggleMute = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "m") {
+        audio.muted = !audio.muted;
+      }
+    };
+
+    window.addEventListener("pointerdown", unlock, { once: true });
+    window.addEventListener("keydown", unlock, { once: true });
+    window.addEventListener("touchstart", unlock, { once: true });
+    window.addEventListener("keydown", toggleMute);
+    document.addEventListener("visibilitychange", resumeWhenVisible);
+
+    return () => {
+      window.removeEventListener("pointerdown", unlock);
+      window.removeEventListener("keydown", unlock);
+      window.removeEventListener("touchstart", unlock);
+      window.removeEventListener("keydown", toggleMute);
+      document.removeEventListener("visibilitychange", resumeWhenVisible);
+    };
+  }, []);
+
+  const handleSelect = (item: MainMenuItem) => {
+    if (item.screen) {
+      onNavigate(item.screen);
+      return;
+    }
+
+    setPlaceholderMessage(item.placeholderMessage ?? `${item.label} has not been migrated yet.`);
+  };
+
+  return (
+    <section className="main-menu-screen" aria-label="Animal Football Main Menu">
+      <div className="corner tl" />
+      <div className="corner tr" />
+      <div className="corner bl" />
+      <div className="corner br" />
+
+      <div className="brand">Animal Football</div>
+
+      <div className="menu-wrap">
+        <div className="panel">
+          <div className="ticker">
+            <div className="track" id="tickerTrack" ref={tickerRef}>
+              WEEK 1 • 8:00 PM ET • HOME vs AWAY <span className="sep">|</span>
+              POWER RANKINGS UPDATE • TOP 5: ATL, DAL, DEN, SEA, CLT <span className="sep">|</span>
+              WEATHER: CLEAR • 62°F • 5 MPH WNW <span className="sep">|</span>
+              INJURY REPORT: RB QUESTIONABLE (ANKLE) <span className="sep">|</span>
+            </div>
+          </div>
+
+          <div className="rail top"><span className="runnerX" /></div>
+          <div className="rail bottom"><span className="runnerX" /></div>
+          <div className="rail left"><span className="runnerY" /></div>
+          <div className="rail right"><span className="runnerY" /></div>
+
+          <div className="node n1" /><div className="node n2" />
+          <div className="node n3" /><div className="node n4" />
+
+          <div className="tick t1" /><div className="tick t2" />
+          <div className="tick t3" /><div className="tick t4" />
+
+          {menuItems.map((item) => (
+            <MainMenuButton item={item} key={item.label} onSelect={handleSelect} />
+          ))}
+        </div>
+        {placeholderMessage && (
+          <div className="main-menu-placeholder" role="status">
+            {placeholderMessage}
+          </div>
+        )}
+      </div>
+
+      <audio ref={audioRef} id="menuAmbience" src={MENU_AMBIENCE_URL} preload="auto" autoPlay muted loop playsInline />
+    </section>
+  );
+}

--- a/apps/web/src/components/mainMenu/types.ts
+++ b/apps/web/src/components/mainMenu/types.ts
@@ -1,0 +1,7 @@
+import type { Screen } from "../../App";
+
+export type MainMenuItem = {
+  label: string;
+  screen?: Screen;
+  placeholderMessage?: string;
+};

--- a/apps/web/src/components/players/PlayerList.tsx
+++ b/apps/web/src/components/players/PlayerList.tsx
@@ -4,12 +4,13 @@ import { Stars } from "./Stars";
 type PlayerListProps = {
   players: Player[];
   onSelectPlayer: (player: Player) => void;
+  onBack?: () => void;
 };
 
-export function PlayerList({ players, onSelectPlayer }: PlayerListProps) {
+export function PlayerList({ players, onSelectPlayer, onBack }: PlayerListProps) {
   return (
     <div id="playerListView">
-      <button id="playerListBack" className="back-button" type="button">← Back</button>
+      <button id="playerListBack" className="back-button" type="button" onClick={onBack}>← Back</button>
       <table id="playerTable" className="player-table">
         <thead>
           <tr>

--- a/apps/web/src/components/players/PlayersScreen.tsx
+++ b/apps/web/src/components/players/PlayersScreen.tsx
@@ -4,7 +4,11 @@ import { PlayerCard } from "./PlayerCard";
 import { PlayerList } from "./PlayerList";
 import type { Player } from "./types";
 
-export function PlayersScreen() {
+type PlayersScreenProps = {
+  onBack?: () => void;
+};
+
+export function PlayersScreen({ onBack }: PlayersScreenProps) {
   const [players, setPlayers] = useState<Player[]>([]);
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -33,7 +37,7 @@ export function PlayersScreen() {
     <>
       {isLoading && <p className="players-message">Loading players...</p>}
       {error && <p className="players-message players-message--error">{error}</p>}
-      {!isLoading && !error && <PlayerList players={players} onSelectPlayer={setSelectedPlayer} />}
+      {!isLoading && !error && <PlayerList players={players} onSelectPlayer={setSelectedPlayer} onBack={onBack} />}
     </>
   );
 }


### PR DESCRIPTION
### Motivation

- Port the legacy Google Apps Script Main Menu (markup, styles, and simple scripts) into the local React/Vite frontend so the app entry experience matches the original UI. 
- Preserve the existing Players screen, backend status indicator, and Google Sheets-as-database constraint while keeping any unmigrated flows visible but safely stubbed.

### Description

- Added a React Main Menu and supporting pieces: `apps/web/src/components/mainMenu/MainMenuScreen.tsx`, `MainMenuButton.tsx`, and `types.ts`, and wired the app screen switcher in `apps/web/src/App.tsx`. 
- Ported styles and visuals from `MenuStyle.html` into `apps/web/src/App.css` and recreated title, ticker (with duplication logic), animated rails/nodes/ticks, button visuals/hover/underline, and ambient audio behavior from `MenuScript.html`. 
- Kept original button labels exactly and implemented navigation for `View Players` while showing clear placeholder messages/TODOs for `Existing League` and `New League` (no backend/API implemented for those flows). 
- Minimal players integration changes to preserve navigation: `apps/web/src/components/players/PlayersScreen.tsx` and `PlayerList.tsx` were adjusted to support a back path to the Main Menu; no Google Sheets access was added to the frontend and no new API endpoints were created. 
- Commands to run locally: run `npm run build` and `npm run lint` in `apps/web`, and optionally run `npx tsc --noEmit` in `apps/api` if dependencies are installed. 

### Testing

- Ran `npm run build` in `apps/web` and the build completed successfully. 
- Ran `npm run lint` in `apps/web` and ESLint completed without blocking errors. 
- Attempted `npx tsc --noEmit` in `apps/api` but this step was skipped because `apps/api` dependencies were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4035f28d60832496fc279632bf596a)