### PR TITLE
Add accel-to-LB yardage when RB reaches second level

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -1,5 +1,5 @@
 import type { LeagueGame } from "../../types";
-import type { EngineContext, FrontendSettings, PlayCallOptions, RunBreakawaySetting, RunThreshold } from "./types";
+import type { EngineContext, FrontendSettings, PlayCallOptions, RunAccelToLBSetting, RunBreakawaySetting, RunThreshold } from "./types";
 import { buildResult } from "./playLogger";
 import { advanceBall, advanceQuarter, byName, byPosition, choose, clockRunoff, defenseTeam, isSafety, isTouchdown, n, nextDownDistance, offenseTeam, playerName, switchPoss, teamPlayers, trait, weightedChoose } from "./utils";
 import {
@@ -37,6 +37,34 @@ type CarryStats = { name: string; runner?: Record<string, unknown>; offStar?: bo
 function settingArray<T>(settings: FrontendSettings | undefined, key: keyof FrontendSettings): T[] {
   const value = settings?.[key];
   return Array.isArray(value) ? (value as T[]) : [];
+}
+
+export function getAccelToLBYards(runner: Record<string, unknown> | undefined, settings: FrontendSettings | undefined, modLog?: string[]) {
+  const baseRoll = Math.floor(Math.random() * 101);
+  const acceleration = trait(runner, "acceleration");
+  const accelerationMod = ((acceleration / 10) ** 2) / 9;
+  const adjustedRoll = Math.min(100, baseRoll + accelerationMod);
+
+  let cumulative = 0;
+  const accelToLBSettings = settingArray<RunAccelToLBSetting>(settings, "accelToLBYards");
+  for (const range of accelToLBSettings) {
+    cumulative += Number(range.percentage) || 0;
+    if (adjustedRoll <= cumulative) {
+      const yards = Number(range.yards) || 0;
+      modLog?.push(
+        `Yard +${yards} Accel to LB (roll ${adjustedRoll.toFixed(2)} = ${baseRoll} + ${accelerationMod.toFixed(2)})`
+      );
+      return yards;
+    }
+  }
+
+  const fallbackYards = Number(accelToLBSettings[accelToLBSettings.length - 1]?.yards) || 0;
+  if (fallbackYards) {
+    modLog?.push(
+      `Yard +${fallbackYards} Accel to LB (capped roll ${adjustedRoll.toFixed(2)})`
+    );
+  }
+  return fallbackYards;
 }
 
 // ---------------------------------------------------------------------------
@@ -573,6 +601,12 @@ export function runPlay(
         ctx.players
       );
     } else {
+      addYards(
+        runState,
+        getAccelToLBYards(byName(ctx, runState.runner), ctx.settings, runState.log),
+        `${runState.runner} accelerates to the second level before meeting a linebacker`
+      );
+
       runState.log.push(
         `${runState.runner} hits the hole behind ${runLaneTarget.selectedPlayer} and clears the defensive line.`
       );


### PR DESCRIPTION
### Motivation
- Introduce a follow-on yardage step for runs where the ballcarrier accelerates to the second level to reflect extra yards gained from acceleration before meeting a linebacker.

### Description
- Added a new helper `getAccelToLBYards` which rolls `0-100`, applies an acceleration modifier `((acceleration/10)^2)/9`, caps the adjusted roll at `100`, and maps the result through the frontend `accelToLBYards` settings to return yardage.
- Exposed the `RunAccelToLBSetting` type in imports so the helper can read the `accelToLBYards` frontend configuration via the existing `settingArray` helper.
- Applied the yardage only in the frontside branch when the runner `hits the hole` and is not `swiped` by a DL by calling `addYards(runState, getAccelToLBYards(...), ...)` and logging the adjustment.
- The helper optionally pushes a descriptive log entry into the run state `modLog` showing the base roll, acceleration modifier, and yards added.

### Testing
- Ran TypeScript build with `npm run build -- --pretty false` which failed due to existing unrelated TypeScript errors in `GameCenter.tsx` where `runPlay` is inferred as `void` (pre-existing issue). 
- Ran `npx tsc -b --pretty false` which failed because there is no root `tsconfig.json` at the workspace root (environment constraint). 
- Ran linter with `npm run lint -- --quiet` which surfaced a pre-existing `react-hooks/set-state-in-effect` error in `GameControls.tsx` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a51c0ac34bc832481f2ca54c7cddaa3)