### PR TITLE
Restore game loading transition and identical in-game UI

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getGames, getTeams } from "../../api/client";
 import type { LeagueGame, LeagueTab, LeagueTeam } from "./types";
 import { mockGames, mockTeams } from "./leagueMockData";
@@ -15,6 +15,9 @@ export function LeagueAppScreen() {
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
+  const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
+  const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
+  const gameLoadTimeout = useRef<number | null>(null);
   useEffect(() => {
     getGames()
       .then(({ games }) => setGames(normalizeGames(games)))
@@ -23,6 +26,47 @@ export function LeagueAppScreen() {
       .then(({ teams }) => setTeams(teams as LeagueTeam[]))
       .catch(() => setTeams(mockTeams));
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (gameLoadTimeout.current !== null) {
+        window.clearTimeout(gameLoadTimeout.current);
+      }
+    };
+  }, []);
+
+  const openGame = (game: LeagueGame) => {
+    if (gameLoadTimeout.current !== null) {
+      window.clearTimeout(gameLoadTimeout.current);
+    }
+
+    setSelectedGame(null);
+    setIsExitingGameLoad(false);
+    setLoadingGame(game);
+
+    gameLoadTimeout.current = window.setTimeout(() => {
+      setIsExitingGameLoad(true);
+      gameLoadTimeout.current = window.setTimeout(() => {
+        setSelectedGame(game);
+        setLoadingGame(null);
+        setIsExitingGameLoad(false);
+      }, 1800);
+    }, 850);
+  };
+
+  const completeGameLoad = () => {
+    if (!loadingGame) return;
+
+    if (gameLoadTimeout.current !== null) {
+      window.clearTimeout(gameLoadTimeout.current);
+      gameLoadTimeout.current = null;
+    }
+
+    setSelectedGame(loadingGame);
+    setLoadingGame(null);
+    setIsExitingGameLoad(false);
+  };
+
   if (selectedGame)
     return (
       <section className="league-app">
@@ -37,34 +81,76 @@ export function LeagueAppScreen() {
         </div>
         <div className="loading-text">Loading Games...</div>
       </div>
-      <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
-      <div id="tabContents">
-        {activeTab === "news" && (
-          <div className="league-tab-content active">
-            <LeagueNews />
+      {loadingGame && (
+        <div
+          id="loadingScreen"
+          className={`loading-screen ${isExitingGameLoad ? "exit-zoom" : ""}`}
+          onAnimationEnd={(event) => {
+            if (
+              event.currentTarget === event.target &&
+              event.animationName === "zoom-in"
+            ) {
+              completeGameLoad();
+            }
+          }}
+        >
+          <div className="logo-container">
+            <img
+              id="loadingHomeLogo"
+              className={`loading-logo ${
+                isExitingGameLoad ? "unclash-left" : "animate-left"
+              }`}
+              src={loadingGame.HomeLogo || "https://via.placeholder.com/150"}
+              alt={`${loadingGame.Home} Logo`}
+            />
+            <img
+              id="loadingAwayLogo"
+              className={`loading-logo ${
+                isExitingGameLoad ? "unclash-right" : "animate-right"
+              }`}
+              src={loadingGame.AwayLogo || "https://via.placeholder.com/150"}
+              alt={`${loadingGame.Away} Logo`}
+            />
           </div>
-        )}
-        {activeTab === "scores" && (
-          <div className="league-tab-content active">
-            <LeagueSchedule games={games} onSelectGame={setSelectedGame} />
+          <img
+            src="https://andrew-jacobson06.github.io/public-audio/loading-football.gif"
+            alt="Loading"
+            className="loading-football"
+          />
+        </div>
+      )}
+      {!loadingGame && (
+        <>
+          <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
+          <div id="tabContents">
+            {activeTab === "news" && (
+              <div className="league-tab-content active">
+                <LeagueNews />
+              </div>
+            )}
+            {activeTab === "scores" && (
+              <div className="league-tab-content active">
+                <LeagueSchedule games={games} onSelectGame={openGame} />
+              </div>
+            )}
+            {activeTab === "standings" && (
+              <div className="league-tab-content active">
+                <LeagueStandings teams={teams} />
+              </div>
+            )}
+            {activeTab === "stats" && (
+              <div className="league-tab-content active">
+                <LeagueStats />
+              </div>
+            )}
+            {activeTab === "draft" && (
+              <div className="league-tab-content active">
+                <div className="coming-soon">Draft coming soon...</div>
+              </div>
+            )}
           </div>
-        )}
-        {activeTab === "standings" && (
-          <div className="league-tab-content active">
-            <LeagueStandings teams={teams} />
-          </div>
-        )}
-        {activeTab === "stats" && (
-          <div className="league-tab-content active">
-            <LeagueStats />
-          </div>
-        )}
-        {activeTab === "draft" && (
-          <div className="league-tab-content active">
-            <div className="coming-soon">Draft coming soon...</div>
-          </div>
-        )}
-      </div>
+        </>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1,6 +1,809 @@
-.league-app{--accent-red:#C10206;--accent-red-dark:#A50113;--gray-dark:#121212;--gray-medium:#1e1e1e;--gray-light:#2c2c2c;--text-light:#F5F5F5;--text-muted:#B0B0B0;--text-link:rgb(0,106,255);min-height:100vh;font-family:Roboto,Arial,sans-serif;background:linear-gradient(135deg,var(--gray-dark) 0%,var(--gray-medium) 100%);color:var(--text-light)}.league-app *{box-sizing:border-box}.league-header{position:sticky;top:0;z-index:100;display:flex;flex-direction:column;align-items:center;background:var(--gray-medium);border-bottom:1px solid var(--gray-light);padding:1vw 2vw}.league-name{font-weight:700;padding-bottom:2vw;text-align:center;font-size:4vw;background:linear-gradient(to right,var(--accent-red-dark),var(--accent-red));-webkit-background-clip:text;background-clip:text;color:transparent}.nav-tabs{display:flex;gap:1vw}.nav-tab{background:none;border:none;color:var(--text-muted);padding:1vw 2vw;cursor:pointer;font-size:clamp(14px,3vw,24px);border-bottom:.6vw solid transparent;height:8vw}.nav-tab.active{color:var(--text-light);border-bottom-color:var(--text-light);font-weight:700}.league-tab-content{display:none}.league-tab-content.active{display:block}.coming-soon{text-align:center;padding:5vw 0;color:var(--text-muted);font-size:clamp(16px,4vw,24px)}
-.news-feed{display:grid;gap:3vw;padding:2.5vw}.news-panel,.news-feature,.news-secondary,.news-secondary-card{background:var(--gray-medium);border:1px solid var(--gray-light);border-radius:10px;box-shadow:0 4px 12px #0004}.news-panel,.news-feature,.news-secondary{padding:3vw}.news-panel-title{margin:0;font-size:clamp(18px,4vw,26px)}.news-headline-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:2vw}.news-headline-item{display:flex;align-items:center;justify-content:space-between;gap:2vw}.news-headline-link{display:inline-flex;align-items:center;gap:1.5vw;flex:1;color:var(--text-light);text-decoration:none;font-size:clamp(24px,4vw,28px);font-weight:bold}.headline-timestamp,.headline-icon{color:var(--text-muted);font-size:clamp(24px,4vw,28px)}.feature-card{display:flex;flex-direction:column;gap:2vw}.feature-tag{font-size:clamp(24px,4vw,28px);letter-spacing:.08em;text-transform:uppercase;color:var(--text-muted)}.feature-matchup{display:grid;grid-template-columns:repeat(3,1fr);align-items:center;gap:1vw;padding:2vw;background:var(--gray-light);border-radius:8px}.feature-team{display:flex;flex-direction:column;align-items:center;font-size:clamp(24px,4vw,28px);font-weight:600}.feature-team-record{font-size:clamp(20px,4vw,24px);color:var(--text-muted)}.feature-kickoff{text-align:center;font-size:clamp(20px,4vw,24px);line-height:1.4}.feature-image{height:clamp(140px,30vw,200px);background:linear-gradient(135deg,#c10206cc,#121212d9);border-radius:12px}.feature-headline{font-size:clamp(30px,4.5vw,36px);font-weight:700;line-height:1.3}.feature-summary,.news-secondary-summary{margin:0;color:var(--text-muted);font-size:clamp(18px,3.5vw,24px);line-height:1.5}.feature-link,.team-link,.complete-link a{color:var(--text-link);text-decoration:none}.news-secondary-title{margin:0;font-size:clamp(24px,4vw,28px);text-transform:uppercase}.news-secondary-grid{display:grid;gap:2vw}.news-secondary-card{padding:2.5vw}.news-secondary-link{color:inherit;text-decoration:none;font-size:clamp(20px,4vw,24px);font-weight:bold}.news-secondary-headline{margin:0 0 1vw;font-size:clamp(24px,4vw,28px)}@media (min-width:1200px){.news-secondary-grid{grid-template-columns:repeat(3,1fr)}}@media (min-width:1500px){.news-feed{grid-template-columns:minmax(220px,2fr) minmax(260px,3fr)}.news-secondary{grid-column:1/-1}}
-.game-list{padding:2.5vw}.game-card{display:block;width:100%;text-align:left;background:var(--gray-medium);border:1px solid var(--gray-light);border-radius:4px;margin-bottom:3vw;cursor:pointer;padding:2.5vw;color:inherit}.game-card .team-row{display:flex;align-items:center;font-size:4vw;gap:0}.game-card .team-row+.team-row{margin-top:1vw}.game-card .team-logo{flex:0 0 10%;max-width:10%;height:auto;object-fit:contain}.game-card .team-name-wrap{flex:0 0 40%;display:flex;align-items:center;gap:1vw}.game-card .team-name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding-left:2vw}.game-card .team-score{flex:0 0 10%;font-weight:bold;text-align:center;font-size:clamp(16px,6vw,60px)!important}.game-card .winner{color:var(--text-light);font-weight:bold}.game-card .loser{color:var(--text-muted)}.game-card .team-time,.game-card .team-qtr,.game-card .team-down,.game-card .team-ball{flex:0 0 20%;text-align:center}
-.standings-wrapper{padding:2.5vw}.standings-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:2vw}.standings-title{font-size:clamp(28px,5vw,42px);font-weight:700}.season-select,.season-pill,.standings-tab{background:var(--gray-light);color:var(--text-light);border:1px solid #444;border-radius:4px;padding:1vw 2vw}.standings-tabs,.stats-tabs{display:flex;gap:1vw;margin-bottom:2vw}.standings-tab.active,.stats-tab.active{background:var(--accent-red)}.standings-panel{background:var(--gray-medium);border:1px solid var(--gray-light)}.standings-panel-header{padding:1.5vw;font-weight:700}.standings-table-scroll{overflow:auto}.standings-table,.leader-table{width:100%;border-collapse:collapse}.standings-table th,.standings-table td,.leader-table th,.leader-table td{padding:1.2vw;border-top:1px solid var(--gray-light);text-align:center}.standings-table .team-col{text-align:left}.team-rank,.rank{display:inline-block;color:var(--text-muted);margin-right:1vw}.stats-tabs,.season-row,.stats-section{padding:2vw}.stats-tab{background:var(--gray-medium);color:var(--text-muted);border:1px solid var(--gray-light);padding:1.5vw 3vw}.stats-section-title{font-size:clamp(24px,4vw,32px);font-weight:700;margin-bottom:2vw}.leader-group{background:var(--gray-medium);border:1px solid var(--gray-light);margin:0 0 2vw}.team-cell{display:flex;align-items:center;gap:1vw}.team-cell .team-logo{width:24px;height:24px}.statCol1{text-align:left!important}.stat-value{text-align:right!important}.complete-link{padding:1vw 2vw}
-.scoreboard{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;background:var(--gray-medium);padding:clamp(10px,5vw,34px) clamp(12px,7vw,42px);border:1px solid var(--gray-light);box-shadow:0 0 15px #0008;position:sticky;top:0;z-index:90;min-height:clamp(120px,35vw,320px)}.league-back-button{position:fixed;top:1vw;left:1vw;background:var(--gray-light);color:var(--text-light);border:none;padding:1vw 2vw;cursor:pointer;z-index:110}.team-block{display:flex;align-items:center;height:100%;justify-content:center}.team-block.away{flex-direction:row-reverse}.team-info{display:flex;flex-direction:column;align-items:center;flex:1}.scoreboard .team-logo{max-height:clamp(70px,15vw,150px);object-fit:contain}.scoreboard .team-name{font-weight:700;font-size:clamp(14px,8vw,38px)}.team-record{font-size:clamp(12px,5vw,34px);color:var(--text-muted)}.score-section{display:flex;flex-direction:column;align-items:center;justify-content:center;margin:0 clamp(1vw,3vw,26px)}.score-row{display:flex;align-items:center}.team-score{font-size:clamp(32px,9vw,80px)!important;font-weight:700}.timeouts{display:flex;gap:1vw;margin-top:1vw}.timeout-dot{width:clamp(6px,2vw,14px);height:clamp(6px,2vw,14px);border-radius:50%;background:yellow}.center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;font-weight:700;color:var(--accent-red);text-align:center;min-width:clamp(80px,25vw,160px)}.center-info .quarter{font-size:clamp(12px,3vw,20px);color:var(--text-muted)}.center-info .clock{font-size:clamp(18px,5vw,36px)}.football-icon{font-size:clamp(20px,3.5vw,40px)}
-.spectate-control{display:flex;align-items:center;justify-content:flex-end;gap:clamp(12px,4vw,32px);background:var(--gray-medium);border:1px solid var(--gray-light);border-top:none;padding:clamp(10px,4vw,26px) clamp(12px,7vw,42px);margin-bottom:clamp(12px,4vw,30px)}.spectate-switch{--toggle-height:clamp(24px,7vw,38px);--toggle-padding:clamp(3px,1vw,6px);position:relative;display:inline-block;width:calc(var(--toggle-height)*2);height:var(--toggle-height)}.spectate-switch input{opacity:0;width:0;height:0}.spectate-slider{position:absolute;inset:0;cursor:pointer;background:var(--gray-light);border-radius:var(--toggle-height)}.spectate-slider:before{content:"";position:absolute;height:calc(var(--toggle-height) - var(--toggle-padding)*2);width:calc(var(--toggle-height) - var(--toggle-padding)*2);left:var(--toggle-padding);bottom:var(--toggle-padding);background:var(--text-light);border-radius:50%;transition:transform .3s}.spectate-switch input:checked+.spectate-slider{background:linear-gradient(135deg,var(--accent-red-dark),var(--accent-red))}.spectate-switch input:checked+.spectate-slider:before{transform:translateX(var(--toggle-height))}.spectate-label{font-size:clamp(12px,3.2vw,16px);letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted)}.spectate-status{font-size:clamp(14px,4vw,20px);font-weight:600;color:var(--text-muted)}.tabs{display:flex;margin:0 0 5vw;background:var(--gray-medium);border:1px solid var(--gray-light);overflow:hidden;position:sticky;top:0;z-index:80}.tab-button{flex:1;padding:2.5vw 3.75vw;background:var(--gray-medium);color:var(--text-muted);border:none;border-bottom:.75vw solid transparent;cursor:pointer;font-size:clamp(16px,4vw,26px)!important}.tab-button.active{color:var(--accent-red);border-bottom:.75vw solid var(--accent-red)}.game-info{display:flex;justify-content:center;gap:clamp(12px,4vw,32px);padding:clamp(16px,4vw,32px);border-bottom:1px solid var(--gray-light);text-align:center}.info-label{font-size:clamp(18px,5vw,24px);font-weight:600;color:var(--text-muted)}.info-value{font-size:clamp(20px,6vw,32px);font-weight:700}.field-wrapper{padding:3vw}.field3D{position:relative;height:260px;background:linear-gradient(90deg,#145c28,#1f7a35,#145c28);border:5px solid #ddd;overflow:hidden}.yardline{position:absolute;top:0;bottom:0;width:2px;background:#ffffffa6;color:#fff}.label{position:absolute;font-weight:700}.top{top:12px}.left{left:-18px}.right{left:3px}.line-of-scrimmage,.first-down-line{position:absolute;top:0;bottom:0;width:4px}.line-of-scrimmage{background:#1e90ff}.first-down-line{background:yellow}.control-panel,.play-log,.placeholder-panel{margin:2vw;padding:2vw;background:var(--gray-medium);border:1px solid var(--gray-light);border-radius:4px}.game-controls{display:flex;flex-wrap:wrap;gap:1vw}.game-controls button{background:var(--accent-red);color:white;border:none;border-radius:4px;padding:1vw 2vw;font-weight:700}.control-note{color:var(--text-muted)}.log-entry{padding:1vw 0;border-top:1px solid var(--gray-light)}.hidden{display:none!important}
+.league-app {
+  --accent-red: #c10206;
+  --accent-red-dark: #a50113;
+  --gray-dark: #121212;
+  --gray-medium: #1e1e1e;
+  --gray-light: #2c2c2c;
+  --text-light: #f5f5f5;
+  --text-muted: #b0b0b0;
+  --text-link: rgb(0, 106, 255);
+  min-height: 100vh;
+  font-family: Roboto, Arial, sans-serif;
+  background: linear-gradient(
+    135deg,
+    var(--gray-dark) 0%,
+    var(--gray-medium) 100%
+  );
+  color: var(--text-light);
+}
+.league-app * {
+  box-sizing: border-box;
+}
+.league-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--gray-medium);
+  border-bottom: 1px solid var(--gray-light);
+  padding: 1vw 2vw;
+}
+.league-name {
+  font-weight: 700;
+  padding-bottom: 2vw;
+  text-align: center;
+  font-size: 4vw;
+  background: linear-gradient(
+    to right,
+    var(--accent-red-dark),
+    var(--accent-red)
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.nav-tabs {
+  display: flex;
+  gap: 1vw;
+}
+.nav-tab {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 1vw 2vw;
+  cursor: pointer;
+  font-size: clamp(14px, 3vw, 24px);
+  border-bottom: 0.6vw solid transparent;
+  height: 8vw;
+}
+.nav-tab.active {
+  color: var(--text-light);
+  border-bottom-color: var(--text-light);
+  font-weight: 700;
+}
+.league-tab-content {
+  display: none;
+}
+.league-tab-content.active {
+  display: block;
+}
+.coming-soon {
+  text-align: center;
+  padding: 5vw 0;
+  color: var(--text-muted);
+  font-size: clamp(16px, 4vw, 24px);
+}
+.news-feed {
+  display: grid;
+  gap: 3vw;
+  padding: 2.5vw;
+}
+.news-panel,
+.news-feature,
+.news-secondary,
+.news-secondary-card {
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px #0004;
+}
+.news-panel,
+.news-feature,
+.news-secondary {
+  padding: 3vw;
+}
+.news-panel-title {
+  margin: 0;
+  font-size: clamp(18px, 4vw, 26px);
+}
+.news-headline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2vw;
+}
+.news-headline-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2vw;
+}
+.news-headline-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.5vw;
+  flex: 1;
+  color: var(--text-light);
+  text-decoration: none;
+  font-size: clamp(24px, 4vw, 28px);
+  font-weight: bold;
+}
+.headline-timestamp,
+.headline-icon {
+  color: var(--text-muted);
+  font-size: clamp(24px, 4vw, 28px);
+}
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2vw;
+}
+.feature-tag {
+  font-size: clamp(24px, 4vw, 28px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.feature-matchup {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: center;
+  gap: 1vw;
+  padding: 2vw;
+  background: var(--gray-light);
+  border-radius: 8px;
+}
+.feature-team {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: clamp(24px, 4vw, 28px);
+  font-weight: 600;
+}
+.feature-team-record {
+  font-size: clamp(20px, 4vw, 24px);
+  color: var(--text-muted);
+}
+.feature-kickoff {
+  text-align: center;
+  font-size: clamp(20px, 4vw, 24px);
+  line-height: 1.4;
+}
+.feature-image {
+  height: clamp(140px, 30vw, 200px);
+  background: linear-gradient(135deg, #c10206cc, #121212d9);
+  border-radius: 12px;
+}
+.feature-headline {
+  font-size: clamp(30px, 4.5vw, 36px);
+  font-weight: 700;
+  line-height: 1.3;
+}
+.feature-summary,
+.news-secondary-summary {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(18px, 3.5vw, 24px);
+  line-height: 1.5;
+}
+.feature-link,
+.team-link,
+.complete-link a {
+  color: var(--text-link);
+  text-decoration: none;
+}
+.news-secondary-title {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 28px);
+  text-transform: uppercase;
+}
+.news-secondary-grid {
+  display: grid;
+  gap: 2vw;
+}
+.news-secondary-card {
+  padding: 2.5vw;
+}
+.news-secondary-link {
+  color: inherit;
+  text-decoration: none;
+  font-size: clamp(20px, 4vw, 24px);
+  font-weight: bold;
+}
+.news-secondary-headline {
+  margin: 0 0 1vw;
+  font-size: clamp(24px, 4vw, 28px);
+}
+@media (min-width: 1200px) {
+  .news-secondary-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+@media (min-width: 1500px) {
+  .news-feed {
+    grid-template-columns: minmax(220px, 2fr) minmax(260px, 3fr);
+  }
+  .news-secondary {
+    grid-column: 1/-1;
+  }
+}
+.game-list {
+  padding: 2.5vw;
+}
+.game-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  border-radius: 4px;
+  margin-bottom: 3vw;
+  cursor: pointer;
+  padding: 2.5vw;
+  color: inherit;
+}
+.game-card .team-row {
+  display: flex;
+  align-items: center;
+  font-size: 4vw;
+  gap: 0;
+}
+.game-card .team-row + .team-row {
+  margin-top: 1vw;
+}
+.game-card .team-logo {
+  flex: 0 0 10%;
+  max-width: 10%;
+  height: auto;
+  object-fit: contain;
+}
+.game-card .team-name-wrap {
+  flex: 0 0 40%;
+  display: flex;
+  align-items: center;
+  gap: 1vw;
+}
+.game-card .team-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-left: 2vw;
+}
+.game-card .team-score {
+  flex: 0 0 10%;
+  font-weight: bold;
+  text-align: center;
+  font-size: clamp(16px, 6vw, 60px) !important;
+}
+.game-card .winner {
+  color: var(--text-light);
+  font-weight: bold;
+}
+.game-card .loser {
+  color: var(--text-muted);
+}
+.game-card .team-time,
+.game-card .team-qtr,
+.game-card .team-down,
+.game-card .team-ball {
+  flex: 0 0 20%;
+  text-align: center;
+}
+.standings-wrapper {
+  padding: 2.5vw;
+}
+.standings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2vw;
+}
+.standings-title {
+  font-size: clamp(28px, 5vw, 42px);
+  font-weight: 700;
+}
+.season-select,
+.season-pill,
+.standings-tab {
+  background: var(--gray-light);
+  color: var(--text-light);
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 1vw 2vw;
+}
+.standings-tabs,
+.stats-tabs {
+  display: flex;
+  gap: 1vw;
+  margin-bottom: 2vw;
+}
+.standings-tab.active,
+.stats-tab.active {
+  background: var(--accent-red);
+}
+.standings-panel {
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+}
+.standings-panel-header {
+  padding: 1.5vw;
+  font-weight: 700;
+}
+.standings-table-scroll {
+  overflow: auto;
+}
+.standings-table,
+.leader-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.standings-table th,
+.standings-table td,
+.leader-table th,
+.leader-table td {
+  padding: 1.2vw;
+  border-top: 1px solid var(--gray-light);
+  text-align: center;
+}
+.standings-table .team-col {
+  text-align: left;
+}
+.team-rank,
+.rank {
+  display: inline-block;
+  color: var(--text-muted);
+  margin-right: 1vw;
+}
+.stats-tabs,
+.season-row,
+.stats-section {
+  padding: 2vw;
+}
+.stats-tab {
+  background: var(--gray-medium);
+  color: var(--text-muted);
+  border: 1px solid var(--gray-light);
+  padding: 1.5vw 3vw;
+}
+.stats-section-title {
+  font-size: clamp(24px, 4vw, 32px);
+  font-weight: 700;
+  margin-bottom: 2vw;
+}
+.leader-group {
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  margin: 0 0 2vw;
+}
+.team-cell {
+  display: flex;
+  align-items: center;
+  gap: 1vw;
+}
+.team-cell .team-logo {
+  width: 24px;
+  height: 24px;
+}
+.statCol1 {
+  text-align: left !important;
+}
+.stat-value {
+  text-align: right !important;
+}
+.complete-link {
+  padding: 1vw 2vw;
+}
+.scoreboard {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  background: var(--gray-medium);
+  padding: clamp(10px, 5vw, 34px) clamp(12px, 7vw, 42px);
+  border: 1px solid var(--gray-light);
+  box-shadow: 0 0 15px #0008;
+  position: sticky;
+  top: 0;
+  z-index: 90;
+  min-height: clamp(120px, 35vw, 320px);
+}
+.league-back-button {
+  position: fixed;
+  top: 1vw;
+  left: 1vw;
+  background: var(--gray-light);
+  color: var(--text-light);
+  border: none;
+  padding: 1vw 2vw;
+  cursor: pointer;
+  z-index: 110;
+}
+.team-block {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  justify-content: center;
+}
+.team-block.away {
+  flex-direction: row-reverse;
+}
+.team-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+.scoreboard .team-logo {
+  max-height: clamp(70px, 15vw, 150px);
+  object-fit: contain;
+}
+.scoreboard .team-name {
+  font-weight: 700;
+  font-size: clamp(14px, 8vw, 38px);
+}
+.team-record {
+  font-size: clamp(12px, 5vw, 34px);
+  color: var(--text-muted);
+}
+.score-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0 clamp(1vw, 3vw, 26px);
+}
+.score-row {
+  display: flex;
+  align-items: center;
+}
+.team-score {
+  font-size: clamp(32px, 9vw, 80px) !important;
+  font-weight: 700;
+}
+.timeouts {
+  display: flex;
+  gap: 1vw;
+  margin-top: 1vw;
+}
+.timeout-dot {
+  width: clamp(6px, 2vw, 14px);
+  height: clamp(6px, 2vw, 14px);
+  border-radius: 50%;
+  background: yellow;
+}
+.center-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--accent-red);
+  text-align: center;
+  min-width: clamp(80px, 25vw, 160px);
+}
+.center-info .quarter {
+  font-size: clamp(12px, 3vw, 20px);
+  color: var(--text-muted);
+}
+.center-info .clock {
+  font-size: clamp(18px, 5vw, 36px);
+}
+.football-icon {
+  font-size: clamp(20px, 3.5vw, 40px);
+}
+.spectate-control {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(12px, 4vw, 32px);
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  border-top: none;
+  padding: clamp(10px, 4vw, 26px) clamp(12px, 7vw, 42px);
+  margin-bottom: clamp(12px, 4vw, 30px);
+}
+.spectate-switch {
+  --toggle-height: clamp(24px, 7vw, 38px);
+  --toggle-padding: clamp(3px, 1vw, 6px);
+  position: relative;
+  display: inline-block;
+  width: calc(var(--toggle-height) * 2);
+  height: var(--toggle-height);
+}
+.spectate-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.spectate-slider {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  background: var(--gray-light);
+  border-radius: var(--toggle-height);
+}
+.spectate-slider:before {
+  content: "";
+  position: absolute;
+  height: calc(var(--toggle-height) - var(--toggle-padding) * 2);
+  width: calc(var(--toggle-height) - var(--toggle-padding) * 2);
+  left: var(--toggle-padding);
+  bottom: var(--toggle-padding);
+  background: var(--text-light);
+  border-radius: 50%;
+  transition: transform 0.3s;
+}
+.spectate-switch input:checked + .spectate-slider {
+  background: linear-gradient(
+    135deg,
+    var(--accent-red-dark),
+    var(--accent-red)
+  );
+}
+.spectate-switch input:checked + .spectate-slider:before {
+  transform: translateX(var(--toggle-height));
+}
+.spectate-label {
+  font-size: clamp(12px, 3.2vw, 16px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.spectate-status {
+  font-size: clamp(14px, 4vw, 20px);
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.tabs {
+  display: flex;
+  margin: 0 0 5vw;
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  overflow: hidden;
+  position: sticky;
+  top: 0;
+  z-index: 80;
+}
+.tab-button {
+  flex: 1;
+  padding: 2.5vw 3.75vw;
+  background: var(--gray-medium);
+  color: var(--text-muted);
+  border: none;
+  border-bottom: 0.75vw solid transparent;
+  cursor: pointer;
+  font-size: clamp(16px, 4vw, 26px) !important;
+}
+.tab-button.active {
+  color: var(--accent-red);
+  border-bottom: 0.75vw solid var(--accent-red);
+}
+.game-info {
+  display: flex;
+  justify-content: center;
+  gap: clamp(12px, 4vw, 32px);
+  padding: clamp(16px, 4vw, 32px);
+  border-bottom: 1px solid var(--gray-light);
+  text-align: center;
+}
+.info-label {
+  font-size: clamp(18px, 5vw, 24px);
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.info-value {
+  font-size: clamp(20px, 6vw, 32px);
+  font-weight: 700;
+}
+.field-wrapper {
+  padding: 3vw;
+}
+.field3D {
+  position: relative;
+  height: 260px;
+  background: linear-gradient(90deg, #145c28, #1f7a35, #145c28);
+  border: 5px solid #ddd;
+  overflow: hidden;
+}
+.yardline {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #ffffffa6;
+  color: #fff;
+}
+.label {
+  position: absolute;
+  font-weight: 700;
+}
+.top {
+  top: 12px;
+}
+.left {
+  left: -18px;
+}
+.right {
+  left: 3px;
+}
+.line-of-scrimmage,
+.first-down-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+}
+.line-of-scrimmage {
+  background: #1e90ff;
+}
+.first-down-line {
+  background: yellow;
+}
+.control-panel,
+.play-log,
+.placeholder-panel {
+  margin: 2vw;
+  padding: 2vw;
+  background: var(--gray-medium);
+  border: 1px solid var(--gray-light);
+  border-radius: 4px;
+}
+.game-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1vw;
+}
+.game-controls button {
+  background: var(--accent-red);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 1vw 2vw;
+  font-weight: 700;
+}
+.control-note {
+  color: var(--text-muted);
+}
+.log-entry {
+  padding: 1vw 0;
+  border-top: 1px solid var(--gray-light);
+}
+.hidden {
+  display: none !important;
+}
+.loading-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  background-image:
+    linear-gradient(#0006, #0006),
+    url("https://andrew-jacobson06.github.io/public-audio/stadium-gif.gif");
+  background-size: cover, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  background-color: #000;
+  transform-origin: center;
+}
+.logo-container {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  height: 40vh;
+}
+.loading-logo {
+  width: 30vw;
+  max-width: 150px;
+  opacity: 0;
+}
+.animate-left {
+  animation: clash-left 0.8s forwards;
+}
+.animate-right {
+  animation: clash-right 0.8s forwards;
+}
+.unclash-left {
+  animation: unclash-left 0.8s forwards;
+}
+.unclash-right {
+  animation: unclash-right 0.8s forwards;
+}
+@keyframes clash-left {
+  from {
+    transform: translateX(-200%);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@keyframes clash-right {
+  from {
+    transform: translateX(200%);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@keyframes unclash-left {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-200%);
+    opacity: 0;
+  }
+}
+@keyframes unclash-right {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(200%);
+    opacity: 0;
+  }
+}
+.exit-zoom {
+  animation: zoom-in 1.6s forwards;
+}
+@keyframes zoom-in {
+  from {
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: scale(3);
+    opacity: 0;
+  }
+}
+.loading-football {
+  position: absolute;
+  bottom: 4vw;
+  right: -3vw;
+  width: 40vw;
+  max-width: 200px;
+  transform: rotate(-45deg);
+}
+.app-loading {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #0b0b0b, #1c1c1c);
+  z-index: 300;
+  color: #fff;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+}
+.app-loading.hidden {
+  display: none;
+}
+.app-spinner {
+  width: 80px;
+  height: 80px;
+  border: 6px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: spin 1s linear infinite;
+  margin-bottom: 20px;
+}
+.app-football {
+  font-size: 32px;
+}
+.loading-text {
+  font-size: 1.2em;
+  letter-spacing: 2px;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
### Motivation
- Reintroduce the loading overlay and entrance/exit animations that were removed when navigating from the league list into a game so the click-into-game flow matches the original UI.
- Keep the league header/tabs hidden while the game is loading so the visual transition into `GameCenter` is identical to the previous behaviour.

### Description
- Added transient load state management to `LeagueAppScreen`: `loadingGame`, `isExitingGameLoad`, and `gameLoadTimeout` to sequence the entrance and exit animations before rendering `GameCenter`.
- Implemented `openGame` and `completeGameLoad` handlers and wired `LeagueSchedule` to call `openGame` when a card is clicked so the loading overlay shows with the selected teams' logos.
- Restored the loading overlay markup and all required styles/animations in `league.css` including logo clash/unclash animations, exit zoom, stadium background, and football GIF so the UI matches the original design.
- Added timer cleanup and a fallback timeout so the selected game will open even if `animationend` is missed.

### Testing
- Ran `npm run build` successfully to produce a production build (Vite build succeeded).
- Ran `npm run lint` successfully with no reported errors.
- Attempted to capture a screenshot with Playwright, but browser download failed (Playwright CDN returned a 403), so automated visual verification via Playwright could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a40440e961c832483d6f94a13880ed8)