### PR TITLE
Use negative yardage table for backfield losses

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -106,6 +106,9 @@ async function getFrontendSettingsFromSheet() {
     secondaryBreakawayYards: settingRows(rows, "Breakaway_")
       .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) }))
       .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.minYards) && Number.isFinite(r.maxYards)),
+    negativeYardage: settingRows(rows, "negative_")
+      .map((r) => ({ label: r[0], percentage: parseFloat(String(r[1])), minYards: parseInt(String(r[2]), 10), maxYards: parseInt(String(r[3]), 10) }))
+      .filter((r) => Number.isFinite(r.percentage) && Number.isFinite(r.minYards) && Number.isFinite(r.maxYards)),
     staminaDrains,
     tackleTable: settingRows(rows, "Tackle_").map((r) => ({ label: r[0], yardageCap: Number(r[1]), DL: Number(r[2]) || 0, LB: Number(r[3]) || 0, DBS: Number(r[4]) || 0 })).sort((a,b)=>a.yardageCap-b.yardageCap),
     completionTable: settingRows(rows, "airYards_Completion_").map((r) => ({ label: r[0], pastLos: Number(r[1]), baseCompletion: Number(r[2]), percentage: Number(r[3]) })),

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -29,6 +29,7 @@ function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendS
   normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards) ? normalized.accelToLBYards : [];
   normalized.secondarySpeedYards = Array.isArray(normalized.secondarySpeedYards) ? normalized.secondarySpeedYards : [];
   normalized.secondaryBreakawayYards = Array.isArray(normalized.secondaryBreakawayYards) ? normalized.secondaryBreakawayYards : [];
+  normalized.negativeYardage = Array.isArray(normalized.negativeYardage) ? normalized.negativeYardage : [];
   normalized.staminaDrains = normalized.staminaDrains ?? {};
   normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
   normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -16,6 +16,7 @@ import {
   randomInt,
   addYards,
   getAccelToLBYards,
+  getBackfieldYards,
   resolveLinebackerSecondLevel,
   pickShortAccelerationDefender,
   chooseRunnerDefenderSecondChanceAttempt,
@@ -525,8 +526,7 @@ export function runPlay(
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
     // A missed hole immediately costs yardage before the runner can attempt to escape the penetrating defender.
-    //CHANGE NUMBER 1: pull in negative yardage chart
-    const backfieldYards = randomInt(-5, -1);
+    const backfieldYards = getBackfieldYards(ctx.settings, runState.log);
 
     addYards(
       runState,

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -5,6 +5,7 @@ import type {
   RunAccelToLBSetting,
   RunSecondarySpeedSetting,
   RunSecondaryBreakawaySetting,
+  RunNegativeYardageSetting,
   FrontendSettings,
   RunPlayState
 } from "./types";
@@ -627,6 +628,42 @@ export function handleLbWrapTackle(
 /** Returns an inclusive random integer for yardage ranges. Both legacy and current run logic use it for bounded random gains or losses. */
 export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+
+/** Rolls backfield loss yardage from the configured negative-yardage table. Falls back to the old -5 to -1 range when settings are unavailable. */
+export function getBackfieldYards(
+  settings: FrontendSettings | undefined,
+  modLog?: string[]
+): number {
+  const negativeYardageSettings = settingArray<RunNegativeYardageSetting>(settings, "negativeYardage");
+
+  if (!negativeYardageSettings.length) {
+    const fallbackYards = randomInt(-5, -1);
+    modLog?.push(`Yard ${fallbackYards} Backfield loss fallback (negative yardage table missing)`);
+    return fallbackYards;
+  }
+
+  const roll = Math.random() * 100;
+  let cumulative = 0;
+
+  for (const range of negativeYardageSettings) {
+    cumulative += Number(range.percentage) || 0;
+    if (roll <= cumulative) {
+      const minYards = Number(range.minYards) || 0;
+      const maxYards = Number(range.maxYards) || minYards;
+      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+      modLog?.push(`Yard ${yards} Backfield loss (${range.label}, roll ${roll.toFixed(2)})`);
+      return yards;
+    }
+  }
+
+  const fallback = negativeYardageSettings[negativeYardageSettings.length - 1];
+  const minYards = Number(fallback.minYards) || 0;
+  const maxYards = Number(fallback.maxYards) || minYards;
+  const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+  modLog?.push(`Yard ${yards} Backfield loss (${fallback.label}, capped roll ${roll.toFixed(2)})`);
+  return yards;
 }
 
 /** Rolls how many yards the runner gains while accelerating from the line to linebacker depth. `runPlay` and second-level restart logic use it before choosing the next defender. */

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -23,12 +23,14 @@ export type RunBreakawaySetting = { label: string; percentage: number; minYards:
 export type RunAccelToLBSetting = { label: string; percentage: number; yards: number };
 export type RunSecondarySpeedSetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type RunSecondaryBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
+export type RunNegativeYardageSetting = { label: string; percentage: number; minYards: number; maxYards: number };
 export type FrontendSettings = Record<string, unknown> & {
   thresholds?: RunThreshold[];
   breakaways?: RunBreakawaySetting[];
   accelToLBYards?: RunAccelToLBSetting[];
   secondarySpeedYards?: RunSecondarySpeedSetting[];
   secondaryBreakawayYards?: RunSecondaryBreakawaySetting[];
+  negativeYardage?: RunNegativeYardageSetting[];
   staminaDrains?: Record<string, number>;
   drainSettings?: Record<string, number>;
   tackleTable?: unknown[];


### PR DESCRIPTION
### Motivation

- Replace the ad-hoc random backfield loss (`-5`..`-1`) with a configurable, sheet-driven negative-yardage distribution so losses match frontend settings.
- Keep the previous random fallback when the negative-yardage table is not present so behavior is stable without settings.

### Description

- Load `negative_` rows from the Settings sheet into the API settings payload as `negativeYardage` (label, percentage, minYards, maxYards). 
- Normalize `negativeYardage` in the web client so the run engine always receives an array alongside other run settings.
- Add `RunNegativeYardageSetting` to run-engine types and expose `negativeYardage` on `FrontendSettings`.
- Implement `getBackfieldYards(settings, modLog?)` in `runEngineHelper.ts` which rolls against the weighted `negativeYardage` table and falls back to `randomInt(-5, -1)` when the table is missing, and wire `runEngine.ts` to use it for backfield losses.

### Testing

- Ran `npx tsc --noEmit` in `apps/api` and it succeeded.
- Ran `npm run build` in `apps/web` and it failed with `TS2304: Cannot find name 'performBruiserCheck'`, which is unrelated to the negative-yardage table change and surfaced during the build.
- Ran `git diff --check` and no whitespace/patch issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57024971cc83248aa5acc8eaf0b0a7)