### PR TITLE
Restore legacy play-caller modal UI

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -3,69 +3,55 @@ import type { LeagueGame } from "./types";
 import type { PlayCallOptions, FormationSlot } from "./gameplay/gameEngine";
 
 const str = (v: unknown) => String(v ?? "");
-const POSITIONS: FormationSlot[] = ["WR1", "TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5", "WR2", "WR3", "QB", "RB1", "RB2"];
+const LINE_SLOTS: FormationSlot[] = ["WR1", "TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5", "WR2", "WR3"];
 const REQUIRED = new Set<FormationSlot>(["QB", "TEOL2", "TEOL3", "TEOL4"]);
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
 
 type Player = Record<string, unknown>;
-type Props = {
-  game: LeagueGame;
-  players: Player[];
-  options: PlayCallOptions;
-  onOptionsChange: (next: PlayCallOptions) => void;
-  onAction: (label: string, options?: PlayCallOptions) => void;
-};
+type DefensiveAssignment = { position: string; player: string; align?: FormationSlot };
+type Props = { game: LeagueGame; players: Player[]; options: PlayCallOptions; onOptionsChange: (next: PlayCallOptions) => void; onAction: (label: string, options?: PlayCallOptions) => void; };
 
 function nameOf(p: Player) { return str(p.name ?? p.Name); }
 function posOf(p: Player) { return str(p.position ?? p.Pos).toUpperCase(); }
 function teamOf(p: Player) { return str(p.team ?? p.Team); }
-function canFill(slot: FormationSlot, p: Player) {
-  const pos = posOf(p);
-  if (slot === "QB") return pos.includes("QB");
-  if (slot.startsWith("RB")) return pos.includes("RB") || pos.includes("HB") || pos.includes("FB") || pos.includes("WR");
-  if (slot.startsWith("WR")) return pos.includes("WR") || pos.includes("TE");
-  return pos.includes("TE") || pos.includes("OL") || pos.includes("C") || pos.includes("G") || pos.includes("T");
-}
+function imgOf(p?: Player) { return str(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo); }
+function trait(p: Player | undefined, key: string) { return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0); }
+function ControlModal({ children, onClose, wide = false, full = false }: { children: React.ReactNode; onClose: () => void; wide?: boolean; full?: boolean }) { return <div className="game-modal open"><div className={`game-modal-panel formation-panel ${wide ? "routes-panel" : ""} ${full ? "formation-full-panel" : ""}`}><button className="close-button" onClick={onClose} type="button">×</button>{children}</div></div>; }
+function eligibleReceivers(formation: Partial<Record<FormationSlot, string>>) { const teols = (["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"] as FormationSlot[]).filter((s) => formation[s]); const edgeTe = teols.length > 1 ? [teols[0], teols[teols.length - 1]] : teols; return (["WR1", "WR2", "WR3", "RB1", "RB2", ...edgeTe] as FormationSlot[]).map((slot) => ({ slot, player: formation[slot] })).filter((x): x is { slot: FormationSlot; player: string } => Boolean(x.player)); }
+function PlayerBubble({ name, player, small = false }: { name?: string; player?: Player; small?: boolean }) { const src = imgOf(player); return <div className={`${small ? "los-player" : "player-circle-static"} ${name ? "" : "empty"}`}>{name && (src ? <img src={src} alt={name} /> : <span>👤</span>)}</div>; }
 
-function ControlModal({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
-  return <div className="game-modal open"><div className="game-modal-panel"><button className="close-button" onClick={onClose} type="button">×</button>{children}</div></div>;
-}
-
-function eligibleReceivers(formation: Partial<Record<FormationSlot, string>>) {
-  const teols = (["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"] as FormationSlot[]).filter((s) => formation[s]);
-  const edgeTe = teols.length > 1 ? [teols[0], teols[teols.length - 1]] : teols;
-  return (["WR1", "WR2", "WR3", "RB1", "RB2", ...edgeTe] as FormationSlot[]).map((slot) => ({ slot, player: formation[slot] })).filter((x): x is { slot: FormationSlot; player: string } => Boolean(x.player));
+function buildDefense(game: LeagueGame, players: Player[], formation: Partial<Record<FormationSlot, string>>): DefensiveAssignment[] {
+  const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
+  const defenders = players.filter((p) => teamOf(p) === defenseTeam);
+  const by = (d: string) => defenders.filter((p) => str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d).sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
+  const dbs = by("DB"), dls = by("DL"), lbs = by("LB"), safeties = by("S");
+  const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
+  const wrs = (["WR1", "WR2", "WR3"] as FormationSlot[]).filter((s) => formation[s]);
+  const ol = (["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"] as FormationSlot[]).filter((s) => formation[s]);
+  const out: DefensiveAssignment[] = [];
+  wrs.forEach((slot, i) => out.push({ position: `DB${i + 1}`, player: nameOf(take([dbs, lbs]) ?? {}), align: slot }));
+  ol.forEach((slot, i) => out.push({ position: `DL${i + 1}`, player: nameOf(take([dls, lbs]) ?? {}), align: slot }));
+  let remaining = Math.max(0, 7 - out.length);
+  (["QB", "RB1", "RB2"] as FormationSlot[]).slice(0, remaining).forEach((slot, i) => { const p = take([lbs, dls, dbs]); if (p) out.push({ position: `LB${i + 1}`, player: nameOf(p), align: slot }); });
+  remaining = Math.max(0, 7 - out.length); if (remaining) { const p = take([safeties, lbs, dbs, dls]); if (p) out.push({ position: "S", player: nameOf(p) }); }
+  return out;
 }
 
 export function GameControls({ game, players, options, onOptionsChange, onAction }: Props) {
-  const [collapsed, setCollapsed] = useState(false);
-  const [modal, setModal] = useState<"formation" | "los" | "routes" | "run" | "clock" | null>(null);
-  const offenseTeam = game.Possession === "Home" ? game.Home : game.Away;
-  const roster = useMemo(() => players.filter((p) => teamOf(p) === offenseTeam), [players, offenseTeam]);
-  const formation = options.formation ?? {};
-  const routes = options.routes ?? {};
-  const reads = options.reads ?? {};
-  const receivers = eligibleReceivers(formation);
-  const runners = (["QB", "RB1", "RB2", "WR1", "WR2", "WR3"] as FormationSlot[]).map((s) => formation[s]).filter((runner): runner is string => Boolean(runner));
-  const validFormation = [...REQUIRED].every((slot) => formation[slot]);
-  const canPass = receivers.some((r) => routes[r.player] && routes[r.player] !== "No Route");
-  const setOpt = (patch: Partial<PlayCallOptions>) => onOptionsChange({ ...options, ...patch });
-  const setFormation = (slot: FormationSlot, player: string) => setOpt({ formation: { ...formation, [slot]: player } });
-  const setRoute = (player: string, route: string) => setOpt({ routes: { ...routes, [player]: route } });
-  const setRead = (player: string, read: string) => setOpt({ reads: Object.fromEntries(Object.entries({ ...reads, [player]: read }).filter(([, v]) => v)) });
-  return <div className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}>
-    <button className="control-panel-toggle" type="button" onClick={() => setCollapsed(!collapsed)}>{collapsed ? "Open Play Caller" : "Collapse Play Caller"}</button>
-    {!collapsed && <>
-      <h3>{offenseTeam} Play Caller</h3>
-      <div className="game-controls"><button onClick={() => setModal("formation")}>Formation</button><button onClick={() => setModal("los")}>View LOS</button><button onClick={() => setModal("routes")}>Routes</button><button onClick={() => setModal("run")}>Run Modal</button><button onClick={() => setModal("clock")}>Clock</button></div>
-      <div className="play-call-summary"><span>{validFormation ? "Formation ready" : "Set required formation"}</span><span>Runner: {options.runner || "Auto"}</span><span>Clock: {options.clockMode || "Normal"}</span></div>
-      <div className="game-controls primary"><button disabled={!validFormation} onClick={() => onAction("Run Play", options)}>Run Play</button><button disabled={!validFormation || !canPass} onClick={() => onAction("Pass Play", options)}>Pass Play</button><button onClick={() => onAction("Field Goal", options)}>FG</button><button onClick={() => onAction("Punt", options)}>Punt</button><button onClick={() => onAction("Two Point", options)}>2PT</button><button onClick={() => onAction("Timeout", options)}>Timeout</button></div>
-    </>}
-    {modal === "formation" && <ControlModal onClose={() => setModal(null)}><h3>Formation</h3><div className="formation-grid">{POSITIONS.map((slot) => <label className={`formation-picker ${REQUIRED.has(slot) ? "required" : ""}`} key={slot}><span>{slot}</span><select value={formation[slot] || ""} onChange={(e) => setFormation(slot, e.target.value)}><option value="">Empty</option>{roster.filter((p) => canFill(slot, p)).map((p) => <option key={nameOf(p)} value={nameOf(p)}>{nameOf(p)} ({posOf(p)})</option>)}</select></label>)}</div></ControlModal>}
-    {modal === "los" && <ControlModal onClose={() => setModal(null)}><h3>Line of Scrimmage</h3><div className="los-preview"><div className="los-defense">Defense auto-matches your eligible receivers and line.</div><div className="los-line-react" />{(["WR1", "TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5", "WR2", "WR3"] as FormationSlot[]).map((s) => <div className="los-token" key={s}><strong>{s}</strong><span>{formation[s] || "—"}</span></div>)}<div className="los-backfield"><span>QB: {formation.QB || "—"}</span><span>RB1: {formation.RB1 || "—"}</span><span>RB2: {formation.RB2 || "—"}</span></div></div></ControlModal>}
-    {modal === "routes" && <ControlModal onClose={() => setModal(null)}><h3>Route Modal</h3><div className="route-list">{receivers.map(({ player }, i) => <div className="route-row" key={player}><strong>{player}</strong><select value={routes[player] || "Short"} onChange={(e) => setRoute(player, e.target.value)}>{ROUTES.map((r) => <option key={r}>{r}</option>)}</select><select value={reads[player] || READS[i] || ""} onChange={(e) => setRead(player, e.target.value)}><option value="">No read</option>{READS.map((r) => <option key={r}>{r}</option>)}</select></div>)}</div></ControlModal>}
-    {modal === "run" && <ControlModal onClose={() => setModal(null)}><h3>Run Play</h3><div className="rusher-options">{runners.map((r) => <button className={`rusher-option ${options.runner === r ? "selected" : ""}`} onClick={() => setOpt({ runner: r })} type="button" key={r}>👤<span>{r}</span></button>)}</div><button disabled={!validFormation} onClick={() => { setModal(null); onAction("Run Play", options); }}>Execute Run</button></ControlModal>}
+  const [collapsed, setCollapsed] = useState(false); const [modal, setModal] = useState<"formation" | "los" | "routes" | "run" | "clock" | null>(null); const [selected, setSelected] = useState<string>(""); const [detail, setDetail] = useState<string>("");
+  const offenseTeam = game.Possession === "Home" ? game.Home : game.Away; const roster = useMemo(() => players.filter((p) => teamOf(p) === offenseTeam), [players, offenseTeam]); const byName = (n?: string) => players.find((p) => nameOf(p) === n);
+  const formation = options.formation ?? {}; const routes = options.routes ?? {}; const reads = options.reads ?? {}; const receivers = eligibleReceivers(formation); const runners = (["QB", "RB1", "RB2", "WR1", "WR2", "WR3"] as FormationSlot[]).map((s) => formation[s]).filter((r): r is string => Boolean(r));
+  const validFormation = [...REQUIRED].every((slot) => formation[slot]); const canPass = receivers.some((r) => routes[r.player] && routes[r.player] !== "No Route"); const setOpt = (patch: Partial<PlayCallOptions>) => onOptionsChange({ ...options, ...patch });
+  const putPlayer = (slot: FormationSlot, player: string) => { const next = Object.fromEntries(Object.entries(formation).filter(([, v]) => v !== player)) as Partial<Record<FormationSlot, string>>; if (player) next[slot] = player; setOpt({ formation: next }); setSelected(""); };
+  const bench = roster.filter((p) => !Object.values(formation).includes(nameOf(p)));
+  const setRouteAndRead = (player: string, route: string, index: number) => { const nextRoutes = { ...routes, [player]: route }; const active = receivers.filter((r) => r.player !== player || route !== "No Route"); const nextReads: Record<string, string> = {}; active.forEach((r, i) => { nextReads[r.player] = READS[i] || ""; }); if (route !== "No Route") nextReads[player] = READS[Math.min(index, READS.length - 1)] || ""; setOpt({ routes: nextRoutes, reads: nextReads }); };
+  const defense = buildDefense(game, players, formation);
+  return <div className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}><button className="control-panel-toggle" type="button" onClick={() => setCollapsed(!collapsed)}>{collapsed ? "Open Play Caller" : "Collapse Play Caller"}</button>{!collapsed && <><h3>{offenseTeam} Play Caller</h3><div className="game-controls"><button onClick={() => setModal("formation")}>Formation</button><button onClick={() => setModal("los")}>View LOS</button><button onClick={() => setModal("routes")}>Routes</button><button onClick={() => setModal("run")}>Run Modal</button><button onClick={() => setModal("clock")}>Clock</button></div><div className="play-call-summary"><span>{validFormation ? "Formation ready" : "Set required formation"}</span><span>Runner: {options.runner || "Auto"}</span><span>Clock: {options.clockMode || "Normal"}</span></div><div className="game-controls primary"><button disabled={!validFormation} onClick={() => onAction("Run Play", options)}>Run Play</button><button disabled={!validFormation || !canPass} onClick={() => onAction("Pass Play", options)}>Pass Play</button><button onClick={() => onAction("Field Goal", options)}>FG</button><button onClick={() => onAction("Punt", options)}>Punt</button><button onClick={() => onAction("Two Point", options)}>2PT</button><button onClick={() => onAction("Timeout", options)}>Timeout</button></div></>}
+    {modal === "formation" && <ControlModal full onClose={() => setModal(null)}><h3>Offensive Formation</h3><div className="formation-field"><div className="formation-row top-row">{LINE_SLOTS.map((slot) => <div key={slot} className={`formation-slot ${slot.startsWith("WR") ? "wr" : "teol"} ${REQUIRED.has(slot) ? "required" : ""} ${formation[slot] ? "filled" : ""}`} data-label={slot} onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer(slot, e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer(slot, selected)}>{formation[slot] && <div draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", formation[slot] || "")}><PlayerBubble name={formation[slot]} player={byName(formation[slot])} /></div>}</div>)}</div><div className="formation-row middle-row"><div className={`formation-slot qb required ${formation.QB ? "filled" : ""}`} data-label="QB" onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer("QB", e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer("QB", selected)}>{formation.QB && <PlayerBubble name={formation.QB} player={byName(formation.QB)} />}</div></div><div className="formation-row bottom-row">{(["RB1", "RB2"] as FormationSlot[]).map((slot) => <div key={slot} className={`formation-slot rb ${formation[slot] ? "filled" : ""}`} data-label={slot} onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer(slot, e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer(slot, selected)}>{formation[slot] && <PlayerBubble name={formation[slot]} player={byName(formation[slot])} />}</div>)}</div></div><div className="bench-wrapper"><h4>Bench</h4><div className="bench">{bench.map((p) => <button type="button" draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", nameOf(p))} onClick={() => setSelected(selected === nameOf(p) ? "" : nameOf(p))} className={`player-item ${selected === nameOf(p) ? "selected" : ""}`} key={nameOf(p)}><span className="player-name">{nameOf(p)}</span><span>{posOf(p)}</span></button>)}</div></div><div className="formation-actions"><button onClick={() => setOpt({ formation: {}, routes: {}, reads: {} })}>Clear</button><button disabled={!validFormation} onClick={() => setModal(null)}>Save</button></div></ControlModal>}
+    {modal === "los" && <ControlModal wide onClose={() => setModal(null)}><h3>Line of Scrimmage</h3><div className="los-field"><div className="los-line" /><div className="los-row">{defense.filter((d) => d.position.startsWith("S")).map((d) => <PlayerBubble key={d.position} small name={d.player} player={byName(d.player)} />)}</div><div className="los-row">{defense.filter((d) => d.position.startsWith("LB") && !d.align?.startsWith("R") && d.align !== "QB").map((d) => <PlayerBubble key={d.position} small name={d.player} player={byName(d.player)} />)}</div><div className="los-grid">{LINE_SLOTS.map((slot) => <div className="los-col" key={slot}><PlayerBubble small name={defense.find((d) => d.align === slot)?.player} player={byName(defense.find((d) => d.align === slot)?.player)} /><PlayerBubble small name={formation[slot]} player={byName(formation[slot])} /></div>)}</div><div className="los-row"><PlayerBubble small name={formation.QB} player={byName(formation.QB)} /></div><div className="los-row">{(["RB1", "RB2"] as FormationSlot[]).map((s) => <PlayerBubble key={s} small name={formation[s]} player={byName(formation[s])} />)}</div></div></ControlModal>}
+    {modal === "routes" && <ControlModal wide onClose={() => setModal(null)}><h3>Receiver Routes</h3><div className="routes-board">{ROUTES.map((r, i) => <div className="route-zone" key={r}><span>{r}</span>{receivers.map(({ player }, idx) => (routes[player] || "Short") === r && <button type="button" draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", player)} onClick={() => setDetail(detail === player ? "" : player)} className="player-circle" style={{ left: `${idx * 100 + 8}px` }} key={player}><span className="read-badge">{routes[player] === "No Route" ? "" : reads[player] || READS[idx]}</span><PlayerBubble name={player} player={byName(player)} /></button>)}<div className="route-drop" onDragOver={(e) => e.preventDefault()} onDrop={(e) => setRouteAndRead(e.dataTransfer.getData("text/plain"), r, i)} /></div>)}</div>{detail && <div className="player-detail"><h4>{detail}</h4><div>Size: {trait(byName(detail), "size")}</div><div>Speed: {trait(byName(detail), "speed")}</div><div>RR: {trait(byName(detail), "routeRunning")}</div><div>JMP: {trait(byName(detail), "jump")}</div><div>HND: {trait(byName(detail), "hands")}</div></div>}<div className="read-summary"><div className="summary-title">Read Summary:</div>{READS.map((r) => { const player = Object.keys(reads).find((p) => reads[p] === r); return <div className="summary-row" key={r}><span className="summary-label">{r}:</span><span>{player ? `${player} - ${routes[player] || ""}` : ""}</span></div>; })}</div><div className="formation-actions"><button onClick={() => setOpt({ routes: {}, reads: {} })}>Clear</button><button onClick={() => setModal(null)}>Save</button></div></ControlModal>}
+    {modal === "run" && <ControlModal onClose={() => setModal(null)}><h3>Run Play</h3><div className="rusher-options">{runners.map((r) => <button className={`rusher-option ${options.runner === r ? "selected" : ""}`} onClick={() => setOpt({ runner: r })} type="button" key={r}><PlayerBubble name={r} player={byName(r)} /><span>{r}</span></button>)}</div><button disabled={!validFormation} onClick={() => { setModal(null); onAction("Run Play", options); }}>Execute Run</button></ControlModal>}
     {modal === "clock" && <ControlModal onClose={() => setModal(null)}><h3>Manage Clock</h3><div className="clock-options">{["Normal", "Hurry Up", "Chew Clock"].map((c) => <button className={options.clockMode === c ? "active" : ""} onClick={() => setOpt({ clockMode: c as PlayCallOptions["clockMode"] })} key={c}>{c}</button>)}<button onClick={() => onAction("Spike", options)}>Spike Ball</button><button onClick={() => onAction("Kneel", options)}>Kneel</button></div></ControlModal>}
   </div>;
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1140,3 +1140,49 @@
 .clock-options { display: grid; gap: 12px; }
 .clock-options .active { background: var(--accent-red); }
 @media (max-width: 700px) { .route-row { grid-template-columns: 1fr; } .los-preview { grid-template-columns: repeat(2, 1fr); } }
+
+/* Legacy-style play caller modals */
+.formation-full-panel { width: 100%; height: 100%; max-width: none; border-radius: 0; overflow: auto; }
+.formation-panel { background: var(--gray-light); }
+.formation-field { margin-bottom: 4vw; overflow-x: auto; min-width: 720px; }
+.formation-row { display: flex; justify-content: center; align-items: center; gap: 2vw; margin-bottom: 4vw; }
+.formation-row.top-row { justify-content: center; }
+.formation-slot { flex: 0 0 clamp(60px, 8vw, 90px); width: clamp(60px, 8vw, 90px); height: clamp(60px, 8vw, 90px); border: 2px dotted var(--text-muted); border-radius: 50%; background: var(--gray-dark); display: flex; align-items: center; justify-content: center; font-size: clamp(12px, 2vw, 18px); font-weight: 500; position: relative; color: var(--text-muted); overflow: hidden; cursor: pointer; }
+.formation-slot::before { content: attr(data-label); }
+.formation-slot.filled::before { content: ''; }
+.formation-slot.qb { border-color: #64b5f6; color: #64b5f6; }
+.formation-slot.rb { border-color: #81c784; color: #81c784; }
+.formation-slot.wr { border-color: #ffb74d; color: #ffb74d; }
+.formation-slot.teol { border-color: #ba68c8; color: #ba68c8; }
+.formation-slot.required::after { content: '*'; color: var(--accent-red); margin-left: 0.2em; font-size: 1.2em; }
+.formation-slot.filled { border-style: solid; }
+.formation-slot.filled::after { content: ''; }
+.formation-slot > div { width: 100%; height: 100%; }
+.bench { display: flex; flex-wrap: wrap; gap: 2vw; }
+.player-item { flex: 1 1 calc(50% - 2vw); max-width: calc(50% - 2vw); border: 2px solid var(--text-muted); border-radius: 8px; background: var(--gray-dark); padding: 1vw; display: flex; flex-direction: column; gap: 0.5vw; font-size: clamp(12px, 2vw, 18px); font-weight: 500; color: var(--text-light); cursor: grab; text-align: left; }
+.player-item.selected { border-color: var(--accent-red); border-width: 4px; }
+.player-name { font-weight: 700; }
+.player-circle-static { width: 100%; height: 100%; background: #fff; color: #000; border-radius: 50%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.player-circle-static img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
+.routes-panel { max-height: 90vh; overflow-y: auto; max-width: 95vw; width: 95vw; }
+.routes-board { margin-bottom: 4vw; position: relative; height: 60vh; min-height: 480px; background: #2e7d32; border: 2px solid #fff; overflow: hidden; display: flex; flex-direction: column-reverse; }
+.route-zone { position: relative; flex: 1; border-top: 2px solid #fff; }
+.route-zone > span { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: clamp(42px, 10vw, 130px); color: rgba(255,255,255,0.2); text-transform: uppercase; pointer-events: none; z-index: 0; }
+.route-drop { position: absolute; inset: 0; z-index: 1; }
+.player-circle { position: absolute; top: 50%; transform: translateY(-50%); width: clamp(60px, 8vw, 90px); height: clamp(60px, 8vw, 90px); padding: 0; border: 0; background: transparent; color: #000; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: grab; box-shadow: 0 2px 4px rgba(0,0,0,0.3); touch-action: none; z-index: 2; overflow: visible; }
+.player-circle:active { cursor: grabbing; }
+.player-circle .read-badge { position: absolute; top: 0; right: 0; transform: translate(10%, -50%); background: var(--accent-red); color: #fff; border-radius: 4px; padding: 0.25rem 0.4rem; font-size: clamp(12px, 1.6vw, 20px); z-index: 3; }
+.read-summary { background: #fff; color: #000; border-radius: 6px; padding: 2vw; margin: 2vw 0; font-size: clamp(14px, 2.5vw, 24px); }
+.read-summary .summary-row { display: flex; gap: 1vw; }
+.read-summary .summary-label { width: 30%; font-weight: 600; }
+.player-detail { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #fff; color: #000; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.5); padding: 2vw; z-index: 2001; font-size: clamp(14px, 2.5vw, 24px); }
+.los-field { background: #2e7d32; padding: 2vw; position: relative; display: flex; flex-direction: column; align-items: center; gap: 1vw; min-height: 520px; }
+.los-line { position: absolute; top: 50%; left: 0; width: 100%; height: 4px; background: #1565c0; }
+.los-row { display: flex; justify-content: center; gap: 1vw; width: 100%; min-height: 80px; z-index: 1; }
+.los-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 1vw; width: 100%; z-index: 1; }
+.los-col { display: flex; flex-direction: column; align-items: center; gap: 1vw; }
+.los-player { width: clamp(52px, 7vw, 86px); height: clamp(52px, 7vw, 86px); background: transparent; border-radius: 50%; overflow: hidden; display: flex; align-items: flex-start; justify-content: center; color: #fff; }
+.los-player img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
+.los-player.empty { visibility: hidden; }
+.formation-actions { display: flex; justify-content: flex-end; gap: 2vw; }
+@media (max-width: 700px) { .formation-field { min-width: 620px; } .routes-board { min-height: 420px; } .player-item { max-width: 100%; flex-basis: 100%; } }


### PR DESCRIPTION
### Motivation
- Restore the legacy formation / LOS / routes UX that existed in the old front-end so the new React controls behave identically to the previous implementation. 

### Description
- Reworked the play-caller React UI to reintroduce full-screen formation builder with bench, click/drag placement, and required-slot enforcement in `apps/web/src/components/league/GameControls.tsx`.
- Reimplemented the routes modal as a zone-based routes board with draggable player circles, drop-to-assign routes, read badges, player detail card, and read summary logic in `GameControls.tsx`.
- Recreated LOS rendering and automated defensive assignment generation (matching legacy `setDefensiveFormation` logic) and player image bubbles in `GameControls.tsx`.
- Added legacy-style CSS for full-screen formation modal, routes field, player circles, read summary, LOS grid and player bubbles in `apps/web/src/components/league/league.css`.

### Testing
- Ran `npm install` in `apps/web` (dependencies installed successfully). 
- Built the web app with `npm run build` in `apps/web` and the TypeScript + Vite production build completed successfully. 
- Verified no TypeScript build errors and that the new UI assets compiled into `dist` (Vite build output produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a40543fccdc832497798b13d07eb2dc)