### PR TITLE
Implement runner 'truck' resolution and post-truck acceleration checks

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -19,6 +19,8 @@ import {
   resolveLinebackerSecondLevel,
   pickShortAccelerationDefender,
   chooseRunnerDefenderSecondChanceAttempt,
+  performTruckAttempt,
+  performPostTruckAccelerationCheck,
 } from "./runEngineHelper";
 
 export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
@@ -533,9 +535,59 @@ export function runPlay(
       );
 
       if (dlSecondChanceAttempt.attempt === "Truck") {
-        runState.log.push(
-          `${runState.runner} lowers a shoulder into ${dlWrapResult.defender}; truck check is not implemented yet.`
+        const truckResult = performTruckAttempt(
+          runState.runner,
+          dlWrapResult.defender,
+          ctx.players
         );
+
+        if (!truckResult.trucked) {
+          runState.log.push(
+            `${runState.runner} fails to truck ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`
+          );
+          fallForwardResult = handleRunnerTackle(
+            runState,
+            dlWrapResult.defender,
+            "DL Backfield Truck Failed",
+            ctx.players
+          );
+        } else {
+          runState.log.push(
+            `${runState.runner} trucks ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to restart downhill.`
+          );
+
+          const otherWinningDLsAfterTruck = getOtherWinningDLs(
+            lineWinLossArray,
+            dlWrapResult.defender
+          );
+          if (otherWinningDLsAfterTruck.length === 0) {
+            runState.log.push(
+              `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`
+            );
+          } else {
+            const accelerationResult = performPostTruckAccelerationCheck(
+              runState.runner,
+              ctx.players
+            );
+
+            if (accelerationResult.acceleratedPast) {
+              runState.log.push(
+                `${runState.runner} accelerates after contact (roll ${accelerationResult.roll.toFixed(2)} <= ${accelerationResult.accelPastChance.toFixed(2)}%) and escapes toward the second level.`
+              );
+            } else {
+              const pursuingDefender = otherWinningDLsAfterTruck[0]?.defensePlayer || dlWrapResult.defender;
+              runState.log.push(
+                `${runState.runner} cannot accelerate past the remaining defenders after the truck (roll ${accelerationResult.roll.toFixed(2)} > ${accelerationResult.accelPastChance.toFixed(2)}%).`
+              );
+              fallForwardResult = handleRunnerTackle(
+                runState,
+                pursuingDefender,
+                "DL Backfield Post-Truck Acceleration Failed",
+                ctx.players
+              );
+            }
+          }
+        }
       } else {
         dlJukeResult = performDlJukeCheck(
           runState.runner,
@@ -544,7 +596,7 @@ export function runPlay(
         );
       }
 
-      if (dlJukeResult && !dlJukeResult.juked) {
+      if (!runState.stopped && dlJukeResult && !dlJukeResult.juked) {
         fallForwardResult = handleRunnerTackle(
           runState,
           dlWrapResult.defender,

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -363,6 +363,67 @@ export function chooseRunnerDefenderSecondChanceAttempt(
   };
 }
 
+
+export type TruckAttemptResult = {
+  runner: string;
+  defender: string;
+  runnerPower: number;
+  defenderPower: number;
+  truckChance: number;
+  roll: number;
+  trucked: boolean;
+};
+
+export function performTruckAttempt(
+  runnerName: string,
+  defenderName: string,
+  players: PlayerTrait[]
+): TruckAttemptResult {
+  const runner = findPlayerByName(players, runnerName);
+  const defender = findPlayerByName(players, defenderName);
+  const runnerPower = trait(runner, "size") + trait(runner, "strength");
+  const defenderPower = trait(defender, "size") + trait(defender, "strength");
+  const totalPower = runnerPower + defenderPower;
+  const truckChance = totalPower > 0 ? (runnerPower / totalPower) * 100 : 0;
+  const roll = Math.random() * 100;
+
+  return {
+    runner: runnerName,
+    defender: defenderName,
+    runnerPower,
+    defenderPower,
+    truckChance,
+    roll,
+    trucked: roll <= truckChance,
+  };
+}
+
+export type TruckAccelerationResult = {
+  runner: string;
+  runnerAcceleration: number;
+  accelPastChance: number;
+  roll: number;
+  acceleratedPast: boolean;
+};
+
+export function performPostTruckAccelerationCheck(
+  runnerName: string,
+  players: PlayerTrait[]
+): TruckAccelerationResult {
+  const runner = findPlayerByName(players, runnerName);
+  const runnerAcceleration = trait(runner, "acceleration");
+  const accelPastChance = ((runnerAcceleration / 10) ** 2) / 3;
+  const roll = Math.random() * 100;
+
+  return {
+    runner: runnerName,
+    runnerAcceleration,
+    accelPastChance,
+    roll,
+    acceleratedPast: roll <= accelPastChance,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Defensive line resolution checks
 // ---------------------------------------------------------------------------
@@ -747,6 +808,8 @@ export type LbSecondLevelResult = {
   fallForwardResult?: FallForwardResult;
   carryDefenderResult?: CarryDefenderResult;
   secondChanceAttempt?: RunnerDefenderSecondChanceAttempt;
+  truckResult?: TruckAttemptResult;
+  truckAccelerationResult?: TruckAccelerationResult;
   nextLevelPressure?: LbNextLevelPressureResult;
   stopped: boolean;
 };
@@ -891,6 +954,8 @@ export function resolveLinebackerSecondLevel(
   let jukeResult: LbJukeResult | undefined;
   let nextLevelPressure: LbNextLevelPressureResult | undefined;
   let secondChanceAttempt: RunnerDefenderSecondChanceAttempt | undefined;
+  let truckResult: TruckAttemptResult | undefined;
+  let truckAccelerationResult: TruckAccelerationResult | undefined;
 
   if (wrapResult.wrapped) {
     carryDefenderResult = handleLbWrapTackle(runState, linebacker.player, "LB Second-Level Wrap", players);
@@ -931,9 +996,46 @@ export function resolveLinebackerSecondLevel(
         );
       }
     } else {
-      runState.log.push(
-        `${runState.runner} lowers a shoulder into ${linebacker.player}; truck check is not implemented yet.`
-      );
+      truckResult = performTruckAttempt(runState.runner, linebacker.player, players);
+
+      if (!truckResult.trucked) {
+        runState.log.push(
+          `${runState.runner} fails to truck ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`
+        );
+        carryDefenderResult = handleLbWrapTackle(
+          runState,
+          linebacker.player,
+          "LB Second-Level Truck Failed",
+          players
+        );
+      } else {
+        runState.log.push(
+          `${runState.runner} trucks ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to accelerate again.`
+        );
+
+        const otherLinebacker = getOtherLinebackerInPlay(defenseFormation, linebacker);
+        const hasDbChase = hasDbChasingPlay(defenseFormation, runLaneTarget);
+        truckAccelerationResult = performPostTruckAccelerationCheck(runState.runner, players);
+
+        if (!otherLinebacker && !hasDbChase) {
+          runState.log.push(`${runState.runner} has no remaining second-level defenders in chase after the truck.`);
+        } else if (truckAccelerationResult.acceleratedPast) {
+          runState.log.push(
+            `${runState.runner} accelerates past the remaining defenders after contact (roll ${truckAccelerationResult.roll.toFixed(2)} <= ${truckAccelerationResult.accelPastChance.toFixed(2)}%).`
+          );
+        } else {
+          const pursuingDefender = otherLinebacker?.player || linebacker.player;
+          runState.log.push(
+            `${runState.runner} cannot accelerate past the remaining defenders after the truck (roll ${truckAccelerationResult.roll.toFixed(2)} > ${truckAccelerationResult.accelPastChance.toFixed(2)}%).`
+          );
+          handleRunnerTackle(
+            runState,
+            pursuingDefender,
+            "LB Post-Truck Acceleration Failed",
+            players
+          );
+        }
+      }
     }
   }
 
@@ -944,6 +1046,8 @@ export function resolveLinebackerSecondLevel(
     fallForwardResult,
     carryDefenderResult,
     secondChanceAttempt,
+    truckResult,
+    truckAccelerationResult,
     nextLevelPressure,
     stopped: runState.stopped,
   };


### PR DESCRIPTION
### Motivation
- Add a runner "truck" mechanic so runners can attempt to shoulder through tacklers using size/strength instead of always juking. 
- Give successful trucks a chance to re-accelerate past remaining defenders using a lower acceleration-succeed probability than a juke to reflect contact and near-zero speed.

### Description
- Added reusable helpers `performTruckAttempt` and `performPostTruckAccelerationCheck` implementing truck chance (runner size+strength vs defender size+strength) and post-truck accel chance `((acceleration/10)**2)/3` in `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts`.
- Wired the truck branch into backfield second-chance resolution in `apps/web/src/components/league/gameplay/engine/runEngine.ts` so failed trucks fall into existing tackle handling and successful trucks attempt to beat remaining penetrating DLs via the post-truck acceleration check.
- Integrated the same truck flow into linebacker second-level resolution in `runEngineHelper.ts` so failed LB trucks use the existing carry/tackle flow and successful LB trucks attempt to accelerate past other second-level defenders (or get tackled if the accel check fails).
- Updated relevant result types to return truck details (`TruckAttemptResult` and `TruckAccelerationResult`) for use in logs and downstream resolution.

### Testing
- Ran `git diff --check` which reported no whitespace/error diffs.
- Ran a TypeScript build with `npx tsc -b` which failed due to pre-existing `GameCenter.tsx` type errors unrelated to the truck changes, so no compile-time errors attributable to the new truck code were observed before the unrelated failures.
- Ran lint with `npm run lint` which reported an existing React hooks issue in `GameControls.tsx` unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a52a009e15883249b109dd0141a2bc1)