### PR TITLE
Make failed truck acceleration recurse through DL pursuit like juke

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -21,7 +21,6 @@ import {
   pickShortAccelerationDefender,
   chooseRunnerDefenderSecondChanceAttempt,
   performTruckAttempt,
-  performPostTruckorJukeAccelerationCheck,
   performBruiserCheck,
   performCarryDefenderChecks,
 } from "./runEngineHelper";
@@ -621,30 +620,18 @@ export function runPlay(
                 `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`
               );
             } else {
-              // A successful truck still needs an acceleration check when other DLs won their lanes and can pursue.
-              const accelerationResult = performPostTruckorJukeAccelerationCheck(
-                runState.runner,
+              runState.log.push(
+                `${runState.runner} trucks ${dlWrapResult.defender}, but other defensive linemen are still in pursuit.`
+              );
+
+              dlPursuitResult = resolveRemainingDlPursuit(
+                runState,
+                otherWinningDLsAfterTruck,
                 ctx.players,
                 "truck"
               );
-                //CHANGE: a failed truck should recurse through resolveRemainingDlPursuit just like juke
 
-              if (accelerationResult.acceleratedPast) {
-                runState.log.push(
-                  `${runState.runner} accelerates after contact (roll ${accelerationResult.roll.toFixed(2)} <= ${accelerationResult.accelPastChance.toFixed(2)}%) and escapes toward the second level.`
-                );
-              } else {
-                const pursuingDefender = otherWinningDLsAfterTruck[0]?.defensePlayer || dlWrapResult.defender;
-                runState.log.push(
-                  `${runState.runner} cannot accelerate past the remaining defenders after the truck (roll ${accelerationResult.roll.toFixed(2)} > ${accelerationResult.accelPastChance.toFixed(2)}%).`
-                );
-                fallForwardResult = handleRunnerTackle(
-                  runState,
-                  pursuingDefender,
-                  "DL Backfield Post-Truck Acceleration Failed",
-                  ctx.players
-                );
-              }
+              console.log("DL pursuit result:", dlPursuitResult);
             }
           }
         } 
@@ -685,7 +672,8 @@ export function runPlay(
             dlPursuitResult = resolveRemainingDlPursuit(
               runState,
               otherWinningDLsAfterJuke,
-              ctx.players
+              ctx.players,
+              "juke"
             );
 
             console.log("DL pursuit result:", dlPursuitResult);

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -1567,7 +1567,8 @@ export type DlPursuitResult = {
 export function resolveRemainingDlPursuit(
   runState: RunPlayState,
   remainingWinningDLs: LineWinLossResult[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
+  accelerationCheckType: PostContactAccelerationCheckType
 ): DlPursuitResult {
   const steps: DlPursuitStep[] = [];
 
@@ -1577,7 +1578,7 @@ export function resolveRemainingDlPursuit(
     const accelerationCheck = performPostTruckorJukeAccelerationCheck(
       runState.runner,
       players,
-      "juke"
+      accelerationCheckType
     );
 
     if (accelerationCheck.acceleratedPast) {


### PR DESCRIPTION
### Motivation
- Ensure that when a runner succeeds at a backfield `Truck` but fails to accelerate past remaining penetrating DLs, pursuit is resolved the same way as a successful `Juke` so the next DL can approach. 
- Avoid prematurely ending play on a failed truck acceleration and allow remaining DLs to attempt pursuit/wrap/juke. 
- Reuse the existing DL-pursuit flow while using the appropriate acceleration formula for `truck` vs `juke` checks.

### Description
- Route successful backfield truck outcomes with remaining winning DLs through `resolveRemainingDlPursuit` instead of performing a one-off acceleration/tackle branch in `runEngine.ts`. (`apps/web/src/components/league/gameplay/engine/runEngine.ts`).
- Add an `accelerationCheckType: PostContactAccelerationCheckType` parameter to `resolveRemainingDlPursuit` and use it when calling `performPostTruckorJukeAccelerationCheck`, so the function applies the correct acceleration formula for `"truck"` or `"juke"`. (`apps/web/src/components/league/gameplay/engine/runEngineHelper.ts`).
- Update the juke path to explicitly pass `"juke"` into `resolveRemainingDlPursuit` to preserve existing behavior, and call `resolveRemainingDlPursuit` with `"truck"` from the truck path. (`runEngine.ts`).
- Remove the inline post-truck acceleration check in `runEngine.ts` and centralize pursuit handling in `resolveRemainingDlPursuit`, and add small log messages to indicate pursuit routing.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and `eslint` completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5704e7fc7883249f8cd7c66e7553cd)