### PR TITLE
Fix accel-to-LB settings loading

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -259,6 +259,14 @@ function getBreakawayYards() {
   return breakRanges;
 }
 
+function normalizeSettingLabel(label) {
+  return String(label || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function settingLabelStartsWith(label, prefix) {
+  return normalizeSettingLabel(label).startsWith(normalizeSettingLabel(prefix));
+}
+
 function getAccelToLBs() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Settings");
   const data = sheet.getDataRange().getValues();
@@ -266,12 +274,19 @@ function getAccelToLBs() {
   // Reads the "RUN PLAY _ ACCEL TO LINE BACKERS" Settings rows:
   // accel_to_LB_N | percentage | yds
   const accelYds = data
-    .filter(row => typeof row[0] === "string" && row[0].startsWith("accel_to_LB_"))
+    .filter(row => settingLabelStartsWith(row[0], "accel_to_LB_"))
     .map(row => ({
       label: row[0],
       percentage: parseFloat(row[1]),
       yards: parseInt(row[2], 10)
-    }));
+    }))
+    .filter(row => !Number.isNaN(row.percentage) && !Number.isNaN(row.yards));
+  Logger.log(`getAccelToLBs found ${accelYds.length} rows`);
+  if (!accelYds.length) {
+    Logger.log(
+      "No accel-to-LB settings found. Check that Settings labels look like accel_to_LB_1, accel to LB 1, or ACCEL_TO_LB_1 and that percentage/yards cells are numeric."
+    );
+  }
   return accelYds;
 }
 

--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -43,7 +43,13 @@ async function getTeamsFromSheet() {
   const { headers, rows } = await sheetRows("Teams");
   return rows.filter((r) => r?.[0] !== "" && r?.[0] != null).slice(0, 10).map((r) => objectFrom(headers, r));
 }
-function settingRows(rows: Row[], prefix: string) { return rows.filter((r) => typeof r[0] === "string" && String(r[0]).startsWith(prefix)); }
+function normalizeSettingLabel(label: unknown) {
+  return String(label || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+function settingRows(rows: Row[], prefix: string) {
+  const normalizedPrefix = normalizeSettingLabel(prefix);
+  return rows.filter((r) => normalizeSettingLabel(r[0]).startsWith(normalizedPrefix));
+}
 async function getFrontendSettingsFromSheet() {
   const { rows } = await sheetRows("Settings");
   let cumulative = 0;
@@ -91,7 +97,9 @@ async function getFrontendSettingsFromSheet() {
   return {
     thresholds,
     breakaways: settingRows(rows, "Break_").map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) })),
-    accelToLBYards: settingRows(rows, "accel_to_LB_").map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), yards: parseInt(String(r[2]), 10) })),
+    accelToLBYards: settingRows(rows, "accel_to_LB_")
+      .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), yards: parseInt(String(r[2]), 10) }))
+      .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.yards)),
     staminaDrains,
     tackleTable: settingRows(rows, "Tackle_").map((r) => ({ label: r[0], yardageCap: Number(r[1]), DL: Number(r[2]) || 0, LB: Number(r[3]) || 0, DBS: Number(r[4]) || 0 })).sort((a,b)=>a.yardageCap-b.yardageCap),
     completionTable: settingRows(rows, "airYards_Completion_").map((r) => ({ label: r[0], pastLos: Number(r[1]), baseCompletion: Number(r[2]), percentage: Number(r[3]) })),

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -25,6 +25,7 @@ function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendS
   normalized.timeNeededToOpen = normalized.timeNeededToOpen ?? normalized.timeNeededToThrow;
   normalized.thresholds = Array.isArray(normalized.thresholds) ? normalized.thresholds : [];
   normalized.breakaways = Array.isArray(normalized.breakaways) ? normalized.breakaways : [];
+  normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards) ? normalized.accelToLBYards : [];
   normalized.staminaDrains = normalized.staminaDrains ?? {};
   normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
   normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];


### PR DESCRIPTION
### Motivation
- The run engine was not receiving `accelToLBYards` when Settings labels did not exactly match `accel_to_LB_` (case/spacing/punctuation differences), causing `getAccelToLBYards()` to behave as if settings were missing.

### Description
- In `Code.js` add `normalizeSettingLabel` and `settingLabelStartsWith` and use them in `getAccelToLBs()` so Settings row labels are matched case- and punctuation-insensitively, and filter out rows with non-numeric percentage/yards values; add `Logger.log` diagnostics when no rows are found.
- In `apps/api/src/routes/gameRoutes.ts` add `normalizeSettingLabel` and replace the exact `startsWith` filter with a normalized `settingRows()` implementation, and filter out invalid accel-to-LB rows before returning `accelToLBYards`.
- In `apps/web/src/components/league/GameCenter.tsx` ensure `accelToLBYards` is always normalized to an array so the frontend run engine receives a predictable value even if the backend response is missing or malformed.

### Testing
- Ran `npx tsc --noEmit` in `apps/api` which succeeded.
- Ran `npm run build` in `apps/web` which failed due to pre-existing TypeScript errors in `GameCenter.tsx` unrelated to this change.
- Ran `npm run lint` in `apps/web` which reported an existing React hook lint error in `GameControls.tsx` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a51c7700bd88324af17be4ada1c7b7c)