### PR TITLE
Load frontend settings into game engine and use them for run outcomes

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -7,13 +7,32 @@ import { GameField } from "./GameField";
 import { GameControls } from "./GameControls";
 import { GameLog } from "./GameLog";
 import { goForTwo, handleTimeout, kickFG, kneel, passPlay, punt, runPlay, spikeBall } from "./gameplay/gameEngine";
-import type { PlayCallOptions } from "./gameplay/gameEngine";
+import type { FrontendSettings, PlayCallOptions } from "./gameplay/gameEngine";
 
 type Play = Record<string, unknown>;
 type Stat = { playername: string; team: string; attempts?: number; completions?: number; yards: number; tds?: number; ints?: number; carries?: number; receptions?: number; targets?: number; sacks?: number; sackYds?: number; tackles?: number; tfl?: number; ff?: number; fr?: number; deflections?: number; fumbles?: number; long?: number };
 const str = (v: unknown) => String(v ?? "");
 const num = (v: unknown) => Number(v) || 0;
 const playField = (p: Play, ...keys: string[]) => keys.map((k) => p[k]).find((v) => v !== undefined && v !== null && v !== "");
+
+
+function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendSettings {
+  const normalized = settings as FrontendSettings;
+  normalized.drainSettings = normalized.drainSettings ?? normalized.staminaDrains;
+  normalized.tackleSettings = normalized.tackleSettings ?? normalized.tackleTable;
+  normalized.timeNeededToOpen = normalized.timeNeededToOpen ?? normalized.timeNeededToThrow;
+  normalized.thresholds = Array.isArray(normalized.thresholds) ? normalized.thresholds : [];
+  normalized.breakaways = Array.isArray(normalized.breakaways) ? normalized.breakaways : [];
+  normalized.staminaDrains = normalized.staminaDrains ?? {};
+  normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
+  normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];
+  normalized.routeTypeAirYards = Array.isArray(normalized.routeTypeAirYards) ? normalized.routeTypeAirYards : [];
+  normalized.timeNeededToThrow = Array.isArray(normalized.timeNeededToThrow) ? normalized.timeNeededToThrow : [];
+  normalized.completionSeparationAdjustment = Array.isArray(normalized.completionSeparationAdjustment) ? normalized.completionSeparationAdjustment : [];
+  normalized.yacBySeparation = normalized.yacBySeparation ?? {};
+  normalized.sackLossTable = Array.isArray(normalized.sackLossTable) ? normalized.sackLossTable : [];
+  return normalized;
+}
 
 function normalizeGame(game: LeagueGame, state: Record<string, unknown> | null): LeagueGame {
   if (!state) return game;
@@ -180,8 +199,8 @@ function LeaderCard({ game, history, players, setTab }: { game: LeagueGame; hist
 }
 function ScoreChart({ game, history }: { game: LeagueGame; history: Play[] }) { const { home, away } = scoreByQuarter(history, game); return <div className="score-chart"><table><thead><tr><th></th><th>1</th><th>2</th><th>3</th><th>4</th><th>T</th></tr></thead><tbody><tr><td className="team-cell"><img src={game.HomeLogo} className="team-logo-small" alt="" /><span>{game.Home}</span></td>{home.map((s, i) => <td key={i}>{s}</td>)}<td className="total-cell">{game.HomeScore}</td></tr><tr><td className="team-cell"><img src={game.AwayLogo} className="team-logo-small" alt="" /><span>{game.Away}</span></td>{away.map((s, i) => <td key={i}>{s}</td>)}<td className="total-cell">{game.AwayScore}</td></tr></tbody></table></div>; }
 export function GameCenter({ game, onBack }: { game: LeagueGame; onBack: () => void }) {
-  const [tab, setTab] = useState<GameTab>("gamecast"); const [currentGame, setCurrentGame] = useState(game); const [history, setHistory] = useState<Play[]>([]); const [players, setPlayers] = useState<Play[]>([]); const [settings, setSettings] = useState<Record<string, unknown>>({}); const [playOptions, setPlayOptions] = useState<PlayCallOptions>({ clockMode: "Normal", formation: {}, routes: {}, reads: {} }); const [log, setLog] = useState(["Loading game state, play history, players, and frontend settings..."]); const ctx = useMemo(() => ({ players, settings, historyLength: history.length }), [players, settings, history.length]);
-  useEffect(() => { let active = true; Promise.all([getGameState(game.GameId), getPlayHistory(game.GameId), getPlayerTraits(), getFrontendSettings()]).then(([stateRes, historyRes, playerRes, settingsRes]) => { if (!active) return; setCurrentGame(normalizeGame(game, stateRes.gameState)); setHistory(historyRes.plays); setPlayers(playerRes.players); setSettings(settingsRes); setLog(historyRes.plays.length ? historyRes.plays.slice(-20).reverse().map((play) => playText(play)) : ["Game loaded. No prior play history found."]); }).catch((error: unknown) => setLog((l) => [`Failed to load live game data: ${error instanceof Error ? error.message : String(error)}`, ...l])); return () => { active = false; }; }, [game]);
+  const [tab, setTab] = useState<GameTab>("gamecast"); const [currentGame, setCurrentGame] = useState(game); const [history, setHistory] = useState<Play[]>([]); const [players, setPlayers] = useState<Play[]>([]); const [settings, setSettings] = useState<FrontendSettings>(normalizeFrontendSettings({})); const [playOptions, setPlayOptions] = useState<PlayCallOptions>({ clockMode: "Normal", formation: {}, routes: {}, reads: {} }); const [log, setLog] = useState(["Loading game state, play history, players, and frontend settings..."]); const ctx = useMemo(() => ({ players, settings, historyLength: history.length }), [players, settings, history.length]);
+  useEffect(() => { let active = true; Promise.all([getGameState(game.GameId), getPlayHistory(game.GameId), getPlayerTraits(), getFrontendSettings()]).then(([stateRes, historyRes, playerRes, settingsRes]) => { if (!active) return; setCurrentGame(normalizeGame(game, stateRes.gameState)); setHistory(historyRes.plays); setPlayers(playerRes.players); setSettings(normalizeFrontendSettings(settingsRes)); setLog(historyRes.plays.length ? historyRes.plays.slice(-20).reverse().map((play) => playText(play)) : ["Game loaded. No prior play history found."]); }).catch((error: unknown) => setLog((l) => [`Failed to load live game data: ${error instanceof Error ? error.message : String(error)}`, ...l])); return () => { active = false; }; }, [game]);
   const persist = async (result: ReturnType<typeof runPlay>) => { setCurrentGame(result.game); setHistory((h) => [...h, result.play]); setLog((l) => [result.text, ...l]); const gamePayload = { gameId: result.game.GameId, quarter: result.game.Qtr, time: result.game.Time, down: result.game.Down, distance: result.game.Distance, ballOn: result.game.BallOn, homeScore: result.game.HomeScore, awayScore: result.game.AwayScore, driveStart: (result.game as unknown as Record<string, unknown>).DriveStart, previous: currentGame.BallOn, possession: result.game.Possession, homeTimeouts: (result.game as unknown as Record<string, unknown>).HomeTimeouts, awayTimeouts: (result.game as unknown as Record<string, unknown>).AwayTimeouts }; try { await savePlayAndGame(result.game.GameId, { play: result.play, game: gamePayload }); } catch (error) { setLog((l) => [`Save failed: ${error instanceof Error ? error.message : String(error)}`, ...l]); } };
   const action = (label: string, options: PlayCallOptions = playOptions) => { if (label === "Run Play") void persist(runPlay(currentGame, ctx, options)); else if (label === "Pass Play") void persist(passPlay(currentGame, ctx, options)); else if (label === "Field Goal") void persist(kickFG(currentGame, ctx)); else if (label === "Punt") void persist(punt(currentGame, ctx)); else if (label === "Two Point") void persist(goForTwo(currentGame, ctx)); else if (label === "Timeout") void persist(handleTimeout(currentGame, ctx)); else if (label === "Spike") void persist(spikeBall(currentGame, ctx)); else if (label === "Kneel") void persist(kneel(currentGame, ctx, options)); };
   const drivePlays = history.filter((p) => str(playField(p, "Possession", "possession")) === currentGame.Possession).length; const driveYards = currentGame.Possession === "Home" ? num(currentGame.BallOn) - num((currentGame as unknown as Play).DriveStart) : num((currentGame as unknown as Play).DriveStart) - num(currentGame.BallOn); const lastPlay = history.length ? playText(history[history.length - 1]) : "";

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -1,5 +1,5 @@
 import type { LeagueGame } from "../../types";
-import type { EngineContext, PlayCallOptions } from "./types";
+import type { EngineContext, FrontendSettings, PlayCallOptions, RunBreakawaySetting, RunThreshold } from "./types";
 import { advanceBall, advanceQuarter, byName, byPosition, choose, clockRunoff, defenseTeam, isSafety, isTouchdown, n, nextDownDistance, offenseTeam, playerName, switchPoss, teamPlayers, trait, weightedChoose } from "./utils";
 import { buildResult } from "./playLogger";
 
@@ -18,7 +18,14 @@ export function checkForFumble(ctx: EngineContext, runnerName: string, tacklerNa
   const defStars = trait(defender, "defStars", 50), offStars = trait(runner, "offStars", 50);
   return { fumble: true, recoveredBy: Math.random() * (defStars + offStars) < offStars ? runnerName : tacklerName };
 }
-export function simulateSingleCarry(stats: { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean }) {
+type CarryStats = { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean; settings?: FrontendSettings };
+
+function settingArray<T>(settings: FrontendSettings | undefined, key: keyof FrontendSettings): T[] {
+  const value = settings?.[key];
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+export function simulateSingleCarry(stats: CarryStats) {
   const modLog: string[] = [];
   //if auto stuff, -3 > 2 yards is the range +1 yard for straight up check against each vision and strength
   if (stats.autoStuff) {
@@ -98,7 +105,7 @@ function applyTraitEffect(traitName: string, traitValue: number, condition: Bool
 }
 
 //Strength check, size check - size + strength/2.2 chance of avoiding loss and turning into 1-2 yard gain
-export function maybeAvoidLoss(yards: number, stats: { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean }, modLog: string[]) {
+export function maybeAvoidLoss(yards: number, stats: CarryStats, modLog: string[]) {
   if (yards < 0) {
     const power = trait(stats.runner, "size") + trait(stats.runner, "strength") + Math.min(0, trait(stats.runner, "fatigue"));
     const chanceToAvoid = power / 2.2; //CHANGE - no hard code
@@ -116,7 +123,7 @@ export function maybeAvoidLoss(yards: number, stats: { name: string; runner?: Re
 //  for 80: add 2 yard
 //  for 90: add 3 yard
 //  for 100: add 4 yard
-export function adjustChunkRunForSpeed(yards: number, stats: { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean }, modLog: string[], yac: boolean) {
+export function adjustChunkRunForSpeed(yards: number, stats: CarryStats, modLog: string[], yac: boolean) {
     if (yac && yards >= 5){
       const bonus = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) / 5); //CHANGE no hard code
       if (bonus !== 0) modLog.push(`Yard ${bonus > 0 ? "+" : ""}${bonus} Speed`);
@@ -130,10 +137,11 @@ export function adjustChunkRunForSpeed(yards: number, stats: { name: string; run
     return yards;
   }
 
-export function getYardageOutcome(roll: number, stats: { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean }, modLog: string[]) {
+export function getYardageOutcome(roll: number, stats: CarryStats, modLog: string[]) {
   if (roll >= 100){
     return getStrictBreakawayYards(stats, modLog);
   }
+  const rollThresholds = settingArray<RunThreshold>(stats.settings, "thresholds");
   for (const r of rollThresholds) {
     if (roll >= r.rollMin && roll < r.rollMax) {
       if (r.label === "RunType_Breakaway") {
@@ -146,13 +154,14 @@ export function getYardageOutcome(roll: number, stats: { name: string; runner?: 
 }
 
 //Speed Check -
-export function getStrictBreakawayYards(stats: { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean }, modLog: string[]) {
+export function getStrictBreakawayYards(stats: CarryStats, modLog: string[]) {
   const baseRoll = Math.floor(Math.random() * 100);
   const speedBoost = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.3);
   const adjustedRoll = Math.min(100, baseRoll + Math.max(0, speedBoost));
   if (speedBoost !== 0) modLog.push(`Pre +${speedBoost} Speed`);
 
   let cumulative = 0;
+  const breakawaySettings = settingArray<RunBreakawaySetting>(stats.settings, "breakaways");
   for (const range of breakawaySettings) {
     if (adjustedRoll >= 100){
       return randomInt(81, 100);
@@ -247,7 +256,7 @@ export function rollDefStarPower(ctx: EngineContext, defense: string) {
 //NEEDS TRansition TO THIS CLASS
 export function runBlockVsRunDef(
   ctx: EngineContext,
-  offense: string,
+  _offense: string,
   defense: string,
   formation: Record<string, string | undefined>,
   ballCarrierName: string
@@ -395,7 +404,8 @@ export function runPlay(game: LeagueGame, ctx: EngineContext, options: PlayCallO
     offStar: offStarPower, 
     defStar: defStarPower, 
     autoStuff: autoStuffVal, 
-    autoRelease: autoReleaseVal 
+    autoRelease: autoReleaseVal,
+    settings: ctx.settings
   });
 
   const newBall = advanceBall(game, carry.yards);

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -11,9 +11,26 @@ export type PlayCallOptions = {
   clockMode?: ClockMode;
 };
 export type PlayerTrait = Record<string, unknown>;
+export type RunThreshold = { label: string; minYards: number; maxYards: number; rollMin: number; rollMax: number };
+export type RunBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
+export type FrontendSettings = Record<string, unknown> & {
+  thresholds?: RunThreshold[];
+  breakaways?: RunBreakawaySetting[];
+  staminaDrains?: Record<string, number>;
+  drainSettings?: Record<string, number>;
+  tackleTable?: unknown[];
+  tackleSettings?: unknown[];
+  completionTable?: unknown[];
+  routeTypeAirYards?: unknown[];
+  timeNeededToThrow?: unknown[];
+  timeNeededToOpen?: unknown[];
+  completionSeparationAdjustment?: unknown[];
+  yacBySeparation?: Record<string, unknown>;
+  sackLossTable?: unknown[];
+};
 export type EngineContext = {
   players: PlayerTrait[];
-  settings: Record<string, unknown>;
+  settings: FrontendSettings;
   historyLength: number;
 };
 export type PlayResult = {

--- a/apps/web/src/components/league/gameplay/gameEngine.ts
+++ b/apps/web/src/components/league/gameplay/gameEngine.ts
@@ -1,4 +1,4 @@
-export type { PlayKind, FormationSlot, PlayCallOptions, EngineContext } from "./engine/types";
+export type { PlayKind, FormationSlot, PlayCallOptions, EngineContext, FrontendSettings } from "./engine/types";
 export { runPlay, simulateSingleCarry, determineTackler, checkForFumble } from "./engine/runEngine";
 export { passPlay, determineTimeToThrow, handleSack, assignRoutes, determineSeparation, choosePassTarget, determineCompletionPct, determinePassOutcome, calcYAC } from "./engine/passEngine";
 export { punt, kickFG, goForTwo, handleTimeout, spikeBall, kneel } from "./engine/specialTeamsEngine";


### PR DESCRIPTION
### Motivation
- Ensure the gameplay engine always receives the same static frontend settings that the legacy code provided so run thresholds, breakaway ranges, stamina drains and other static tables are available to the new engine.
- Preserve compatibility with legacy aliases like `staminaDrains`/`drainSettings`, `tackleTable`/`tackleSettings`, and `timeNeededToThrow`/`timeNeededToOpen` so existing sheet payloads work unchanged.

### Description
- Added a typed `FrontendSettings` shape and related types (`RunThreshold`, `RunBreakawaySetting`) in `engine/types.ts` to represent all legacy settings including `thresholds`, `breakaways`, `staminaDrains`/`drainSettings`, `tackleTable`/`tackleSettings`, `completionTable`, `routeTypeAirYards`, `timeNeededToThrow`/`timeNeededToOpen`, `completionSeparationAdjustment`, `yacBySeparation`, and `sackLossTable`.
- Normalized the server `getFrontendSettings()` response in the UI by adding `normalizeFrontendSettings()` to `GameCenter.tsx` and switched the engine context to hold `FrontendSettings` so settings are always initialized and alias-compatible.
- Updated the run engine (`runEngine.ts`) to accept settings for carry simulation by introducing `CarryStats`, a helper `settingArray<T>()`, and passing `ctx.settings` into `simulateSingleCarry()`; the carry/outcome logic now pulls `thresholds` and `breakaways` from `settings` instead of relying on globals.
- Re-exported `FrontendSettings` from the gameplay barrel (`gameEngine.ts`) so UI and engine code share the same settings contract.

### Testing
- Ran `npm install` in `apps/web` to ensure dependencies were present and `npm run build` to run a full TypeScript/Vite build; the build completed successfully.
- Ran `git diff --check` to validate there are no whitespace/format issues; the check passed.
- Verified the modified files compile under the app build: `apps/web/src/components/league/GameCenter.tsx`, `apps/web/src/components/league/gameplay/engine/runEngine.ts`, `apps/web/src/components/league/gameplay/engine/types.ts`, and `apps/web/src/components/league/gameplay/gameEngine.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a40a022fb2c8324bf105b97a97e749e)