### PR TITLE
Add second-level juke check

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -629,9 +629,52 @@ export function pickLinebackerForRunLane(
 export type LbSecondLevelResult = {
   linebacker?: DefensiveAssignment;
   wrapResult?: DefenderWrapResult;
+  jukeResult?: LbJukeResult;
   carryDefenderResult?: CarryDefenderResult;
+  secondChanceAttempt?: "Juke" | "Truck";
   stopped: boolean;
 };
+
+export type LbJukeResult = {
+  runner: string;
+  defender: string;
+  runnerJukeTrait: number;
+  defenderTacklingTrait: number;
+  rbJukeScore: number;
+  lbDefendScore: number;
+  targetToBeat: number;
+  roll: number;
+  juked: boolean;
+};
+
+export function performLbJukeCheck(
+  runnerName: string,
+  defenderName: string,
+  players: PlayerTrait[]
+): LbJukeResult {
+  const runner = findPlayerByName(players, runnerName);
+  const defender = findPlayerByName(players, defenderName);
+
+  const runnerJukeTrait = trait(runner, "juke");
+  const defenderTacklingTrait = trait(defender, "tackling");
+
+  const rbJukeScore = 15 + ((runnerJukeTrait / 10) ** 2) / 3;
+  const lbDefendScore = ((defenderTacklingTrait / 15) ** 2) / 2;
+  const targetToBeat = rbJukeScore - lbDefendScore;
+  const roll = Math.random() * 100;
+
+  return {
+    runner: runnerName,
+    defender: defenderName,
+    runnerJukeTrait,
+    defenderTacklingTrait,
+    rbJukeScore,
+    lbDefendScore,
+    targetToBeat,
+    roll,
+    juked: roll < targetToBeat,
+  };
+}
 
 export function resolveLinebackerSecondLevel(
   runState: RunPlayState,
@@ -657,17 +700,44 @@ export function resolveLinebackerSecondLevel(
 
   const wrapResult = performDefenderWrapCheck(linebacker.player, players);
   let carryDefenderResult: CarryDefenderResult | undefined;
+  let jukeResult: LbJukeResult | undefined;
+  let secondChanceAttempt: "Juke" | "Truck" | undefined;
 
   if (wrapResult.wrapped) {
     carryDefenderResult = handleLbWrapTackle(runState, linebacker.player, "LB Second-Level Wrap", players);
   } else {
     runState.log.push(`${linebacker.player} fails to wrap ${runState.runner} at the second level.`);
+
+    secondChanceAttempt = Math.random() < 0.5 ? "Juke" : "Truck";
+
+    if (secondChanceAttempt === "Juke") {
+      jukeResult = performLbJukeCheck(runState.runner, linebacker.player, players);
+
+      if (jukeResult.juked) {
+        runState.log.push(
+          `${runState.runner} jukes ${linebacker.player} at the second level (roll ${jukeResult.roll.toFixed(2)} < ${jukeResult.targetToBeat.toFixed(2)}).`
+        );
+      } else {
+        carryDefenderResult = handleLbWrapTackle(
+          runState,
+          linebacker.player,
+          "LB Second-Level Juke Failed",
+          players
+        );
+      }
+    } else {
+      runState.log.push(
+        `${runState.runner} lowers a shoulder into ${linebacker.player}; truck check is not implemented yet.`
+      );
+    }
   }
 
   return {
     linebacker,
     wrapResult,
+    jukeResult,
     carryDefenderResult,
+    secondChanceAttempt,
     stopped: runState.stopped,
   };
 }


### PR DESCRIPTION
### Motivation
- Implement a second-level juke attempt for runners who reach the linebacker level when the LB fails to wrap, using the requested RB and LB formulas and giving a 50/50 chance to attempt a juke or a truck stub.

### Description
- Added a new `LbJukeResult` type and `performLbJukeCheck` function that computes `rbJukeScore = 15 + ((juke/10)^2)/3` and `lbDefendScore = ((tackling/15)^2)/2` then checks `roll < (rbJukeScore - lbDefendScore)`. The function returns trait values, scores, roll, and success boolean.
- Extended `LbSecondLevelResult` to include `jukeResult` and `secondChanceAttempt` and updated `resolveLinebackerSecondLevel` to choose a 50/50 follow-up when the LB fails to wrap: perform the juke check or log a truck-check stub.
- On a successful juke the code logs the success; on a failed juke it delegates to `handleLbWrapTackle` with reason `"LB Second-Level Juke Failed"`; truck behavior is left as a logged stub for future implementation.
- Changes are localized to `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` (added types, `performLbJukeCheck`, and second-level flow updates).

### Testing
- Ran `git diff --check` which reported no whitespace issues. (success)
- Ran `npm --prefix apps/web run build` which failed due to existing unrelated TypeScript errors in `GameCenter.tsx` (build failed).
- Ran `npm --prefix apps/web run lint` which surfaced an existing React hooks lint error in `GameControls.tsx` (lint failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a51d32a29a08324ad855b113a3ba735)