### PR TITLE
Add bruiser check for negative runs

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -22,6 +22,8 @@ import {
   chooseRunnerDefenderSecondChanceAttempt,
   performTruckAttempt,
   performPostTruckorJukeAccelerationCheck,
+  performBruiserCheck,
+  performCarryDefenderChecks,
 } from "./runEngineHelper";
 
 /** Chooses the most plausible tackler after a run or pass play has ended, weighting nearby defender groups by tackling ability. It is used by `runPlay`, `runPlayOld`, and pass-play fumble/tackle resolution when no specific tackler was already recorded. */
@@ -522,6 +524,8 @@ export function runPlay(
   let dlJukeResult: ReturnType<typeof performDlJukeCheck> | null = null;
   let otherWinningDLsAfterJuke: ReturnType<typeof getOtherWinningDLs> = [];
   let dlPursuitResult: ReturnType<typeof resolveRemainingDlPursuit> | null = null;
+  let bruiserResult: ReturnType<typeof performBruiserCheck> | null = null;
+  let bruiserCarryDefenderResult: ReturnType<typeof performCarryDefenderChecks> | null = null;
 
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
@@ -534,11 +538,28 @@ export function runPlay(
       `${runState.runner} fails to hit the hole and is forced into the backfield`
     );
 
-    //CHANGE: add in real performBruiserCheck function
-    const bruiserSuccess = performBruiserCheck();
+    bruiserResult = performBruiserCheck(runState.runner, ctx.players);
 
-    if(bruiserSuccess){
-      //CHANGE: tackle at line of scrimmage with performCarryDefenderChecks 
+    if (bruiserResult.succeeded) {
+      const bruiserTackler = runLaneTarget.selectedPlayer;
+      runState.yards = 0;
+      runState.log.push(
+        `${runState.runner} powers out of the backfield loss (roll ${bruiserResult.roll.toFixed(2)} <= ${bruiserResult.bruiserScore.toFixed(2)}%) and gets back to the line of scrimmage.`
+      );
+
+      bruiserCarryDefenderResult = performCarryDefenderChecks(runState.runner, ctx.players);
+
+      if (bruiserCarryDefenderResult.yardsAdded > 0) {
+        runState.yards += bruiserCarryDefenderResult.yardsAdded;
+        runState.log.push(
+          `${runState.runner} carries ${bruiserTackler} for +${bruiserCarryDefenderResult.yardsAdded} ${bruiserCarryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`
+        );
+      }
+
+      runState.tackler = bruiserTackler;
+      runState.stopped = true;
+      runState.stopReason = "Bruiser Check Tackle";
+      runState.log.push(`${bruiserTackler} tackles ${runState.runner}. Reason: Bruiser Check Tackle.`);
     }
     else{
       // The first penetrating DL gets a clean wrap attempt before the runner can choose a counter move.
@@ -706,6 +727,8 @@ export function runPlay(
   console.log("DL juke result:", dlJukeResult);
   console.log("Other winning DLs after juke:", otherWinningDLsAfterJuke);
   console.log("DL pursuit result:", dlPursuitResult);
+  console.log("Bruiser result:", bruiserResult);
+  console.log("Bruiser carry defender result:", bruiserCarryDefenderResult);
 
   //if tackled in backfield or snuffed at line
   if (runState.stopped) {

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -545,6 +545,38 @@ export function performFallForwardCheck(
   };
 }
 
+
+export type BruiserCheckResult = {
+  runner: string;
+  runnerSize: number;
+  runnerStrength: number;
+  bruiserScore: number;
+  roll: number;
+  succeeded: boolean;
+};
+
+/** Gives a powerful runner a chance to erase a negative-yardage result before normal backfield contact is resolved. */
+export function performBruiserCheck(
+  runnerName: string,
+  players: PlayerTrait[]
+): BruiserCheckResult {
+  const runner = findPlayerByName(players, runnerName);
+
+  const runnerSize = trait(runner, "size"); // TRAIT USED: Size
+  const runnerStrength = trait(runner, "strength"); // TRAIT USED: Strength
+  const bruiserScore = (((runnerSize + runnerStrength) / 2) / 21) ** 2.7;
+  const roll = Math.random() * 100;
+
+  return {
+    runner: runnerName,
+    runnerSize,
+    runnerStrength,
+    bruiserScore,
+    roll,
+    succeeded: roll < bruiserScore,
+  };
+}
+
 export type CarryDefenderResult = {
   runner: string;
   runnerSize: number;


### PR DESCRIPTION
### Motivation
- Give powerful running backs a chance to erase backfield negative-yardage outcomes and convert them into a 0/1/2 yard result before normal defensive-line backfield resolution.

### Description
- Add `BruiserCheckResult` and `performBruiserCheck(runnerName, players)` to `runEngineHelper.ts`, computing the bruiser score as `(((size+strength)/2)/21) ** 2.7` and rolling a decimal 0–100 with success when the roll is below the score.
- Integrate the bruiser check into the backfield branch in `runEngine.ts` immediately after negative yardage is applied, resetting `runState.yards = 0` and emitting a log entry on success.
- On bruiser success, select the penetrating DL (`runLaneTarget.selectedPlayer`) as the tackler, call `performCarryDefenderChecks` to potentially add 1–2 yards, mark the play stopped, set `tackler`/`stopReason`, and record logs describing the outcome.
- Import the new helpers into `runEngine.ts`, introduce `bruiserResult` and `bruiserCarryDefenderResult` variables for tracking, and add debug log output for those results.

### Testing
- Ran `npm --prefix apps/web run build` and the build completed successfully.
- Ran `npm --prefix apps/web run lint` and ESLint completed without errors.
- Attempted `npm --prefix apps/web run typecheck` but the project has no `typecheck` script so that command failed with an error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5703b87384832497d80d5b2a201452)