### PR TITLE
Add secondary speed yardage for run breakouts

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -100,6 +100,9 @@ async function getFrontendSettingsFromSheet() {
     accelToLBYards: settingRows(rows, "accel_to_LB_")
       .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), yards: parseInt(String(r[2]), 10) }))
       .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.yards)),
+    secondarySpeedYards: settingRows(rows, "speed_lvl2_")
+      .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) }))
+      .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.minYards) && Number.isFinite(r.maxYards)),
     staminaDrains,
     tackleTable: settingRows(rows, "Tackle_").map((r) => ({ label: r[0], yardageCap: Number(r[1]), DL: Number(r[2]) || 0, LB: Number(r[3]) || 0, DBS: Number(r[4]) || 0 })).sort((a,b)=>a.yardageCap-b.yardageCap),
     completionTable: settingRows(rows, "airYards_Completion_").map((r) => ({ label: r[0], pastLos: Number(r[1]), baseCompletion: Number(r[2]), percentage: Number(r[3]) })),

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -26,6 +26,7 @@ function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendS
   normalized.thresholds = Array.isArray(normalized.thresholds) ? normalized.thresholds : [];
   normalized.breakaways = Array.isArray(normalized.breakaways) ? normalized.breakaways : [];
   normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards) ? normalized.accelToLBYards : [];
+  normalized.secondarySpeedYards = Array.isArray(normalized.secondarySpeedYards) ? normalized.secondarySpeedYards : [];
   normalized.staminaDrains = normalized.staminaDrains ?? {};
   normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
   normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -722,4 +722,31 @@ export function runPlay(
 
     console.log("LB second level result:", lbSecondLevelResult);
   }
+
+  const rawYards = runState.yards;
+  const newBall = advanceBall(game, rawYards);
+  const td = isTouchdown(game, newBall);
+  const safety = isSafety(game, newBall);
+  const yards = td
+    ? Math.abs((game.Possession === "Home" ? 100 : 0) - n(game.BallOn))
+    : safety
+      ? -Math.abs(n(game.BallOn) - (game.Possession === "Home" ? 0 : 100))
+      : rawYards;
+  const tackler = td ? "NA" : runState.tackler || determineTackler(ctx, defense, yards);
+  const fumble = td || safety ? { fumble: false, recoveredBy: "" } : checkForFumble(ctx, runnerName, tackler);
+  const next = nextDownDistance(game, yards, newBall);
+  const result = td ? "Touchdown" : safety ? "Safety" : fumble.fumble ? "Fumble" : next.turnover ? "TO on Downs" : yards >= n(game.Distance) ? "First Down" : "Normal";
+  let hs = n(game.HomeScore), as = n(game.AwayScore);
+  if (td) { if (game.Possession === "Home") hs += 6; else as += 6; }
+  if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
+  const possession = td || safety || next.turnover || (fumble.fumble && fumble.recoveredBy === tackler) ? switchPoss(game) : game.Possession;
+  const runner = byName(ctx, runnerName);
+  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result)));
+  const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: next.down, Distance: next.distance, BallOn: next.ballOn, Previous: game.BallOn, DriveStart: next.turnover || td || safety ? next.ballOn : (game as unknown as Record<string, unknown>).DriveStart ?? game.BallOn, Possession: possession };
+
+  return buildResult(game, updated, "Run", runnerName, "", yards, tackler, result, ctx.historyLength, {
+    recoveredby: fumble.recoveredBy,
+    runLog: runState.log,
+    stopReason: runState.stopReason ?? "",
+  });
 }

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -3,6 +3,7 @@ import type {
   DefensiveAssignment,
   PlayerTrait,
   RunAccelToLBSetting,
+  RunSecondarySpeedSetting,
   FrontendSettings,
   RunPlayState
 } from "./types";
@@ -631,6 +632,64 @@ export function getAccelToLBYards(
   return fallbackYards;
 }
 
+export function getSecondarySpeedYards(
+  runner: PlayerTrait | undefined,
+  settings: FrontendSettings | undefined,
+  modLog?: string[]
+) {
+  const baseRoll = Math.floor(Math.random() * 101);
+  const speed = trait(runner, "speed");
+  const speedMod = (speed / 15) ** 2;
+  const adjustedRoll = Math.min(100, baseRoll + speedMod);
+
+  let cumulative = 0;
+  const secondarySpeedSettings = settingArray<RunSecondarySpeedSetting>(settings, "secondarySpeedYards");
+  for (const range of secondarySpeedSettings) {
+    cumulative += Number(range.percentage) || 0;
+    if (adjustedRoll <= cumulative) {
+      const minYards = Number(range.minYards) || 0;
+      const maxYards = Number(range.maxYards) || minYards;
+      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+      modLog?.push(
+        `Yard +${yards} Secondary Speed (roll ${adjustedRoll.toFixed(2)} = ${baseRoll} + ${speedMod.toFixed(2)})`
+      );
+      return yards;
+    }
+  }
+
+  const fallback = secondarySpeedSettings[secondarySpeedSettings.length - 1];
+  if (fallback) {
+    const minYards = Number(fallback.minYards) || 0;
+    const maxYards = Number(fallback.maxYards) || minYards;
+    const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+    modLog?.push(
+      `Yard +${yards} Secondary Speed (capped roll ${adjustedRoll.toFixed(2)})`
+    );
+    return yards;
+  }
+
+  return 0;
+}
+
+function addSecondarySpeedYards(
+  runState: RunPlayState,
+  players: PlayerTrait[],
+  settings: FrontendSettings | undefined
+) {
+  const secondarySpeedYards = getSecondarySpeedYards(
+    findPlayerByName(players, runState.runner),
+    settings,
+    runState.log
+  );
+  if (secondarySpeedYards > 0) {
+    addYards(
+      runState,
+      secondarySpeedYards,
+      `${runState.runner} uses speed in the secondary before pursuit can close`
+    );
+  }
+}
+
 export type DefenderWrapResult = {
   defender: string;
   defenderTackling: number;
@@ -928,7 +987,8 @@ export function resolveLinebackerSecondLevel(
   );
 
   if (!linebacker) {
-    runState.log.push(`${runState.runner} reaches the second level with no linebacker in position.`);
+    runState.log.push(`${runState.runner} reaches the second level with no linebacker in position and breaks into the secondary.`);
+    addSecondarySpeedYards(runState, players, settings);
     return { stopped: false };
   }
 
@@ -945,6 +1005,7 @@ export function resolveLinebackerSecondLevel(
       runState.log.push(
         `${runState.runner} has no remaining linebackers or defensive linemen after the ${action} and accelerates into the secondary.`
       );
+      addSecondarySpeedYards(runState, players, settings);
       return undefined;
     }
 
@@ -957,6 +1018,7 @@ export function resolveLinebackerSecondLevel(
       runState.log.push(
         `${runState.runner} accelerates past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} <= ${escapeAccelerationResult.accelPastChance.toFixed(2)}%) and breaks into the secondary.`
       );
+      addSecondarySpeedYards(runState, players, settings);
       return undefined;
     }
 
@@ -987,6 +1049,7 @@ export function resolveLinebackerSecondLevel(
       runState.log.push(
         `${runState.runner} has no remaining eligible defenders after gaining +${accelerationYards} and accelerates into the secondary.`
       );
+      addSecondarySpeedYards(runState, players, settings);
       return undefined;
     }
 

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -21,10 +21,12 @@ export type PlayerTrait = Record<string, unknown>;
 export type RunThreshold = { label: string; minYards: number; maxYards: number; rollMin: number; rollMax: number };
 export type RunBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type RunAccelToLBSetting = { label: string; percentage: number; yards: number };
+export type RunSecondarySpeedSetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type FrontendSettings = Record<string, unknown> & {
   thresholds?: RunThreshold[];
   breakaways?: RunBreakawaySetting[];
   accelToLBYards?: RunAccelToLBSetting[];
+  secondarySpeedYards?: RunSecondarySpeedSetting[];
   staminaDrains?: Record<string, number>;
   drainSettings?: Record<string, number>;
   tackleTable?: unknown[];


### PR DESCRIPTION
### Motivation
- Implement extra yardage when a runner breaks into the secondary by using a Settings table (speed_lvl2_) and a speed-based roll modifier so fast runners can gain additional yards before pursuit closes.

### Description
- Add `RunSecondarySpeedSetting` type and `secondarySpeedYards` to `FrontendSettings`, and normalize it in the frontend. (types and normalization updates in `types.ts` and `GameCenter.tsx`).
- Parse `speed_lvl2_` rows from the Settings sheet into the API frontend settings as `secondarySpeedYards`. (`apps/api/src/routes/gameRoutes.ts`).
- Add `getSecondarySpeedYards` and helper `addSecondarySpeedYards` which roll 0–100, add `(speed/15)^2` as a modifier, select the configured percentage bucket, then pick a random int between the bucket `minYards` and `maxYards` and log the modifier. (`runEngineHelper.ts`).
- Apply the computed secondary speed yards when the runner breaks into the secondary (no linebacker, accelerates past remaining defenders, or after restart cycles), and include `runState.log` and `stopReason` in the run-play result; ensure the run pipeline returns a built play result using accumulated run-state yards. (`runEngineHelper.ts`, `runEngine.ts`).

### Testing
- Built the web frontend with `npm run build --prefix apps/web`, which completed successfully.
- Ran `npm run build --prefix apps/api`, which failed because the API package has no `build` script (expected repository limitation).
- Ran `git diff --check` to validate whitespace/patch issues with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53bac3596c8324a850977a36dcaf75)