### PR TITLE
Add secondary breakaway yardage resolution

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -103,6 +103,9 @@ async function getFrontendSettingsFromSheet() {
     secondarySpeedYards: settingRows(rows, "speed_lvl2_")
       .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) }))
       .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.minYards) && Number.isFinite(r.maxYards)),
+    secondaryBreakawayYards: settingRows(rows, "Breakaway_")
+      .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) }))
+      .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.minYards) && Number.isFinite(r.maxYards)),
     staminaDrains,
     tackleTable: settingRows(rows, "Tackle_").map((r) => ({ label: r[0], yardageCap: Number(r[1]), DL: Number(r[2]) || 0, LB: Number(r[3]) || 0, DBS: Number(r[4]) || 0 })).sort((a,b)=>a.yardageCap-b.yardageCap),
     completionTable: settingRows(rows, "airYards_Completion_").map((r) => ({ label: r[0], pastLos: Number(r[1]), baseCompletion: Number(r[2]), percentage: Number(r[3]) })),

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -27,6 +27,7 @@ function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendS
   normalized.breakaways = Array.isArray(normalized.breakaways) ? normalized.breakaways : [];
   normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards) ? normalized.accelToLBYards : [];
   normalized.secondarySpeedYards = Array.isArray(normalized.secondarySpeedYards) ? normalized.secondarySpeedYards : [];
+  normalized.secondaryBreakawayYards = Array.isArray(normalized.secondaryBreakawayYards) ? normalized.secondaryBreakawayYards : [];
   normalized.staminaDrains = normalized.staminaDrains ?? {};
   normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
   normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -4,6 +4,7 @@ import type {
   PlayerTrait,
   RunAccelToLBSetting,
   RunSecondarySpeedSetting,
+  RunSecondaryBreakawaySetting,
   FrontendSettings,
   RunPlayState
 } from "./types";
@@ -721,7 +722,110 @@ function addSecondarySpeedYards(
     );
   }
 
-  resolveSecondaryPursuit(runState, defenseFormation, players);
+  const pursuitResult = resolveSecondaryPursuit(runState, defenseFormation, players);
+  if (pursuitResult?.escaped) {
+    addSecondaryBreakawayYards(runState, players, settings);
+    tackleByFastestSecondaryDefender(runState, defenseFormation, players);
+  }
+}
+
+
+/** Rolls true breakaway yardage after the runner has escaped the initial secondary DB/LB chase. A separate speed check determines whether the speed modifier applies to the yardage-bucket roll. */
+export function getSecondaryBreakawayYards(
+  runner: PlayerTrait | undefined,
+  settings: FrontendSettings | undefined,
+  modLog?: string[]
+) {
+  const speed = trait(runner, "speed"); // TRAIT USED: Speed
+  const speedModifier = (speed / 18) ** 2;
+  const modifierChance = ((speed / 15) ** 2) / 100;
+  const modifierRoll = Math.floor(Math.random() * 101);
+  const modifierApplied = modifierRoll <= modifierChance;
+  const baseRoll = Math.floor(Math.random() * 101);
+  const adjustedRoll = Math.min(100, baseRoll + (modifierApplied ? speedModifier : 0));
+
+  let cumulative = 0;
+  const breakawaySettings = settingArray<RunSecondaryBreakawaySetting>(settings, "secondaryBreakawayYards");
+  for (const range of breakawaySettings) {
+    cumulative += Number(range.percentage) || 0;
+    if (adjustedRoll <= cumulative) {
+      const minYards = Number(range.minYards) || 0;
+      const maxYards = Number(range.maxYards) || minYards;
+      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+      modLog?.push(
+        `Yard +${yards} Breakaway (roll ${adjustedRoll.toFixed(2)} = ${baseRoll}${modifierApplied ? ` + ${speedModifier.toFixed(2)} Speed` : ""}; speed bonus roll ${modifierRoll} <= ${modifierChance.toFixed(2)} ${modifierApplied ? "applied" : "failed"})`
+      );
+      return yards;
+    }
+  }
+
+  const fallback = breakawaySettings[breakawaySettings.length - 1];
+  if (fallback) {
+    const minYards = Number(fallback.minYards) || 0;
+    const maxYards = Number(fallback.maxYards) || minYards;
+    const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+    modLog?.push(
+      `Yard +${yards} Breakaway (capped roll ${adjustedRoll.toFixed(2)}; speed bonus ${modifierApplied ? "applied" : "failed"})`
+    );
+    return yards;
+  }
+
+  modLog?.push(
+    `Breakaway yardage skipped because no Breakaway_ settings were loaded (roll ${adjustedRoll.toFixed(2)}).`
+  );
+  return 0;
+}
+
+function addSecondaryBreakawayYards(
+  runState: RunPlayState,
+  players: PlayerTrait[],
+  settings: FrontendSettings | undefined
+) {
+  const breakawayYards = getSecondaryBreakawayYards(
+    findPlayerByName(players, runState.runner),
+    settings,
+    runState.log
+  );
+  if (breakawayYards > 0) {
+    addYards(
+      runState,
+      breakawayYards,
+      `${runState.runner} breaks away after escaping the initial secondary pursuit`
+    );
+  }
+}
+
+function tackleByFastestSecondaryDefender(
+  runState: RunPlayState,
+  defenseFormation: DefensiveAssignment[],
+  players: PlayerTrait[]
+) {
+  if (runState.stopped) return;
+
+  const fastestDefender = defenseFormation
+    .filter((assignment) =>
+      assignment.player &&
+      (assignment.position.startsWith("DB") ||
+        assignment.position.startsWith("LB") ||
+        assignment.position.startsWith("S"))
+    )
+    .map((assignment) => ({
+      assignment,
+      speed: trait(findPlayerByName(players, assignment.player), "speed"), // TRAIT USED: Speed
+    }))
+    .sort((a, b) => b.speed - a.speed)[0];
+
+  if (!fastestDefender) return;
+
+  handleRunnerTackle(
+    runState,
+    fastestDefender.assignment.player,
+    "Breakaway End Fastest Secondary Defender",
+    players
+  );
+  runState.log.push(
+    `${fastestDefender.assignment.player} makes the automatic tackle after the breakaway as the fastest DB/LB/S on the field.`
+  );
 }
 
 export type SecondaryPursuitResult = {

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -22,11 +22,13 @@ export type RunThreshold = { label: string; minYards: number; maxYards: number; 
 export type RunBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type RunAccelToLBSetting = { label: string; percentage: number; yards: number };
 export type RunSecondarySpeedSetting = { label: string; percentage: number; minYards: number; maxYards: number };
+export type RunSecondaryBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type FrontendSettings = Record<string, unknown> & {
   thresholds?: RunThreshold[];
   breakaways?: RunBreakawaySetting[];
   accelToLBYards?: RunAccelToLBSetting[];
   secondarySpeedYards?: RunSecondarySpeedSetting[];
+  secondaryBreakawayYards?: RunSecondaryBreakawaySetting[];
   staminaDrains?: Record<string, number>;
   drainSettings?: Record<string, number>;
   tackleTable?: unknown[];


### PR DESCRIPTION
### Motivation
- Implement a new secondary breakaway model that applies a conditional speed bonus and then selects a breakaway yardage bucket after the runner escapes the initial DB/LB chase. 
- Keep the secondary breakaway buckets separate from the legacy breakaway table so frontend tuning can supply distinct `Breakaway_` rows.

### Description
- Add `RunSecondaryBreakawaySetting` and `secondaryBreakawayYards` to the frontend `types` so the client understands the new table and setting. 
- Pull `Breakaway_` rows from the sheet in `apps/api/src/routes/gameRoutes.ts` and expose them as `secondaryBreakawayYards` in the API settings payload. 
- Normalize `secondaryBreakawayYards` in the web client (`GameCenter.tsx`) so missing data becomes an empty array at runtime. 
- Add `getSecondaryBreakawayYards`, `addSecondaryBreakawayYards`, and `tackleByFastestSecondaryDefender` in `runEngineHelper.ts`, and wire them into the existing secondary flow so that after `resolveSecondaryPursuit` returns `escaped` the engine: performs the speed-bonus roll (modifier `(speed/18)^2` applied with chance `((speed/15)^2)/100`), rolls the breakaway bucket (from `secondaryBreakawayYards`) for random yardage, logs the modifier and roll details, and then automatically resolves the tackle using the fastest DB/LB/S on the field. 

### Testing
- Ran `npm run build` in `apps/web` (which runs `tsc -b` and `vite build`) and the build completed successfully. 
- Ran `npx tsc --noEmit` in `apps/api` and TypeScript checks passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53c4567dd88324b3a3f540f500b202)