### PR TITLE
Include adjacent DLs for short acceleration (<=3 yards) tackler selection

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -17,6 +17,7 @@ import {
   addYards,
   getAccelToLBYards,
   resolveLinebackerSecondLevel,
+  pickShortAccelerationDefender,
 } from "./runEngineHelper";
 
 export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
@@ -599,11 +600,37 @@ export function runPlay(
   //if hit hole or juked out of backfield...
   else {
     console.log("Run survived DL phase:", runState);
+
+    const accelToSecondLevelYards = getAccelToLBYards(
+      byName(ctx, runState.runner),
+      ctx.settings,
+      runState.log
+    );
+    const jukedBackfieldDefenders = [
+      dlJukeResult?.juked ? dlJukeResult.defender : undefined,
+      ...(dlPursuitResult?.steps
+        .filter((step) => step.outcome === "Juked")
+        .map((step) => step.defender) ?? []),
+    ].filter((defender): defender is string => Boolean(defender));
+    const secondLevelDefender =
+      accelToSecondLevelYards <= 3
+        ? pickShortAccelerationDefender(
+            defenseFormation,
+            lineWinLossArray,
+            runLaneTarget,
+            offenseFormation,
+            runState.runner,
+            jukedBackfieldDefenders,
+            ctx.players
+          )
+        : undefined;
     
     addYards(
       runState,
-      getAccelToLBYards(byName(ctx, runState.runner), ctx.settings, runState.log),
-      `${runState.runner} accelerates to the second level before meeting a linebacker`
+      accelToSecondLevelYards,
+      secondLevelDefender?.position.startsWith("DL")
+        ? `${runState.runner} accelerates through a short crease before meeting a defensive lineman`
+        : `${runState.runner} accelerates to the second level before meeting a linebacker`
     );
 
     runState.log.push(
@@ -615,7 +642,8 @@ export function runPlay(
       defenseFormation,
       runLaneTarget,
       offenseFormation,
-      ctx.players
+      ctx.players,
+      secondLevelDefender
     );
 
     console.log("LB second level result:", lbSecondLevelResult);

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -626,6 +626,90 @@ export function pickLinebackerForRunLane(
     : linebackers[linebackers.length - 1];
 }
 
+export function getAdjacentDefensiveLinemenForRunLane(
+  lineWinLossArray: LineWinLossResult[],
+  selectedSlot: FormationSlot,
+  jukedDefenders: string[] = []
+): DefensiveAssignment[] {
+  const selectedIndex = TEOL_SLOTS.indexOf(selectedSlot);
+  if (selectedIndex < 0) return [];
+
+  const jukedDefenderSet = new Set(jukedDefenders.filter(Boolean));
+
+  return [selectedIndex - 1, selectedIndex + 1]
+    .map((index) => TEOL_SLOTS[index])
+    .filter((slot): slot is FormationSlot => Boolean(slot))
+    .map((slot) => lineWinLossArray.find((battle) => battle.slot === slot))
+    .filter((battle): battle is LineWinLossResult =>
+      Boolean(
+        battle?.defensePlayer &&
+        battle.defensePosition.startsWith("DL") &&
+        !jukedDefenderSet.has(battle.defensePlayer)
+      )
+    )
+    .map((battle) => ({
+      position: battle.defensePosition,
+      player: battle.defensePlayer,
+      align: battle.slot,
+    }));
+}
+
+export function weightedPickDefenderByDefStars(
+  defenders: DefensiveAssignment[],
+  players: PlayerTrait[]
+): DefensiveAssignment | undefined {
+  const weightedDefenders = defenders
+    .map((defender) => {
+      const defensivePlayer = findPlayerByName(players, defender.player);
+      return {
+        defender,
+        weight: trait(defensivePlayer, "defStars") ** 2,
+      };
+    })
+    .filter(({ weight }) => weight > 0);
+
+  if (weightedDefenders.length === 0) return defenders[0];
+
+  const totalWeight = weightedDefenders.reduce((sum, { weight }) => sum + weight, 0);
+  const roll = Math.random() * totalWeight;
+  let runningTotal = 0;
+
+  for (const weightedDefender of weightedDefenders) {
+    runningTotal += weightedDefender.weight;
+    if (roll <= runningTotal) return weightedDefender.defender;
+  }
+
+  return weightedDefenders[weightedDefenders.length - 1].defender;
+}
+
+export function pickShortAccelerationDefender(
+  defenseFormation: DefensiveAssignment[],
+  lineWinLossArray: LineWinLossResult[],
+  runLaneTarget: RunLaneTargetResult,
+  offenseFormation: Partial<Record<FormationSlot, string>>,
+  runnerName: string,
+  jukedDefenders: string[],
+  players: PlayerTrait[]
+): DefensiveAssignment | undefined {
+  const runnerSlot = (Object.entries(offenseFormation) as [FormationSlot, string | undefined][])
+    .find(([, player]) => player === runnerName)?.[0];
+  const linebacker = pickLinebackerForRunLane(
+    defenseFormation,
+    runLaneTarget.selectedSlot,
+    runnerSlot
+  );
+  const adjacentDefensiveLinemen = getAdjacentDefensiveLinemenForRunLane(
+    lineWinLossArray,
+    runLaneTarget.selectedSlot,
+    jukedDefenders
+  );
+  const candidates = [linebacker, ...adjacentDefensiveLinemen].filter(
+    (defender): defender is DefensiveAssignment => Boolean(defender?.player)
+  );
+
+  return weightedPickDefenderByDefStars(candidates, players);
+}
+
 export type LbSecondLevelResult = {
   linebacker?: DefensiveAssignment;
   wrapResult?: DefenderWrapResult;
@@ -753,11 +837,12 @@ export function resolveLinebackerSecondLevel(
   defenseFormation: DefensiveAssignment[],
   runLaneTarget: RunLaneTargetResult,
   offenseFormation: Partial<Record<FormationSlot, string>>,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
+  selectedDefender?: DefensiveAssignment
 ): LbSecondLevelResult {
   const runnerSlot = (Object.entries(offenseFormation) as [FormationSlot, string | undefined][])
     .find(([, player]) => player === runState.runner)?.[0];
-  const linebacker = pickLinebackerForRunLane(
+  const linebacker = selectedDefender ?? pickLinebackerForRunLane(
     defenseFormation,
     runLaneTarget.selectedSlot,
     runnerSlot


### PR DESCRIPTION
### Motivation
- Short acceleration gains (3 yards or less) should be able to be tackled by either a linebacker or a nearby defensive lineman instead of always forcing a linebacker.

### Description
- Evaluate `getAccelToLBYards` once and, when the returned yards are `<= 3`, build a candidate pool that includes the lane linebacker and adjacent defensive linemen from the offensive-line slots immediately to either side of the run lane, excluding DLs that were juked in the backfield. (`apps/web/src/components/league/gameplay/engine/runEngine.ts`, `runEngineHelper.ts`).
- Added `getAdjacentDefensiveLinemenForRunLane`, `weightedPickDefenderByDefStars`, and `pickShortAccelerationDefender` to collect DL candidates and pick a tackler weighted by `defStars^2`. (`apps/web/src/components/league/gameplay/engine/runEngineHelper.ts`).
- Pass a preselected defender into `resolveLinebackerSecondLevel` so the existing second-level resolution logic runs unchanged with the selected LB/DL when applicable. (`resolveLinebackerSecondLevel` signature and call sites updated).
- Preserve existing behavior for `4+` yard acceleration gains (still choose a linebacker only) and keep other run-engine logic intact.

### Testing
- Ran `npx eslint` against the modified engine files and it completed successfully for those files. 
- Ran `npm install` and attempted `npm run build`, which failed due to pre-existing TypeScript errors in other components (`GameCenter.tsx`), not due to these changes. 
- Ran `npm run lint`, which surfaced an existing lint error in `GameControls.tsx` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a529895ca448324a689736a4df4b0ad)