### PR TITLE
Organize run engine helpers and wire accel-to-LB frontend setting

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -262,6 +262,9 @@ function getBreakawayYards() {
 function getAccelToLBs() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
   const data = sheet.getDataRange().getValues();
+
+  // Reads the "RUN PLAY _ ACCEL TO LINE BACKERS" Settings rows:
+  // accel_to_LB_N | percentage | yds
   const accelYds = data
     .filter(row => typeof row[0] === "string" && row[0].startsWith("accel_to_LB_"))
     .map(row => ({
@@ -416,7 +419,7 @@ function getFrontendSettings() {
   Logger.log("Fetching frontend settings...");
   const thresholds = getRunThresholdsFromSettings();
   Logger.log(thresholds);
-  data= {
+  const data = {
     thresholds: getRunThresholdsFromSettings(),
     breakaways: getBreakawayYards(),
     accelToLBYards: getAccelToLBs(),

--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -91,6 +91,7 @@ async function getFrontendSettingsFromSheet() {
   return {
     thresholds,
     breakaways: settingRows(rows, "Break_").map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) })),
+    accelToLBYards: settingRows(rows, "accel_to_LB_").map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), yards: parseInt(String(r[2]), 10) })),
     staminaDrains,
     tackleTable: settingRows(rows, "Tackle_").map((r) => ({ label: r[0], yardageCap: Number(r[1]), DL: Number(r[2]) || 0, LB: Number(r[3]) || 0, DBS: Number(r[4]) || 0 })).sort((a,b)=>a.yardageCap-b.yardageCap),
     completionTable: settingRows(rows, "airYards_Completion_").map((r) => ({ label: r[0], pastLos: Number(r[1]), baseCompletion: Number(r[2]), percentage: Number(r[3]) })),

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -1,5 +1,6 @@
 import type { LeagueGame } from "../../types";
-import type { EngineContext, FrontendSettings, PlayCallOptions, RunBreakawaySetting, RunThreshold, DefensiveAssignment } from "./types";
+import type { EngineContext, FrontendSettings, PlayCallOptions, RunBreakawaySetting, RunThreshold } from "./types";
+import { buildResult } from "./playLogger";
 import { advanceBall, advanceQuarter, byName, byPosition, choose, clockRunoff, defenseTeam, isSafety, isTouchdown, n, nextDownDistance, offenseTeam, playerName, switchPoss, teamPlayers, trait, weightedChoose } from "./utils";
 import {
   performLineWinLoss,
@@ -12,10 +13,8 @@ import {
   performDlJukeCheck,
   getOtherWinningDLs,
   resolveRemainingDlPursuit,
-  performAccelerationCheck,
   randomInt,
   addYards,
-  stopRun
 } from "./runEngineHelper";
 
 export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
@@ -39,6 +38,10 @@ function settingArray<T>(settings: FrontendSettings | undefined, key: keyof Fron
   const value = settings?.[key];
   return Array.isArray(value) ? (value as T[]) : [];
 }
+
+// ---------------------------------------------------------------------------
+// Legacy single-carry yardage model
+// ---------------------------------------------------------------------------
 
 export function simulateSingleCarry(stats: CarryStats) {
   const modLog: string[] = [];
@@ -202,6 +205,9 @@ export function maybeBoostRollForAcceleration(acceleration: number, fatigue: num
   return boost;
 }
 
+// ---------------------------------------------------------------------------
+// Legacy run-play support
+// ---------------------------------------------------------------------------
 
 //ballCarrier.offStars ^2 chance of true. Otherwise false
 //NEEDS TRansition TO THIS CLASS
@@ -430,6 +436,10 @@ export function runPlayOld(game: LeagueGame, ctx: EngineContext, options: PlayCa
   return buildResult(game, updated, "Run", runnerName, "", yards, tackler, result, ctx.historyLength, { recoveredby: fumble.recoveredBy });
 }
 
+// ---------------------------------------------------------------------------
+// Current run-play pipeline
+// ---------------------------------------------------------------------------
+
 export function runPlay(
   game: LeagueGame,
   ctx: EngineContext,
@@ -482,7 +492,7 @@ export function runPlay(
   let otherWinningDLsAfterJuke: ReturnType<typeof getOtherWinningDLs> = [];
   let dlPursuitResult: ReturnType<typeof resolveRemainingDlPursuit> | null = null;
 
-  //IF the runner doesn't hit a hole...
+  // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
     const backfieldYards = randomInt(-5, -1);
 
@@ -546,7 +556,7 @@ export function runPlay(
       }
     }
   }
-  //Otherwise, if the runner DOES hit a hole...
+  // Frontside branch: the runner found the intended lane and may face a swipe attempt.
   else {
     dlSwipeResult =
       runLaneTarget.selectedSide === "OL"

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -7,6 +7,10 @@ import type {
 
 const TEOL_SLOTS: FormationSlot[] = ["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"];
 
+// ---------------------------------------------------------------------------
+// Player / formation lookup helpers
+// ---------------------------------------------------------------------------
+
 export type OlDlMatchup = {
   slot: FormationSlot;
   offensePlayer: string;
@@ -59,6 +63,10 @@ export function findPlayerByName(
     return name === playerName;
   });
 }
+
+// ---------------------------------------------------------------------------
+// Line-of-scrimmage checks
+// ---------------------------------------------------------------------------
 
 export type LineWinLossResult = {
   slot: FormationSlot;
@@ -281,6 +289,11 @@ export function pickRunLaneTarget(
     candidates,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Run-lane selection and run-state mutation helpers
+// ---------------------------------------------------------------------------
+
 export function createRunPlayState(runner: string): RunPlayState {
   return {
     yards: 0,
@@ -311,6 +324,10 @@ export function stopRun(
   state.log.push(`${tackler} stops ${state.runner}. Reason: ${reason}.`);
   return state;
 }
+
+// ---------------------------------------------------------------------------
+// Defensive line resolution checks
+// ---------------------------------------------------------------------------
 
 export type DlSwipeResult = {
   attempted: boolean;

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -20,9 +20,11 @@ export type PlayCallOptions = {
 export type PlayerTrait = Record<string, unknown>;
 export type RunThreshold = { label: string; minYards: number; maxYards: number; rollMin: number; rollMax: number };
 export type RunBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
+export type RunAccelToLBSetting = { label: string; percentage: number; yards: number };
 export type FrontendSettings = Record<string, unknown> & {
   thresholds?: RunThreshold[];
   breakaways?: RunBreakawaySetting[];
+  accelToLBYards?: RunAccelToLBSetting[];
   staminaDrains?: Record<string, number>;
   drainSettings?: Record<string, number>;
   tackleTable?: unknown[];


### PR DESCRIPTION
### Motivation

- Make the run engine code easier to read and maintain by grouping related helpers and adding clarifying section comments while avoiding material behavioral changes. 
- Ensure the new `accel_to_LB_*` Settings table is parsed consistently and exposed to frontend consumers so the web engine can consume the acceleration-to-linebacker distribution. 

### Description

- Added descriptive section headers and reorganized imports in the run engine to separate the legacy single-carry model, legacy run-play support, and the current run-play pipeline without changing runtime logic, and imported `buildResult` where needed (`apps/web/src/components/league/gameplay/engine/runEngine.ts`).
- Grouped and documented helper responsibilities in `runEngineHelper.ts` with clear sections for player/formation lookups, line-of-scrimmage checks, run-state mutation helpers, and defensive-line resolution checks.
- Wired the Apps Script `getAccelToLBs()` parsing (with a short comment) and fixed `getFrontendSettings()` to return a `const data` object in `Code.js` so the `accel_to_LB_*` rows are included as `accelToLBYards`.
- Exposed the same `accelToLBYards` structure from the API by adding it to `getFrontendSettingsFromSheet()` and added a typed `RunAccelToLBSetting` plus `accelToLBYards?: RunAccelToLBSetting[]` to the web `FrontendSettings` types (`apps/api/src/routes/gameRoutes.ts`, `apps/web/src/components/league/gameplay/engine/types.ts`).

### Testing

- Ran a small `node` snippet to parse the provided `accel_to_LB_0`..`accel_to_LB_7` table and verified it produced 8 rows that sum to `100%` (success).
- Ran `npm run build` for the web app which currently fails due to TypeScript errors at the `GameCenter.tsx` call sites because `runPlay` presently returns `void` instead of a play result (build failed).
- Ran `npm run lint` which surfaced an existing React hooks lint error in `GameControls.tsx` unrelated to these refactors (lint failed).
- Performed `npm install` in `apps/web` (install completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a51be5c480c832493d6f69b012f4bce)