### PR TITLE
Fix run play field animations

### DIFF
--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -147,14 +147,21 @@
 .play-line {
   background-color: #333;
   border-radius: 0;
-  animation: grow-line 2s forwards;
+  animation: grow-line 1.4s ease forwards;
+}
+
+.play-line--right {
+  transform-origin: left center;
+}
+
+.play-line--left {
+  transform-origin: right center;
 }
 
 .play-line::before {
   content: "";
   position: absolute;
   top: 50%;
-  left: -10px;
   transform: translateY(-50%);
   width: 12px;
   height: 12px;
@@ -162,15 +169,31 @@
   border-radius: 50%;
 }
 
+.play-line--right::before {
+  left: -10px;
+}
+
+.play-line--left::before {
+  right: -10px;
+}
+
 .play-line::after {
   content: "";
   position: absolute;
   top: 50%;
-  right: -10px;
   transform: translateY(-50%);
   border-top: clamp(6px, 3vw, 9px) solid transparent;
   border-bottom: clamp(6px, 3vw, 9px) solid transparent;
+}
+
+.play-line--right::after {
+  right: -10px;
   border-left: clamp(12px, 3vw, 18px) solid #333;
+}
+
+.play-line--left::after {
+  left: -10px;
+  border-right: clamp(12px, 3vw, 18px) solid #333;
 }
 
 .arc-container {
@@ -181,12 +204,10 @@
 @keyframes grow-line {
   from {
     transform: translateY(-50%) scaleX(0);
-    transform-origin: left center;
   }
 
   to {
     transform: translateY(-50%) scaleX(1);
-    transform-origin: left center;
   }
 }
 

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -3,9 +3,20 @@ import type { LeagueGame } from "./types";
 type Play = Record<string, unknown>;
 
 const num = (v: unknown) => Number(v) || 0;
+const str = (v: unknown) => String(v ?? "");
+
+function playField(play: Play | undefined, ...keys: string[]) {
+  if (!play) return undefined;
+  const key = keys.find((candidate) => play[candidate] !== undefined);
+  return key ? play[key] : undefined;
+}
+
+function clampYard(yard: number) {
+  return Math.max(0, Math.min(100, yard));
+}
 
 function getFieldPercent(yardLine: unknown) {
-  const yard = Math.max(0, Math.min(100, num(yardLine)));
+  const yard = clampYard(num(yardLine));
 
   // Your old static field uses 0-100 as left-to-right field position.
   // 0 = left goal line, 100 = right goal line.
@@ -22,6 +33,39 @@ function getDriveLeftPercent(start: unknown, current: unknown) {
   const startYard = num(start);
   const currentYard = num(current);
   return `${Math.min(startYard, currentYard)}%`;
+}
+
+function getRunAnimation(lastPlay: Play | undefined, fallbackBallOn: number) {
+  const playType = str(playField(lastPlay, "playtype", "PlayType"));
+  if (!lastPlay || (playType !== "Run" && playType !== "Kneel")) return null;
+
+  const start = clampYard(num(playField(lastPlay, "ballon", "BallOn", "Previous", "previous") ?? fallbackBallOn));
+  const possession = str(playField(lastPlay, "possession", "Possession"));
+  const result = str(playField(lastPlay, "result", "Result", "description", "Description"));
+  const rawEnd = num(playField(lastPlay, "newballon", "NewBallOn", "newBallOn") ?? fallbackBallOn);
+
+  const end = clampYard(
+    result === "Touchdown"
+      ? possession === "Home"
+        ? 100
+        : 0
+      : result === "Safety"
+        ? possession === "Home"
+          ? 0
+          : 100
+        : rawEnd
+  );
+
+  const left = Math.min(start, end);
+  const width = Math.abs(end - start);
+  const movesRight = end >= start;
+
+  return {
+    key: str(playField(lastPlay, "playid", "PlayId")) || `${start}-${end}-${playType}`,
+    left,
+    width,
+    directionClass: movesRight ? "play-line--right" : "play-line--left",
+  };
 }
 
 export function GameField({
@@ -41,18 +85,7 @@ export function GameField({
       ? Math.min(100, ballOn + distance)
       : Math.max(0, ballOn - distance);
 
-  const previousBallOn = lastPlay
-    ? num(
-        lastPlay.BallOn ??
-          lastPlay.ballon ??
-          lastPlay.PreviousBallOn ??
-          lastPlay.previousBallOn ??
-          ballOn
-      )
-    : ballOn;
-
-  const playLeft = Math.min(previousBallOn, ballOn);
-  const playWidth = Math.abs(ballOn - previousBallOn);
+  const runAnimation = getRunAnimation(lastPlay, ballOn);
 
   const yardMarkers = [
     { left: 8.3333, label: null },
@@ -138,14 +171,17 @@ export function GameField({
           }}
         />
 
-        <div
-          className="play-line"
-          id="play"
-          style={{
-            left: `${playLeft}%`,
-            width: `${playWidth}%`,
-          }}
-        />
+        {runAnimation && (
+          <div
+            key={runAnimation.key}
+            className={`play-line ${runAnimation.directionClass}`}
+            id="play"
+            style={{
+              left: `${runAnimation.left}%`,
+              width: `${runAnimation.width}%`,
+            }}
+          />
+        )}
 
         <div id="arc-container" className="arc-container" />
       </div>

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -45,7 +45,7 @@ export function simulateSingleCarry(stats: CarryStats) {
   //  for 80: add 1.5 to roll 
   //  for 90: add 2.25 to roll
   //  for 100: add 3 to roll
-  let visionMod = (trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.75;
+  const visionMod = (trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.75;
   roll += visionMod
   //HARDCODED 88 ALERT!
   if (roll < 88){
@@ -90,7 +90,7 @@ export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (safeMax - safeMin + 1)) + safeMin;
 }
 
-function applyTraitEffect(traitName: string, traitValue: number, condition: Boolean, modLog: string[]) {
+function applyTraitEffect(traitName: string, traitValue: number, condition: boolean, modLog: string[]) {
   if (!condition) return 0;
   const deviation = traitValue - 60;
   const triggerChance = Math.abs(deviation) / 100;


### PR DESCRIPTION
### Motivation
- Run and kneel plays were not animating correctly on the new GameField; the UI needed to derive animation start/end positions from the logged play record instead of relying on the old LeagueAppScript implementation.
- The animation direction and endpoints (including touchdown/safety before kickoff reset) had to be correct for both Home and Away possessions.

### Description
- Add `getRunAnimation`, `playField`, `clampYard`, and `str` helpers to `GameField.tsx` to derive a run/kneel play's start, end, width, and unique key from the `lastPlay` record and to clamp yard values to 0..100.
- Replace the static `.play-line` render with a conditional remounted play element keyed by the play id so the CSS `grow-line` animation reliably re-triggers for each run play and animates from the true start to end positions, mapping scoring/safety results to proper endpoints.
- Add directional CSS classes in `GameCenter.css` (`.play-line--right` / `.play-line--left`) to set transform origins and arrow/circle placements so the play-line grows and points in the correct horizontal direction; shorten and normalize the animation timing.
- Small lint/type fixes in `runEngine.ts` (`visionMod` -> `const` and `condition: boolean`) to resolve ESLint/TS issues discovered while building.

### Testing
- Installed dependencies with `npm --prefix apps/web install` which completed successfully.
- Ran the linter with `npm --prefix apps/web run lint` after fixes and it passed (previously surfaced errors were fixed).
- Built the web bundle with `npm --prefix apps/web run build` which completed successfully and produced the production assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a40aba8e58483248202c270793482fb)