### PR TITLE
Hide migration nav and backend status

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -23,6 +23,7 @@ body {
 }
 
 .backend-status {
+  display: none;
   position: fixed;
   right: 1vw;
   top: 1vw;
@@ -40,6 +41,7 @@ body {
 }
 
 .migration-nav {
+  display: none;
   position: fixed;
   top: calc(1vw + 44px);
   left: 1vw;


### PR DESCRIPTION
### Motivation
- Temporarily hide the top-left migration navigation buttons and the top-right backend status indicator in the web UI while preserving their styles for future re-enabling.

### Description
- Add `display: none` to the `.backend-status` and `.migration-nav` selectors in `apps/web/src/App.css` so the status indicator and migration nav are hidden but their markup and styling remain unchanged.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which completed successfully.
- Attempted `npx playwright install chromium` to capture a screenshot but the browser download failed with a `403 Domain forbidden`, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a403fa064348324be6203a1dab34a4c)