### PR TITLE
Add LB wrap carry yardage checks (up to +2 yards)

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -419,6 +419,37 @@ export function performFallForwardCheck(
   };
 }
 
+export type CarryDefenderResult = {
+  runner: string;
+  runnerSize: number;
+  runnerStrength: number;
+  carryScore: number;
+  rolls: number[];
+  yardsAdded: number;
+};
+
+export function performCarryDefenderChecks(
+  runnerName: string,
+  players: PlayerTrait[]
+): CarryDefenderResult {
+  const runner = findPlayerByName(players, runnerName);
+
+  const runnerSize = trait(runner, "size");
+  const runnerStrength = trait(runner, "strength");
+  const carryScore = (runnerSize + runnerStrength) / 2;
+  const rolls = [Math.random() * 100, Math.random() * 100];
+  const yardsAdded = rolls.filter((roll) => roll <= carryScore).length;
+
+  return {
+    runner: runnerName,
+    runnerSize,
+    runnerStrength,
+    carryScore,
+    rolls,
+    yardsAdded,
+  };
+}
+
 export function handleRunnerTackle(
   state: RunPlayState,
   tackler: string,
@@ -440,6 +471,29 @@ export function handleRunnerTackle(
   state.log.push(`${tackler} tackles ${state.runner}. Reason: ${reason}.`);
 
   return fallForwardResult;
+}
+
+export function handleLbWrapTackle(
+  state: RunPlayState,
+  tackler: string,
+  reason: string,
+  players: PlayerTrait[]
+): CarryDefenderResult {
+  const carryDefenderResult = performCarryDefenderChecks(state.runner, players);
+
+  if (carryDefenderResult.yardsAdded > 0) {
+    state.yards += carryDefenderResult.yardsAdded;
+    state.log.push(
+      `${state.runner} carries ${tackler} for +${carryDefenderResult.yardsAdded} extra ${carryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`
+    );
+  }
+
+  state.tackler = tackler;
+  state.stopped = true;
+  state.stopReason = reason;
+  state.log.push(`${tackler} tackles ${state.runner}. Reason: ${reason}.`);
+
+  return carryDefenderResult;
 }
 
 export function randomInt(min: number, max: number): number {
@@ -575,6 +629,7 @@ export function pickLinebackerForRunLane(
 export type LbSecondLevelResult = {
   linebacker?: DefensiveAssignment;
   wrapResult?: DefenderWrapResult;
+  carryDefenderResult?: CarryDefenderResult;
   stopped: boolean;
 };
 
@@ -601,9 +656,10 @@ export function resolveLinebackerSecondLevel(
   runState.log.push(`${runState.runner} meets ${linebacker.player} at the second level.`);
 
   const wrapResult = performDefenderWrapCheck(linebacker.player, players);
+  let carryDefenderResult: CarryDefenderResult | undefined;
 
   if (wrapResult.wrapped) {
-    handleRunnerTackle(runState, linebacker.player, "LB Second-Level Wrap", players);
+    carryDefenderResult = handleLbWrapTackle(runState, linebacker.player, "LB Second-Level Wrap", players);
   } else {
     runState.log.push(`${linebacker.player} fails to wrap ${runState.runner} at the second level.`);
   }
@@ -611,6 +667,7 @@ export function resolveLinebackerSecondLevel(
   return {
     linebacker,
     wrapResult,
+    carryDefenderResult,
     stopped: runState.stopped,
   };
 }


### PR DESCRIPTION
### Motivation
- Model linebackers "carried" by runners on successful wraps so a runner can gain up to 2 extra yards when dragging a defender after a wrap.
- Use two independent 0–100 checks against the runner's average `size` and `strength` to determine 0–2 additional carried yards.

### Description
- Added `CarryDefenderResult` and `performCarryDefenderChecks` to compute two 0–100 rolls vs the runner average of `size` and `strength` and count successes as extra yards in `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts`.
- Added `handleLbWrapTackle` to apply carried yards to the `RunPlayState` log and yards before finalizing a tackle.
- Updated `resolveLinebackerSecondLevel` to call `handleLbWrapTackle` on successful LB wraps and to return `carryDefenderResult` inside the `LbSecondLevelResult`.
- Kept existing `handleRunnerTackle`/`performFallForwardCheck` intact for other tackle paths.

### Testing
- Ran `npm install` in `apps/web` successfully.
- Linted the updated helper via `npx eslint apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` with no new errors reported for the changed file.
- `npm run build` failed due to existing unrelated TypeScript errors in `src/components/league/GameCenter.tsx` and did not complete successfully.
- `npm run lint` reports existing React Hooks lint warnings/errors in `src/components/league/GameControls.tsx` and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a51cfccf4088324bca1100108114108)