### PR TITLE
Document run engine play logic

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -23,23 +23,26 @@ import {
   performPostTruckorJukeAccelerationCheck,
 } from "./runEngineHelper";
 
+/** Chooses the most plausible tackler after a run or pass play has ended, weighting nearby defender groups by tackling ability. It is used by `runPlay`, `runPlayOld`, and pass-play fumble/tackle resolution when no specific tackler was already recorded. */
 export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
   const defenders = teamPlayers(ctx, defense);
   const preferred = yards <= 2 ? ["DL", "LB"] : yards <= 8 ? ["LB", "DB", "S"] : ["DB", "S", "LB"];
   const pool = defenders.filter((p) => preferred.includes(String(p.defPos ?? "").toUpperCase())) || defenders;
-  return playerName(weightedChoose(pool.length ? pool : defenders, (p) => trait(p, "tackleChance")), "NA");
+  return playerName(weightedChoose(pool.length ? pool : defenders, (p) => trait(p, "tackleChance")), "NA"); // TRAIT USED: TackleChance
 }
+/** Resolves whether contact creates a fumble by comparing the defender's strip skill against the runner's ball security and hands. It is called after run and pass tackles so possession changes can be reflected in the final play result. */
 export function checkForFumble(ctx: EngineContext, runnerName: string, tacklerName: string, sack = false) {
   const runner = byName(ctx, runnerName); const defender = byName(ctx, tacklerName);
-  const strip = trait(defender, "strip", 20); const ballSecurity = (trait(runner, "ballsecurity", 50) + trait(runner, "hands", 50)) / 2;
-  const chance = sack ? (strip / 12) * ((110 - ballSecurity) / 100) + trait(defender, "defStars", 0) / 150 : (strip / 10) * ((100 - ballSecurity) / 100);
+  const strip = trait(defender, "strip", 20); const ballSecurity = (trait(runner, "ballsecurity", 50) + trait(runner, "hands", 50)) / 2; // TRAIT USED: Strip TRAIT USED: BallSecurity TRAIT USED: Hands
+  const chance = sack ? (strip / 12) * ((110 - ballSecurity) / 100) + trait(defender, "defStars", 0) / 150 : (strip / 10) * ((100 - ballSecurity) / 100); // TRAIT USED: DefStars
   const fumble = Math.random() * 100 < chance;
   if (!fumble) return { fumble: false, recoveredBy: "" };
-  const defStars = trait(defender, "defStars", 50), offStars = trait(runner, "offStars", 50);
+  const defStars = trait(defender, "defStars", 50), offStars = trait(runner, "offStars", 50); // TRAIT USED: DefStars TRAIT USED: OffStars
   return { fumble: true, recoveredBy: Math.random() * (defStars + offStars) < offStars ? runnerName : tacklerName };
 }
 type CarryStats = { name: string; runner?: Record<string, unknown>; offStar?: boolean; defStar?: boolean; autoStuff?: boolean; autoRelease?: boolean; settings?: FrontendSettings };
 
+/** Safely reads a run-engine settings array so callers can use frontend tuning data without defensive null checks. It is used by the legacy carry outcome and breakaway-yard helpers below. */
 function settingArray<T>(settings: FrontendSettings | undefined, key: keyof FrontendSettings): T[] {
   const value = settings?.[key];
   return Array.isArray(value) ? (value as T[]) : [];
@@ -50,15 +53,16 @@ function settingArray<T>(settings: FrontendSettings | undefined, key: keyof Fron
 // Legacy single-carry yardage model
 // ---------------------------------------------------------------------------
 
+/** Simulates the old one-roll rushing model from handoff to yardage result. It remains available through `runPlayOld` and as a compact helper for legacy tests or fallback play logic. */
 export function simulateSingleCarry(stats: CarryStats) {
   const modLog: string[] = [];
   //if auto stuff, -3 > 2 yards is the range +1 yard for straight up check against each vision and strength
   if (stats.autoStuff) {
     let yards = Math.floor(Math.random() * 5) - 2;
     //vision check - add 1 yard to autostuff
-    if (Math.random() * 100 < trait(stats.runner, "vision")) { yards += 1; modLog.push("Vision softened auto-stuff"); }
+    if (Math.random() * 100 < trait(stats.runner, "vision")) { yards += 1; modLog.push("Vision softened auto-stuff"); } // TRAIT USED: Vision
     //strength check - add 1 yard to autostuff
-    if (Math.random() * 100 < trait(stats.runner, "strength")) { yards += 1; modLog.push("Power fell forward"); }
+    if (Math.random() * 100 < trait(stats.runner, "strength")) { yards += 1; modLog.push("Power fell forward"); } // TRAIT USED: Strength
     return { name: stats.name, roll: 0, yards, modLog };
   }
   let roll = Math.floor(Math.random() * 101);
@@ -70,11 +74,11 @@ export function simulateSingleCarry(stats: CarryStats) {
   //  for 80: add 1.5 to roll 
   //  for 90: add 2.25 to roll
   //  for 100: add 3 to roll
-  const visionMod = (trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.055;
+  const visionMod = (trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.055; // TRAIT USED: Vision TRAIT USED: Fatigue
   roll += visionMod
   //HARDCODED 88 ALERT!
   if (roll < 88){
-    roll += maybeBoostRollForAcceleration(trait(stats.runner, "acceleration"), trait(stats.runner, "fatigue"));
+    roll += maybeBoostRollForAcceleration(trait(stats.runner, "acceleration"), trait(stats.runner, "fatigue")); // TRAIT USED: Acceleration TRAIT USED: Fatigue
   }
 
   //let yards = roll >= 98 ? Math.floor(Math.random() * 31) + 20 : roll >= 85 ? Math.floor(Math.random() * 11) + 10 : roll >= 65 ? Math.floor(Math.random() * 6) + 5 : roll >= 40 ? Math.floor(Math.random() * 5) + 1 : roll >= 20 ? 0 : -Math.floor(Math.random() * 4);
@@ -82,25 +86,25 @@ export function simulateSingleCarry(stats: CarryStats) {
 
   //Off Stars Check - add yards = floor(stars) if triggered
   if (stats.offStar) {
-    yards += Math.floor(trait(stats.runner, "offStars"));
-    modLog.push(`Yard +`+Math.floor(trait(stats.runner, "offStars"))+` : offStarPower`);
+    yards += Math.floor(trait(stats.runner, "offStars")); // TRAIT USED: OffStars
+    modLog.push(`Yard +`+Math.floor(trait(stats.runner, "offStars"))+` : offStarPower`); // TRAIT USED: OffStars
   }
   //Def Stars Check - remove yards = floor(stars) if triggered
   if (stats.defStar) {
-    yards += - Math.floor(trait(stats.runner, "defStars"));
-    modLog.push(`Yard -`+Math.floor(trait(stats.runner, "defStars"))+` : defStarPower`);
+    yards += - Math.floor(trait(stats.runner, "defStars")); // TRAIT USED: DefStars
+    modLog.push(`Yard -`+Math.floor(trait(stats.runner, "defStars"))+` : defStarPower`); // TRAIT USED: DefStars
   }
 
   yards = maybeAvoidLoss(yards, stats, modLog);
 
   //Vision Check - 
-  if (yards <= 2) yards += applyTraitEffect("Vision", trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog);
+  if (yards <= 2) yards += applyTraitEffect("Vision", trait(stats.runner, "vision") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog); // TRAIT USED: Vision TRAIT USED: Fatigue
   //Strength Check, Size Check - 
-  if (yards <= 4) yards += applyTraitEffect("Power", (trait(stats.runner, "size") + trait(stats.runner, "strength") + Math.min(0, trait(stats.runner, "fatigue")))/2, true, modLog);
+  if (yards <= 4) yards += applyTraitEffect("Power", (trait(stats.runner, "size") + trait(stats.runner, "strength") + Math.min(0, trait(stats.runner, "fatigue")))/2, true, modLog); // TRAIT USED: Size TRAIT USED: Strength TRAIT USED: Fatigue
   //Acceleration Check - 
-  if (yards >= 3 && yards <= 4) yards += applyTraitEffect("Acceleration", trait(stats.runner, "acceleration") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog);
+  if (yards >= 3 && yards <= 4) yards += applyTraitEffect("Acceleration", trait(stats.runner, "acceleration") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog); // TRAIT USED: Acceleration TRAIT USED: Fatigue
   //Juke Check - 
-  if (yards > 0 && yards < 10) yards += applyTraitEffect("Juke", trait(stats.runner, "juke") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog);
+  if (yards > 0 && yards < 10) yards += applyTraitEffect("Juke", trait(stats.runner, "juke") + Math.min(0, trait(stats.runner, "fatigue")), true, modLog); // TRAIT USED: Juke TRAIT USED: Fatigue
 
   yards = adjustChunkRunForSpeed(yards, stats, modLog, false);
 
@@ -108,6 +112,7 @@ export function simulateSingleCarry(stats: CarryStats) {
 }
 
 
+/** Converts a runner trait deviation from average into a small yardage modifier. It is used inside `simulateSingleCarry` after the base yardage tier has already been chosen. */
 function applyTraitEffect(traitName: string, traitValue: number, condition: boolean, modLog: string[]) {
   if (!condition) return 0;
   const deviation = traitValue - 60;
@@ -123,9 +128,10 @@ function applyTraitEffect(traitName: string, traitValue: number, condition: bool
 }
 
 //Strength check, size check - size + strength/2.2 chance of avoiding loss and turning into 1-2 yard gain
+/** Gives a powerful runner a chance to turn a negative legacy carry into a short gain. It is used by `simulateSingleCarry` before the final trait-based polish is applied. */
 export function maybeAvoidLoss(yards: number, stats: CarryStats, modLog: string[]) {
   if (yards < 0) {
-    const power = trait(stats.runner, "size") + trait(stats.runner, "strength") + Math.min(0, trait(stats.runner, "fatigue"));
+    const power = trait(stats.runner, "size") + trait(stats.runner, "strength") + Math.min(0, trait(stats.runner, "fatigue")); // TRAIT USED: Size TRAIT USED: Strength TRAIT USED: Fatigue
     const chanceToAvoid = power / 2.2; //CHANGE - no hard code
     if (Math.random() < chanceToAvoid / 100) {
       const newYards = randomInt(1, 2);
@@ -141,20 +147,22 @@ export function maybeAvoidLoss(yards: number, stats: CarryStats, modLog: string[
 //  for 80: add 2 yard
 //  for 90: add 3 yard
 //  for 100: add 4 yard
+/** Applies speed bonuses to chunk gains or yards-after-catch style runs in the legacy carry model. It is used by `simulateSingleCarry` and can also support YAC callers that pass the `yac` flag. */
 export function adjustChunkRunForSpeed(yards: number, stats: CarryStats, modLog: string[], yac: boolean) {
     if (yac && yards >= 5){
-      const bonus = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) / 5); //CHANGE no hard code
+      const bonus = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) / 5); //CHANGE no hard code // TRAIT USED: Speed TRAIT USED: Fatigue
       if (bonus !== 0) modLog.push(`Yard ${bonus > 0 ? "+" : ""}${bonus} Speed`);
       return yards + bonus;
     }
     else if (yards >= 10 && yards <= 15) { //CHANGE no hard code
-      const bonus = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) / 10); //CHANGE no hard code
+      const bonus = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) / 10); //CHANGE no hard code // TRAIT USED: Speed TRAIT USED: Fatigue
       if (bonus !== 0) modLog.push(`Yard ${bonus > 0 ? "+" : ""}${bonus} Speed`);
       return yards + bonus;
     }
     return yards;
   }
 
+/** Translates the legacy carry roll into yards using frontend thresholds, with breakaway rolls delegated to `getStrictBreakawayYards`. It is the main yardage table lookup inside `simulateSingleCarry`. */
 export function getYardageOutcome(roll: number, stats: CarryStats, modLog: string[]) {
   if (roll >= 100){
     return getStrictBreakawayYards(stats, modLog);
@@ -172,9 +180,10 @@ export function getYardageOutcome(roll: number, stats: CarryStats, modLog: strin
 }
 
 //Speed Check -
+/** Rolls the specific yardage for a legacy breakaway run and lets speed push the runner toward longer breakaway buckets. It is used whenever `getYardageOutcome` reaches the breakaway tier. */
 export function getStrictBreakawayYards(stats: CarryStats, modLog: string[]) {
   const baseRoll = Math.floor(Math.random() * 100);
-  const speedBoost = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.3);
+  const speedBoost = Math.floor((trait(stats.runner, "speed") + Math.min(0, trait(stats.runner, "fatigue")) - 60) * 0.3); // TRAIT USED: Speed TRAIT USED: Fatigue
   const adjustedRoll = Math.min(100, baseRoll + Math.max(0, speedBoost));
   if (speedBoost !== 0) modLog.push(`Pre +${speedBoost} Speed`);
 
@@ -197,6 +206,7 @@ export function getStrictBreakawayYards(stats: CarryStats, modLog: string[]) {
 //  for 80: 13.3% chance of 1.67 to 6.67 to roll 
 //  for 90: 20% chance of 5 to 10 to roll 
 //  for 100: 26.7% chance of 8.33 to 13.33 to roll
+/** Gives acceleration a pre-yardage chance to lift an otherwise ordinary legacy carry roll. It is used by `simulateSingleCarry` before threshold lookup. */
 export function maybeBoostRollForAcceleration(acceleration: number, fatigue: number){
   let boost = 0;
   const chance = (acceleration + Math.min(0, fatigue) - 60) / 1.5;
@@ -218,9 +228,10 @@ export function maybeBoostRollForAcceleration(acceleration: number, fatigue: num
 
 //ballCarrier.offStars ^2 chance of true. Otherwise false
 //NEEDS TRansition TO THIS CLASS
+/** Checks whether the ball carrier's offensive star power activates for the legacy model. It is used by `runPlayOld` before calling `simulateSingleCarry`. */
 export function rollOffStarPower(ctx: EngineContext, ballCarrierName: string) {
   const ballCarrier = byName(ctx, ballCarrierName);
-  const stars = trait(ballCarrier, "offStars", 0);
+  const stars = trait(ballCarrier, "offStars", 0); // TRAIT USED: OffStars
 
   const threshold = Math.pow(stars, 2);
   const roll = Math.random() * 100;
@@ -228,6 +239,7 @@ export function rollOffStarPower(ctx: EngineContext, ballCarrierName: string) {
   return roll <= threshold;
 }
 //NEEDS TRansition TO THIS CLASS
+/** Selects and checks a front-seven defender for defensive star power in the legacy model. It is used by `runPlayOld` to apply a defensive yardage penalty. */
 export function rollDefStarPower(ctx: EngineContext, defense: string) {
   const candidates = teamPlayers(ctx, defense)
     .filter((p) => {
@@ -235,7 +247,7 @@ export function rollDefStarPower(ctx: EngineContext, defense: string) {
       return pos === "DL" || pos === "LB";
     })
     .map((p) => {
-      const stars = trait(p, "defStars", 0);
+      const stars = trait(p, "defStars", 0); // TRAIT USED: DefStars
       return {
         player: p,
         name: playerName(p),
@@ -275,6 +287,7 @@ export function rollDefStarPower(ctx: EngineContext, defense: string) {
   };
 }
 //NEEDS TRansition TO THIS CLASS
+/** Compares total run-blocking strength against defensive front run defense for the legacy auto-stuff/auto-release branch. It is used only by `runPlayOld`. */
 export function runBlockVsRunDef(
   ctx: EngineContext,
   _offense: string,
@@ -308,12 +321,12 @@ export function runBlockVsRunDef(
     .filter(Boolean);
 
   const dlTotal = defensiveFront.reduce(
-    (sum, p) => sum + trait(p, "runDef", 0),
+    (sum, p) => sum + trait(p, "runDef", 0), // TRAIT USED: RunDef
     0
   );
 
   const olTotal = offensiveBlockers.reduce(
-    (sum, p) => sum + trait(p, "runBlocking", 0),
+    (sum, p) => sum + trait(p, "runBlocking", 0), // TRAIT USED: RunBlocking
     0
   );
 
@@ -338,6 +351,7 @@ export function runBlockVsRunDef(
   };
 }
 //NEEDS TRansition TO THIS CLASS
+/** Rolls whether a winning defensive front immediately stuffs the legacy run. It is used by `runPlayOld` after `runBlockVsRunDef` says the defense won the blocking contest. */
 export function tryAutoStuff(ctx: EngineContext, defense: string) {
   const defensiveFront = teamPlayers(ctx, defense).filter((p) => {
     const pos = String(p.defPos ?? "").toUpperCase();
@@ -345,7 +359,7 @@ export function tryAutoStuff(ctx: EngineContext, defense: string) {
   });
 
   const starPower = defensiveFront.reduce((sum, p) => {
-    const stars = trait(p, "defStars", 0);
+    const stars = trait(p, "defStars", 0); // TRAIT USED: DefStars
     return sum + Math.pow(stars, 2) / 2.5;
   }, 0);
 
@@ -354,6 +368,7 @@ export function tryAutoStuff(ctx: EngineContext, defense: string) {
   return roll <= starPower;
 }
 //NEEDS TRansition TO THIS CLASS
+/** Rolls whether a winning blocking unit creates an automatic release in the legacy run. It is used by `runPlayOld` after `runBlockVsRunDef` says the offense won the blocking contest. */
 export function tryAutoRelease(
   ctx: EngineContext,
   formation: Record<string, string | undefined>,
@@ -380,7 +395,7 @@ export function tryAutoRelease(
     .filter(Boolean);
 
   const starPower = blockers.reduce((sum, p) => {
-    const stars = trait(p, "offStars", 0);
+    const stars = trait(p, "offStars", 0); // TRAIT USED: OffStars
     return sum + Math.pow(stars, 2) / 2.5;
   }, 0);
 
@@ -389,6 +404,7 @@ export function tryAutoRelease(
   return roll <= starPower;
 }
 
+/** Runs the previous compact rushing simulation and then applies normal football bookkeeping. It remains exported for compatibility while `runPlay` below is the current step-by-step pipeline. */
 export function runPlayOld(game: LeagueGame, ctx: EngineContext, options: PlayCallOptions = {}) {
   const offense = offenseTeam(game), defense = defenseTeam(game);
   const formation = options.formation ?? {};
@@ -396,8 +412,8 @@ export function runPlayOld(game: LeagueGame, ctx: EngineContext, options: PlayCa
   const runnerName = playerName(runner, `${offense} Runner`);
   //const blockers = Object.values(formation).map((name) => byName(ctx, name)).filter(Boolean).filter((p) => playerName(p) !== runnerName);
   //const rushers = teamPlayers(ctx, defense).filter((p) => ["DL", "LB"].includes(String(p.defPos ?? "").toUpperCase()));
-  //const offTotal = blockers.reduce((s, p) => s + trait(p, "runBlocking"), 0);
-  //const defTotal = rushers.reduce((s, p) => s + trait(p, "runDef"), 0);
+  //const offTotal = blockers.reduce((s, p) => s + trait(p, "runBlocking"), 0); // TRAIT USED: RunBlocking
+  //const defTotal = rushers.reduce((s, p) => s + trait(p, "runDef"), 0); // TRAIT USED: RunDef
 
   const offStarPower = rollOffStarPower(ctx, runnerName);
   const defStarPowerResult = rollDefStarPower(ctx, defense);
@@ -438,7 +454,7 @@ export function runPlayOld(game: LeagueGame, ctx: EngineContext, options: PlayCa
   const result = td ? "Touchdown" : safety ? "Safety" : fumble.fumble ? "Fumble" : next.turnover ? "TO on Downs" : yards >= n(game.Distance) ? "First Down" : "Normal";
   let hs = n(game.HomeScore), as = n(game.AwayScore); if (td) { if (game.Possession === "Home") hs += 6; else as += 6; } if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
   const possession = td || safety || next.turnover || (fumble.fumble && fumble.recoveredBy === tackler) ? switchPoss(game) : game.Possession;
-  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result)));
+  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result))); // TRAIT USED: Speed
   const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: next.down, Distance: next.distance, BallOn: next.ballOn, Previous: game.BallOn, DriveStart: next.turnover || td || safety ? next.ballOn : (game as unknown as Record<string, unknown>).DriveStart ?? game.BallOn, Possession: possession };
   return buildResult(game, updated, "Run", runnerName, "", yards, tackler, result, ctx.historyLength, { recoveredby: fumble.recoveredBy });
 }
@@ -447,6 +463,7 @@ export function runPlayOld(game: LeagueGame, ctx: EngineContext, options: PlayCa
 // Current run-play pipeline
 // ---------------------------------------------------------------------------
 
+/** Runs the current detailed rushing pipeline from line matchups through second-level pursuit and final scoreboard bookkeeping. This is the primary run-play entry point re-exported by `gameEngine.ts`. */
 export function runPlay(
   game: LeagueGame,
   ctx: EngineContext,
@@ -455,12 +472,14 @@ export function runPlay(
   const offense = offenseTeam(game);
   const defense = defenseTeam(game);
 
+  // Establish the two teams before any football logic so all later lookups use the same possession snapshot.
   console.log("Offense:", offense);
   console.log("Defense:", defense);
 
   const offenseFormation = options.formation ?? {};
   const defenseFormation = options.defense ?? [];
 
+  // The runner is explicitly selected by the caller when possible, then falls back to the primary back or quarterback in the formation.
   const runnerName = options.runner ?? offenseFormation.RB1 ?? offenseFormation.QB ?? "";
 
   if (!runnerName) {
@@ -469,6 +488,7 @@ export function runPlay(
 
   const runState = createRunPlayState(runnerName);
 
+  // First phase: every trench slot resolves independently so the later vision check knows whether lanes are open or collapsed.
   const lineWinLossArray = performLineWinLoss(
     offenseFormation,
     defenseFormation,
@@ -477,8 +497,10 @@ export function runPlay(
 
   const olWins = lineWinLossArray.filter((battle) => battle.winner === "OL").length;
   const dlWins = lineWinLossArray.filter((battle) => battle.winner === "DL").length;
+  // More OL wins make the runner's vision target easier; more DL wins make the hole harder to find.
   const runBlockingModifier = (olWins - dlWins) * 10;
 
+  // Second phase: the runner either reads the blocking and gets past the defensive line, or misses the hole into backfield trouble.
   const visionCheck = performVisionCheck(
     runnerName,
     ctx.players,
@@ -486,6 +508,7 @@ export function runPlay(
     runBlockingModifier
   );
 
+  // The lane target records the blocker who sprung the lane or the defender who created penetration.
   const runLaneTarget = pickRunLaneTarget(
     lineWinLossArray,
     visionCheck,
@@ -501,6 +524,7 @@ export function runPlay(
 
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
+    // A missed hole immediately costs yardage before the runner can attempt to escape the penetrating defender.
     const backfieldYards = randomInt(-5, -1);
 
     addYards(
@@ -509,6 +533,7 @@ export function runPlay(
       `${runState.runner} fails to hit the hole and is forced into the backfield`
     );
 
+    // The first penetrating DL gets a clean wrap attempt before the runner can choose a counter move.
     dlWrapResult = performDlWrapCheck(
       runLaneTarget.selectedPlayer,
       ctx.players
@@ -523,6 +548,7 @@ export function runPlay(
       );
     } 
     else {
+      // If the wrap fails, the runner chooses the more natural second-chance move for the size matchup.
       const dlSecondChanceAttempt = chooseRunnerDefenderSecondChanceAttempt(
         runState.runner,
         dlWrapResult.defender,
@@ -535,6 +561,7 @@ export function runPlay(
       );
 
       if (dlSecondChanceAttempt.attempt === "Truck") {
+        // Truck attempts compare combined size/strength power and either restart the run or end in a tackle.
         const truckResult = performTruckAttempt(
           runState.runner,
           dlWrapResult.defender,
@@ -565,6 +592,7 @@ export function runPlay(
               `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`
             );
           } else {
+            // A successful truck still needs an acceleration check when other DLs won their lanes and can pursue.
             const accelerationResult = performPostTruckorJukeAccelerationCheck(
               runState.runner,
               ctx.players,
@@ -590,6 +618,7 @@ export function runPlay(
           }
         }
       } else {
+        // Juke attempts are the agility counter to a failed DL wrap.
         dlJukeResult = performDlJukeCheck(
           runState.runner,
           dlWrapResult.defender,
@@ -598,6 +627,7 @@ export function runPlay(
       }
 
       if (!runState.stopped && dlJukeResult && !dlJukeResult.juked) {
+        // A failed backfield juke gives the original defender the tackle, with fall-forward contact still possible.
         fallForwardResult = handleRunnerTackle(
           runState,
           dlWrapResult.defender,
@@ -606,6 +636,7 @@ export function runPlay(
         );
       } 
       else if (dlJukeResult?.juked) {
+        // After beating the first DL, only other DLs that won their matchups can continue the backfield pursuit chain.
         otherWinningDLsAfterJuke = getOtherWinningDLs(
           lineWinLossArray,
           dlWrapResult.defender
@@ -633,12 +664,14 @@ export function runPlay(
   }
   // Frontside branch: the runner found the intended lane and may face a swipe attempt.
   else {
+    // If the selected lane came from an OL win, the beaten DL can still make a last swipe at the runner's legs.
     dlSwipeResult =
       runLaneTarget.selectedSide === "OL"
         ? performDlSwipeCheck(lineWinLossArray, runLaneTarget, ctx.players)
         : null;
 
     if (dlSwipeResult?.tackled) {
+      // A successful swipe stops the runner at the line before acceleration yardage is added.
       runState.yards = 0;
 
       fallForwardResult = handleRunnerTackle(
@@ -672,6 +705,7 @@ export function runPlay(
   else {
     console.log("Run survived DL phase:", runState);
 
+    // Surviving the line creates acceleration yardage before the runner meets linebackers or short-crease DL pursuit.
     const accelToSecondLevelYards = getAccelToLBYards(
       byName(ctx, runState.runner),
       ctx.settings,
@@ -683,6 +717,7 @@ export function runPlay(
         .filter((step) => step.outcome === "Juked")
         .map((step) => step.defender) ?? []),
     ].filter((defender): defender is string => Boolean(defender));
+    // Short acceleration keeps nearby DLs alive as possible tacklers; longer acceleration means only second-level defenders are in position.
     const secondLevelDefender =
       accelToSecondLevelYards <= 3
         ? pickShortAccelerationDefender(
@@ -708,6 +743,7 @@ export function runPlay(
       `${runState.runner} hits the hole behind ${runLaneTarget.selectedPlayer} and clears the defensive line.`
     );
 
+    // The second-level resolver owns all LB contact, recursive juke/truck restarts, and secondary breakaway handling.
     const lbSecondLevelResult = resolveLinebackerSecondLevel(
       runState,
       defenseFormation,
@@ -724,6 +760,7 @@ export function runPlay(
   }
 
   const rawYards = runState.yards;
+  // Convert simulated yards into field position and clamp special scoring plays to the actual distance to goal/safety.
   const newBall = advanceBall(game, rawYards);
   const td = isTouchdown(game, newBall);
   const safety = isSafety(game, newBall);
@@ -735,13 +772,14 @@ export function runPlay(
   const tackler = td ? "NA" : runState.tackler || determineTackler(ctx, defense, yards);
   const fumble = td || safety ? { fumble: false, recoveredBy: "" } : checkForFumble(ctx, runnerName, tackler);
   const next = nextDownDistance(game, yards, newBall);
+  // Final result priority mirrors football outcomes: scoring, turnover events, then first down or normal play.
   const result = td ? "Touchdown" : safety ? "Safety" : fumble.fumble ? "Fumble" : next.turnover ? "TO on Downs" : yards >= n(game.Distance) ? "First Down" : "Normal";
   let hs = n(game.HomeScore), as = n(game.AwayScore);
   if (td) { if (game.Possession === "Home") hs += 6; else as += 6; }
   if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
   const possession = td || safety || next.turnover || (fumble.fumble && fumble.recoveredBy === tackler) ? switchPoss(game) : game.Possession;
   const runner = byName(ctx, runnerName);
-  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result)));
+  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result))); // TRAIT USED: Speed
   const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: next.down, Distance: next.distance, BallOn: next.ballOn, Previous: game.BallOn, DriveStart: next.turnover || td || safety ? next.ballOn : (game as unknown as Record<string, unknown>).DriveStart ?? game.BallOn, Possession: possession };
 
   return buildResult(game, updated, "Run", runnerName, "", yards, tackler, result, ctx.historyLength, {

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -11,6 +11,7 @@ import type {
 const TEOL_SLOTS: FormationSlot[] = ["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"];
 const CENTER_SLOT: FormationSlot = "TEOL3";
 
+/** Reads an optional frontend setting array and returns an empty list when the setting is absent. Run-yardage helpers use this to stay safe when tuning data is not loaded. */
 function settingArray<T>(settings: FrontendSettings | undefined, key: keyof FrontendSettings): T[] {
   const value = settings?.[key];
   return Array.isArray(value) ? (value as T[]) : [];
@@ -27,6 +28,7 @@ export type OlDlMatchup = {
   defensePosition: string;
 };
 
+/** Builds the offensive-line versus defensive-line battles for each trench slot. It is used by `performLineWinLoss` to decide who controls each run lane. */
 export function buildOlDlMatchups(
   offense: Partial<Record<FormationSlot, string>>,
   defense: DefensiveAssignment[]
@@ -47,6 +49,7 @@ export function buildOlDlMatchups(
     .filter((matchup) => matchup.offensePlayer || matchup.defensePlayer);
 }
 
+/** Normalizes trait-name spelling and casing before reading a numeric player trait. It is the central trait accessor used by every helper in this file and by run-engine callers. */
 export function trait(player: PlayerTrait | undefined, key: string): number {
   if (!player) return 0;
 
@@ -63,6 +66,7 @@ export function trait(player: PlayerTrait | undefined, key: string): number {
   return Number(value ?? 0);
 }
 
+/** Looks up a player object by the display/name fields used across roster data. It is used anywhere the run engine has a player name but needs trait values. */
 export function findPlayerByName(
   players: PlayerTrait[],
   playerName: string
@@ -92,6 +96,7 @@ export type LineWinLossResult = {
   winner: "DL" | "OL";
 };
 
+/** Resolves every OL/DL trench matchup and records whether the blocker or defender wins. `runPlay` uses this as the first phase of the detailed run simulation. */
 export function performLineWinLoss(
   offenseFormation: Partial<Record<FormationSlot, string>>,
   defenseFormation: DefensiveAssignment[],
@@ -103,15 +108,18 @@ export function performLineWinLoss(
     const offensivePlayer = findPlayerByName(players, matchup.offensePlayer);
     const defensivePlayer = findPlayerByName(players, matchup.defensePlayer);
 
-    const olRunBlocking = trait(offensivePlayer, "Run Blocking");
-    const dlRunStop = trait(defensivePlayer, "RunStop");
+    const olRunBlocking = trait(offensivePlayer, "Run Blocking"); // TRAIT USED: RunBlocking - measures how well this blocker controls the run lane.
+    const dlRunStop = trait(defensivePlayer, "RunStop"); // TRAIT USED: RunStop - measures how likely this defender is to penetrate the lane.
 
+    // Start the trench battle at 50/50, then shift it by the defender-minus-blocker trait gap.
     const rawDlWinChance = 50 + dlRunStop - olRunBlocking;
 
+    // Clamp the chance so great players matter without making a single matchup completely deterministic.
     const dlWinChance = Math.max(5, Math.min(95, rawDlWinChance));
 
     const roll = Math.random() * 100;
 
+    // Low rolls are defensive wins because `dlWinChance` is the DL success target.
     const winner: "DL" | "OL" = roll <= dlWinChance ? "DL" : "OL";
 
     return {
@@ -138,6 +146,7 @@ export type VisionCheckResult = {
   getsPastDL: boolean;
 };
 
+/** Determines whether the runner sees and reaches the intended hole after the line battle. `runPlay` uses the result to branch into either a backfield challenge or a clean lane. */
 export function performVisionCheck(
   runnerName: string,
   players: PlayerTrait[],
@@ -145,8 +154,9 @@ export function performVisionCheck(
   runBlockingModifier: number
 ): VisionCheckResult {
   const runner = findPlayerByName(players, runnerName);
-  const runnerVision = trait(runner, "vision");
+  const runnerVision = trait(runner, "vision"); // TRAIT USED: Vision - determines whether the runner can identify and hit the crease.
 
+  // Count line wins to detect automatic outcomes and explain how blocking modifies the vision target.
   const olWins = lineWinLossArray.filter((battle) => battle.winner === "OL").length;
   const dlWins = lineWinLossArray.filter((battle) => battle.winner === "DL").length;
   const totalBattles = lineWinLossArray.length;
@@ -154,11 +164,13 @@ export function performVisionCheck(
   const allOlWon = totalBattles > 0 && olWins === totalBattles;
   const allDlWon = totalBattles > 0 && dlWins === totalBattles;
 
+  // Vision starts from the runner trait plus the line result; the clamp keeps the target in percent-roll bounds.
   const rawVisionTarget = ((runnerVision * 0.19) + 75) + runBlockingModifier;
 
   const visionTarget = Math.max(0, Math.min(100, rawVisionTarget));
 
   if (allOlWon) {
+    // Perfect blocking means every gap is clean enough that the runner automatically reaches the second phase.
     return {
       runner: runnerName,
       runnerVision,
@@ -171,6 +183,7 @@ export function performVisionCheck(
   }
 
   if (allDlWon) {
+    // Perfect penetration means the runner has no viable read and is automatically trapped in the backfield.
     return {
       runner: runnerName,
       runnerVision,
@@ -184,6 +197,7 @@ export function performVisionCheck(
 
   const roll = Math.random() * 100;
 
+  // Passing this percentage check sends the play past the DL; failing it creates the backfield challenge.
   const getsPastDL = roll <= visionTarget;
 
   return {
@@ -213,6 +227,7 @@ export type RunLaneTargetResult = {
   }[];
 };
 
+/** Chooses one candidate proportionally to its trait value. Lane and defender selection helpers use it when several successful blockers or defenders could become the focal point. */
 function weightedPick<T extends { traitValue: number }>(
   candidates: T[]
 ): { selected: T; totalWeight: number; roll: number } {
@@ -250,6 +265,7 @@ function weightedPick<T extends { traitValue: number }>(
   };
 }
 
+/** Picks the specific blocker or defender that defines the run lane after the vision check. `runPlay` uses this selected target to decide DL swipe/wrap pressure and second-level alignment. */
 export function pickRunLaneTarget(
   lineWinLossArray: LineWinLossResult[],
   visionCheck: VisionCheckResult,
@@ -263,7 +279,7 @@ export function pickRunLaneTarget(
     .map((battle) => {
       if (visionPassed) {
         const offensivePlayer = findPlayerByName(players, battle.offensePlayer);
-        const traitValue = trait(offensivePlayer, "runBlocking");
+        const traitValue = trait(offensivePlayer, "runBlocking"); // TRAIT USED: RunBlocking
 
         return {
           slot: battle.slot,
@@ -274,7 +290,7 @@ export function pickRunLaneTarget(
       }
 
       const defensivePlayer = findPlayerByName(players, battle.defensePlayer);
-      const traitValue = trait(defensivePlayer, "runStop");
+      const traitValue = trait(defensivePlayer, "runStop"); // TRAIT USED: RunStop
 
       return {
         slot: battle.slot,
@@ -303,6 +319,7 @@ export function pickRunLaneTarget(
 // Run-lane selection and run-state mutation helpers
 // ---------------------------------------------------------------------------
 
+/** Creates the mutable state object that tracks yards, stoppage, tackler, and human-readable run logs. `runPlay` passes this object through every phase. */
 export function createRunPlayState(runner: string): RunPlayState {
   return {
     yards: 0,
@@ -312,6 +329,7 @@ export function createRunPlayState(runner: string): RunPlayState {
   };
 }
 
+/** Adds yardage to the current run state and records the reason in the play log. It is used throughout the run pipeline whenever acceleration, contact, or pursuit changes the gain. */
 export function addYards(
   state: RunPlayState,
   yards: number,
@@ -322,6 +340,7 @@ export function addYards(
   return state;
 }
 
+/** Marks the run as stopped without running extra contact checks. It is available for direct stoppages, though most current tackles use `handleRunnerTackle` or `handleLbWrapTackle`. */
 export function stopRun(
   state: RunPlayState,
   tackler: string,
@@ -343,6 +362,7 @@ export type RunnerDefenderSecondChanceAttempt = {
   roll: number;
 };
 
+/** Decides whether a runner who survived initial contact should truck or juke based on the size matchup. DL and LB contact branches use this before resolving the chosen move. */
 export function chooseRunnerDefenderSecondChanceAttempt(
   runnerName: string,
   defenderName: string,
@@ -350,7 +370,7 @@ export function chooseRunnerDefenderSecondChanceAttempt(
 ): RunnerDefenderSecondChanceAttempt {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
-  const sizeDifference = trait(runner, "size") - trait(defender, "size");
+  const sizeDifference = trait(runner, "size") - trait(defender, "size"); // TRAIT USED: Size TRAIT USED: Size
   const cappedSizeDifference = Math.max(-25, Math.min(25, sizeDifference));
   const truckChance = 50 + cappedSizeDifference;
   const roll = Math.random() * 100;
@@ -375,6 +395,7 @@ export type TruckAttemptResult = {
   trucked: boolean;
 };
 
+/** Resolves a truck attempt by comparing runner and defender power. It is used after `chooseRunnerDefenderSecondChanceAttempt` selects Truck. */
 export function performTruckAttempt(
   runnerName: string,
   defenderName: string,
@@ -382,8 +403,8 @@ export function performTruckAttempt(
 ): TruckAttemptResult {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
-  const runnerPower = trait(runner, "size") + trait(runner, "strength");
-  const defenderPower = trait(defender, "size") + trait(defender, "strength");
+  const runnerPower = trait(runner, "size") + trait(runner, "strength"); // TRAIT USED: Size TRAIT USED: Strength
+  const defenderPower = trait(defender, "size") + trait(defender, "strength"); // TRAIT USED: Size TRAIT USED: Strength
   const totalPower = runnerPower + defenderPower;
   const truckChance = totalPower > 0 ? (runnerPower / (totalPower + 80)) * 100 : 0;
   const roll = Math.random() * 100;
@@ -410,13 +431,14 @@ export type TruckOrJukeAccelerationResult = {
   acceleratedPast: boolean;
 };
 
+/** Checks whether the runner can accelerate away after a successful truck or juke. Backfield pursuit and second-level restart logic use it before assigning another defender. */
 export function performPostTruckorJukeAccelerationCheck(
   runnerName: string,
   players: PlayerTrait[],
   checkType: PostContactAccelerationCheckType
 ): TruckOrJukeAccelerationResult {
   const runner = findPlayerByName(players, runnerName);
-  const runnerAcceleration = trait(runner, "acceleration");
+  const runnerAcceleration = trait(runner, "acceleration"); // TRAIT USED: Acceleration
   const accelPastChance =
     checkType === "juke"
       ? runnerAcceleration
@@ -448,6 +470,7 @@ export type DlSwipeResult = {
   tackled: boolean;
 };
 
+/** Gives a beaten defensive lineman a chance to swipe the runner at the line. `runPlay` uses it on clean frontside lanes before the runner accelerates to linebackers. */
 export function performDlSwipeCheck(
   lineWinLossArray: LineWinLossResult[],
   runLaneTarget: RunLaneTargetResult,
@@ -463,7 +486,7 @@ export function performDlSwipeCheck(
 
   const defensivePlayer = findPlayerByName(players, matchup.defensePlayer);
 
-  const dlTackling = trait(defensivePlayer, "tackling");
+  const dlTackling = trait(defensivePlayer, "tackling"); // TRAIT USED: Tackling
 
   const swipeScore = ((dlTackling / 17) ** 2) / 2;
 
@@ -493,14 +516,15 @@ export type FallForwardResult = {
   yardsAdded: number;
 };
 
+/** Gives a tackled runner a chance to fall forward for an extra yard. Tackle handlers use it when the runner is brought down by DL-style contact. */
 export function performFallForwardCheck(
   runnerName: string,
   players: PlayerTrait[]
 ): FallForwardResult {
   const runner = findPlayerByName(players, runnerName);
 
-  const runnerSize = trait(runner, "size");
-  const runnerStrength = trait(runner, "strength");
+  const runnerSize = trait(runner, "size"); // TRAIT USED: Size
+  const runnerStrength = trait(runner, "strength"); // TRAIT USED: Strength
 
   const fallForwardScore = (((runnerSize + runnerStrength) / 20) ** 2);
 
@@ -528,14 +552,15 @@ export type CarryDefenderResult = {
   yardsAdded: number;
 };
 
+/** Gives a wrapped runner up to two extra yards for carrying a defender. Linebacker tackle handling uses it to model power through contact. */
 export function performCarryDefenderChecks(
   runnerName: string,
   players: PlayerTrait[]
 ): CarryDefenderResult {
   const runner = findPlayerByName(players, runnerName);
 
-  const runnerSize = trait(runner, "size");
-  const runnerStrength = trait(runner, "strength");
+  const runnerSize = trait(runner, "size"); // TRAIT USED: Size
+  const runnerStrength = trait(runner, "strength"); // TRAIT USED: Strength
   const carryScore = (runnerSize + runnerStrength) / 2;
   const rolls = [Math.random() * 100, Math.random() * 100];
   const yardsAdded = rolls.filter((roll) => roll <= carryScore).length;
@@ -550,6 +575,7 @@ export function performCarryDefenderChecks(
   };
 }
 
+/** Applies a standard tackle, including the fall-forward check, and marks the play stopped. DL tackles, pursuit tackles, and secondary pursuit all call this helper. */
 export function handleRunnerTackle(
   state: RunPlayState,
   tackler: string,
@@ -573,6 +599,7 @@ export function handleRunnerTackle(
   return fallForwardResult;
 }
 
+/** Applies a linebacker wrap tackle, including possible carry-the-defender yards, and marks the play stopped. The second-level branch uses it for LB wraps and failed trucks. */
 export function handleLbWrapTackle(
   state: RunPlayState,
   tackler: string,
@@ -596,17 +623,19 @@ export function handleLbWrapTackle(
   return carryDefenderResult;
 }
 
+/** Returns an inclusive random integer for yardage ranges. Both legacy and current run logic use it for bounded random gains or losses. */
 export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+/** Rolls how many yards the runner gains while accelerating from the line to linebacker depth. `runPlay` and second-level restart logic use it before choosing the next defender. */
 export function getAccelToLBYards(
   runner: PlayerTrait | undefined,
   settings: FrontendSettings | undefined,
   modLog?: string[]
 ) {
   const baseRoll = Math.floor(Math.random() * 101);
-  const acceleration = trait(runner, "acceleration");
+  const acceleration = trait(runner, "acceleration"); // TRAIT USED: Acceleration
   const accelerationMod = ((acceleration / 10) ** 2) / 9;
   const adjustedRoll = Math.min(100, baseRoll + accelerationMod);
 
@@ -632,13 +661,14 @@ export function getAccelToLBYards(
   return fallbackYards;
 }
 
+/** Rolls extra open-field yards using the runner's speed and configured secondary-yard buckets. Secondary entry points use it before resolving chase pursuit. */
 export function getSecondarySpeedYards(
   runner: PlayerTrait | undefined,
   settings: FrontendSettings | undefined,
   modLog?: string[]
 ) {
   const baseRoll = Math.floor(Math.random() * 101);
-  const speed = trait(runner, "speed");
+  const speed = trait(runner, "speed"); // TRAIT USED: Speed
   const speedMod = (speed / 15) ** 2;
   const adjustedRoll = Math.min(100, baseRoll + speedMod);
 
@@ -671,6 +701,7 @@ export function getSecondarySpeedYards(
   return 0;
 }
 
+/** Adds open-field speed yardage and immediately resolves secondary pursuit. It is used when a runner clears linebackers or no linebacker is in position. */
 function addSecondarySpeedYards(
   runState: RunPlayState,
   players: PlayerTrait[],
@@ -704,6 +735,7 @@ export type SecondaryPursuitResult = {
   escaped: boolean;
 };
 
+/** Selects a DB/LB/safety chaser and compares speed to decide whether the runner is caught in the secondary. It is called after secondary speed yardage is awarded. */
 export function resolveSecondaryPursuit(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
@@ -720,7 +752,7 @@ export function resolveSecondaryPursuit(
     )
     .map((assignment) => {
       const player = findPlayerByName(players, assignment.player);
-      const speed = trait(player, "speed");
+      const speed = trait(player, "speed"); // TRAIT USED: Speed
       return {
         assignment,
         speed,
@@ -791,13 +823,14 @@ export type DefenderWrapResult = {
 
 export type DlWrapResult = DefenderWrapResult;
 
+/** Checks whether any named defender wraps the runner cleanly based on tackling. DL and LB wrap wrappers both delegate here. */
 export function performDefenderWrapCheck(
   defenderName: string,
   players: PlayerTrait[]
 ): DefenderWrapResult {
   const defender = findPlayerByName(players, defenderName);
 
-  const defenderTackling = trait(defender, "tackling");
+  const defenderTackling = trait(defender, "tackling"); // TRAIT USED: Tackling
 
   const wrapScore = defenderTackling / 2;
 
@@ -815,6 +848,7 @@ export function performDefenderWrapCheck(
   };
 }
 
+/** Names the generic wrap check as a defensive-line wrap for backfield readability. `runPlay` and DL pursuit call it during DL contact. */
 export function performDlWrapCheck(
   defenderName: string,
   players: PlayerTrait[]
@@ -825,6 +859,7 @@ export function performDlWrapCheck(
 
 type RunLaneSide = "left" | "center" | "right";
 
+/** Converts a trench slot into left, center, or right. Linebacker targeting uses it to match pursuit to the run lane. */
 function laneSide(slot: FormationSlot): RunLaneSide {
   const slotIndex = TEOL_SLOTS.indexOf(slot);
   const centerIndex = TEOL_SLOTS.indexOf(CENTER_SLOT);
@@ -833,14 +868,17 @@ function laneSide(slot: FormationSlot): RunLaneSide {
   return slotIndex < centerIndex ? "left" : "right";
 }
 
+/** Converts a defensive assignment alignment into a lane side. `pickLinebackerForRunLane` uses this to find same-side linebackers. */
 function assignmentSide(assignment: DefensiveAssignment): RunLaneSide {
   return assignment.align ? laneSide(assignment.align) : "center";
 }
 
+/** Extracts the numeric linebacker order from a position label. Linebacker selection uses it for stable left-to-right sorting. */
 function lbPositionNumber(assignment: DefensiveAssignment): number {
   return Number(assignment.position.match(/\d+/)?.[0] ?? 0);
 }
 
+/** Chooses the linebacker most responsible for the selected run lane. Second-level resolution and short-acceleration defender selection call this helper. */
 export function pickLinebackerForRunLane(
   defenseFormation: DefensiveAssignment[],
   selectedSlot: FormationSlot,
@@ -874,6 +912,7 @@ export function pickLinebackerForRunLane(
     : linebackers[linebackers.length - 1];
 }
 
+/** Finds defensive linemen adjacent to the chosen lane who can still chase. Short-acceleration pressure uses these DLs when the runner has not created enough space. */
 export function getAdjacentDefensiveLinemenForRunLane(
   lineWinLossArray: LineWinLossResult[],
   selectedSlot: FormationSlot,
@@ -902,6 +941,7 @@ export function getAdjacentDefensiveLinemenForRunLane(
     }));
 }
 
+/** Chooses among eligible defenders by defensive star power. Short-acceleration and second-level restart logic use this when several defenders can challenge. */
 export function weightedPickDefenderByDefStars(
   defenders: DefensiveAssignment[],
   players: PlayerTrait[]
@@ -911,7 +951,7 @@ export function weightedPickDefenderByDefStars(
       const defensivePlayer = findPlayerByName(players, defender.player);
       return {
         defender,
-        weight: trait(defensivePlayer, "defStars") ** 2,
+        weight: trait(defensivePlayer, "defStars") ** 2, // TRAIT USED: DefStars
       };
     })
     .filter(({ weight }) => weight > 0);
@@ -930,6 +970,7 @@ export function weightedPickDefenderByDefStars(
   return weightedDefenders[weightedDefenders.length - 1].defender;
 }
 
+/** Chooses a nearby LB or adjacent DL when the runner gains only a short burst after the line. `runPlay` uses this to keep tight creases from becoming free linebacker entries. */
 export function pickShortAccelerationDefender(
   defenseFormation: DefensiveAssignment[],
   lineWinLossArray: LineWinLossResult[],
@@ -959,6 +1000,7 @@ export function pickShortAccelerationDefender(
   return weightedPickDefenderByDefStars(candidates, players);
 }
 
+/** Lists unbeaten linebackers and, when close enough, defensive linemen still eligible to challenge. The recursive second-level cycle uses it after successful jukes or trucks. */
 function getRemainingSecondLevelDefenders(
   defenseFormation: DefensiveAssignment[],
   lineWinLossArray: LineWinLossResult[],
@@ -1023,6 +1065,7 @@ export type LbJukeResult = {
   juked: boolean;
 };
 
+/** Resolves a runner juke against a linebacker by comparing juke skill against tackling. `resolveLinebackerSecondLevel` uses it when the runner chooses Juke. */
 export function performLbJukeCheck(
   runnerName: string,
   defenderName: string,
@@ -1031,8 +1074,8 @@ export function performLbJukeCheck(
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
 
-  const runnerJukeTrait = trait(runner, "juke");
-  const defenderTacklingTrait = trait(defender, "tackling");
+  const runnerJukeTrait = trait(runner, "juke"); // TRAIT USED: Juke
+  const defenderTacklingTrait = trait(defender, "tackling"); // TRAIT USED: Tackling
 
   const rbJukeScore = 15 + ((runnerJukeTrait / 10) ** 2) / 3;
   const lbDefendScore = ((defenderTacklingTrait / 15) ** 2) / 2;
@@ -1053,6 +1096,7 @@ export function performLbJukeCheck(
 }
 
 
+/** Runs the linebacker/second-level phase, including wraps, jukes, trucks, recursive restarts, and secondary entry. `runPlay` calls this after the runner clears or survives the defensive line. */
 export function resolveLinebackerSecondLevel(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
@@ -1267,6 +1311,7 @@ export type DlJukeResult = {
   juked: boolean;
 };
 
+/** Resolves a runner juke against a defensive lineman using the runner's juke trait. Backfield and DL pursuit branches call it after a failed wrap. */
 export function performDlJukeCheck(
   runnerName: string,
   defenderName: string,
@@ -1274,7 +1319,7 @@ export function performDlJukeCheck(
 ): DlJukeResult {
   const runner = findPlayerByName(players, runnerName);
 
-  const runnerJuke = trait(runner, "juke");
+  const runnerJuke = trait(runner, "juke"); // TRAIT USED: Juke
 
   const jukeScore = ((runnerJuke / 10) ** 2) / 2;
 
@@ -1292,6 +1337,7 @@ export function performDlJukeCheck(
   };
 }
 
+/** Returns other penetrating defensive linemen besides the one already challenged. Backfield truck and juke wins use it to continue DL pursuit if needed. */
 export function getOtherWinningDLs(
   lineWinLossArray: LineWinLossResult[],
   challengedDefender: string
@@ -1319,6 +1365,7 @@ export type DlPursuitResult = {
   steps: DlPursuitStep[];
 };
 
+/** Resolves pursuit by any remaining winning defensive linemen after the runner beats the first DL. `runPlay` uses it in the backfield juke branch before moving to linebackers. */
 export function resolveRemainingDlPursuit(
   runState: RunPlayState,
   remainingWinningDLs: LineWinLossResult[],


### PR DESCRIPTION
### Motivation
- Make the rushing pipeline and helper functions easy for a human reader to follow by adding concise descriptions of each function and inline explanations of key play logic phases. 
- Highlight every player trait access so engineers can quickly find where specific traits influence run resolution and tuning.

### Description
- Added function-level documentation and short, explanatory inline comments across `apps/web/src/components/league/gameplay/engine/runEngine.ts` and `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` describing where each helper participates in the run-play pipeline. 
- Annotated trait reads with explicit `// TRAIT USED: ...` comments (e.g., `Speed`, `Tackling`, `RunBlocking`, `RunStop`, `Juke`, `Acceleration`, `DefStars`, `OffStars`, `BallSecurity`, etc.) at every site `trait(...)` is called so trait-impact is easy to audit. 
- Added clarifying comments inside `runPlay` for setup, trench resolution, vision check, lane selection, backfield/DL branches, DL pursuit, acceleration-to-second-level, LB second-level recursion, and final score/clock bookkeeping. 
- Added compact docstrings and small explanatory notes for legacy helpers (`simulateSingleCarry`, `rollOffStarPower`, `runPlayOld`) and many helper utilities (lane/lineup lookup, weighted picks, wrap/swipe/juke/truck checks, pursuit and acceleration helpers). 

### Testing
- `npm --prefix apps/web run build` completed successfully and produced a production build. 
- `git diff --check` produced no whitespace or diff errors. 
- `npm --prefix apps/web run lint` was executed and reported a pre-existing React Hooks lint error in `apps/web/src/components/league/GameControls.tsx` outside the changed run-engine files, so lint did not pass but the failure is unrelated to these modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53c0ad7a248324946f8475984691d5)