### PR TITLE
Combine post-truck and post-juke acceleration checks (`performPostTruckorJukeAccelerationCheck`)

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -20,7 +20,7 @@ import {
   pickShortAccelerationDefender,
   chooseRunnerDefenderSecondChanceAttempt,
   performTruckAttempt,
-  performPostTruckAccelerationCheck,
+  performPostTruckorJukeAccelerationCheck,
 } from "./runEngineHelper";
 
 export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
@@ -565,9 +565,10 @@ export function runPlay(
               `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`
             );
           } else {
-            const accelerationResult = performPostTruckAccelerationCheck(
+            const accelerationResult = performPostTruckorJukeAccelerationCheck(
               runState.runner,
-              ctx.players
+              ctx.players,
+              "truck"
             );
 
             if (accelerationResult.acceleratedPast) {

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -398,25 +398,33 @@ export function performTruckAttempt(
   };
 }
 
-export type TruckAccelerationResult = {
+export type PostContactAccelerationCheckType = "truck" | "juke";
+
+export type TruckOrJukeAccelerationResult = {
   runner: string;
+  checkType: PostContactAccelerationCheckType;
   runnerAcceleration: number;
   accelPastChance: number;
   roll: number;
   acceleratedPast: boolean;
 };
 
-export function performPostTruckAccelerationCheck(
+export function performPostTruckorJukeAccelerationCheck(
   runnerName: string,
-  players: PlayerTrait[]
-): TruckAccelerationResult {
+  players: PlayerTrait[],
+  checkType: PostContactAccelerationCheckType
+): TruckOrJukeAccelerationResult {
   const runner = findPlayerByName(players, runnerName);
   const runnerAcceleration = trait(runner, "acceleration");
-  const accelPastChance = ((runnerAcceleration / 10) ** 2) / 3;
+  const accelPastChance =
+    checkType === "juke"
+      ? runnerAcceleration
+      : ((runnerAcceleration / 10) ** 2) / 3;
   const roll = Math.random() * 100;
 
   return {
     runner: runnerName,
+    checkType,
     runnerAcceleration,
     accelPastChance,
     roll,
@@ -841,7 +849,7 @@ export type LbSecondLevelResult = {
   carryDefenderResult?: CarryDefenderResult;
   secondChanceAttempt?: RunnerDefenderSecondChanceAttempt;
   truckResult?: TruckAttemptResult;
-  truckAccelerationResult?: TruckAccelerationResult;
+  truckAccelerationResult?: TruckOrJukeAccelerationResult;
   nextLevelPressure?: LbNextLevelPressureResult;
   stopped: boolean;
 };
@@ -940,7 +948,11 @@ export function resolveLinebackerSecondLevel(
       return undefined;
     }
 
-    const escapeAccelerationResult = performPostTruckAccelerationCheck(runState.runner, players);
+    const escapeAccelerationResult = performPostTruckorJukeAccelerationCheck(
+      runState.runner,
+      players,
+      action
+    );
     if (escapeAccelerationResult.acceleratedPast) {
       runState.log.push(
         `${runState.runner} accelerates past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} <= ${escapeAccelerationResult.accelPastChance.toFixed(2)}%) and breaks into the secondary.`
@@ -1139,16 +1151,9 @@ export function getOtherWinningDLs(
   );
 }
 
-export type AccelerationCheckResult = {
-  runner: string;
-  runnerAcceleration: number;
-  roll: number;
-  succeeded: boolean;
-};
-
 export type DlPursuitStep = {
   defender: string;
-  accelerationCheck: AccelerationCheckResult;
+  accelerationCheck: TruckOrJukeAccelerationResult;
   wrapResult?: DlWrapResult;
   jukeResult?: DlJukeResult;
   outcome: "Accelerated Past DLs" | "Wrapped" | "Juked" | "Juke Failed";
@@ -1161,26 +1166,6 @@ export type DlPursuitResult = {
   steps: DlPursuitStep[];
 };
 
-export function performAccelerationCheck(
-  runnerName: string,
-  players: PlayerTrait[]
-): AccelerationCheckResult {
-  const runner = findPlayerByName(players, runnerName);
-
-  const runnerAcceleration = trait(runner, "acceleration");
-
-  const roll = Math.random() * 100;
-
-  const succeeded = roll <= runnerAcceleration;
-
-  return {
-    runner: runnerName,
-    runnerAcceleration,
-    roll,
-    succeeded,
-  };
-}
-
 export function resolveRemainingDlPursuit(
   runState: RunPlayState,
   remainingWinningDLs: LineWinLossResult[],
@@ -1191,12 +1176,13 @@ export function resolveRemainingDlPursuit(
   for (const dlBattle of remainingWinningDLs) {
     const defenderName = dlBattle.defensePlayer;
 
-    const accelerationCheck = performAccelerationCheck(
+    const accelerationCheck = performPostTruckorJukeAccelerationCheck(
       runState.runner,
-      players
+      players,
+      "juke"
     );
 
-    if (accelerationCheck.succeeded) {
+    if (accelerationCheck.acceleratedPast) {
       steps.push({
         defender: defenderName,
         accelerationCheck,


### PR DESCRIPTION
### Motivation
- Unify post-contact acceleration logic so both post-truck and post-juke checks use a single helper and callers can distinguish which check ran.
- After a juke the acceleration test should be a straight 0–100 roll against the runner's `acceleration` trait, while the existing post-truck formula is preserved.

### Description
- Added `PostContactAccelerationCheckType` and `TruckOrJukeAccelerationResult` and replaced the old `performPostTruckAccelerationCheck` with `performPostTruckorJukeAccelerationCheck` that accepts a `checkType` (`"truck" | "juke"`) and returns `checkType` in the result.
- Kept the previous truck formula and implemented juke checks as a direct 0–100 roll against the runner's `acceleration` by using `accelPastChance = runnerAcceleration` when `checkType === "juke"`.
- Updated callers to pass the appropriate check type: backfield post-truck callers now pass `"truck"`, DL pursuit/juke flows pass `"juke"`, and the second-level restart logic forwards the actual action (`"truck" | "juke"`).
- Replaced the earlier `AccelerationCheckResult`/`performAccelerationCheck` use in DL pursuit with the new `TruckOrJukeAccelerationResult` type so steps include the check type and result.
- Files changed: `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` and `apps/web/src/components/league/gameplay/engine/runEngine.ts`.

### Testing
- Ran `git diff --check` with no whitespace/patch issues found. 
- Ran `npm run build` for `apps/web`, which failed due to pre-existing TypeScript errors in `GameCenter.tsx` unrelated to the changes in run engine files; no type errors were reported for the modified run-engine symbols after the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a52a55fb4088324b22f7dea39f8d2ef)