### PR TITLE
Convert GameField to proper TSX and wire control callbacks

### DIFF
--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,34 +1,71 @@
+type GameFieldActionName = "loadExampleJson" | "runJsonFromBox" | "resetCurrentPlan";
+
+declare global {
+  interface Window {
+    loadExampleJson?: () => void;
+    runJsonFromBox?: () => void;
+    resetCurrentPlan?: () => void;
+  }
+}
+
+const runGameFieldAction = (actionName: GameFieldActionName) => {
+  window[actionName]?.();
+};
+
 export default function GameField() {
-  
   return (
-      <div class="game-shell"> 
-        <div class="scorebug"> 
-          <div class="score-main" id="scoreMain">POR 7 | CLT 3</div> 
-          <div class="situation" id="situationText">Paste animation JSON below and run play</div> 
-        </div> 
-        <div class="field-viewport" id="fieldViewport"> 
-          <div class="field-wrap" id="field"> 
-            <div class="field-title">Dynamic Football Animation View</div> 
-            <div class="camera-note" id="cameraNote">Manual scroll field</div> 
-            <div class="team-end" id="cltEnd">WILDFIRE</div> 
-            <div class="team-end" id="porEnd">PORTLAND</div> 
-            <div class="field-line los-line" id="losLine"></div> 
-            <div class="field-line first-down-line" id="firstDownLine"></div> 
-            <div class="field-line end-line" id="endLine"></div> 
-            <div class="line-label" id="losLabel">LOS</div> 
-            <div class="line-label" id="firstDownLabel">1ST</div> 
-            <div class="line-label" id="endLabel">END</div> 
-            <div class="football" id="football"></div> 
-          </div> 
-        </div> 
-        <div class="caption" id="caption"> Paste a play animation JSON below, or load the example. </div> 
-        <div class="controls"> 
-          <button onclick="loadExampleJson()">Load Example JSON</button> 
-          <button onclick="runJsonFromBox()">Run JSON Play</button> 
-          <button onclick="resetCurrentPlan()">Reset Current Play</button> 
-        </div> 
-        <textarea id="jsonInput" spellcheck="false" placeholder="Paste PlayAnimationPlan JSON here..."></textarea> 
-        <div class="error-box" id="errorBox"></div> 
+    <div className="game-shell">
+      <div className="scorebug">
+        <div className="score-main" id="scoreMain">
+          POR 7 | CLT 3
+        </div>
+        <div className="situation" id="situationText">
+          Paste animation JSON below and run play
+        </div>
       </div>
+      <div className="field-viewport" id="fieldViewport">
+        <div className="field-wrap" id="field">
+          <div className="field-title">Dynamic Football Animation View</div>
+          <div className="camera-note" id="cameraNote">
+            Manual scroll field
+          </div>
+          <div className="team-end" id="cltEnd">
+            WILDFIRE
+          </div>
+          <div className="team-end" id="porEnd">
+            PORTLAND
+          </div>
+          <div className="field-line los-line" id="losLine" />
+          <div className="field-line first-down-line" id="firstDownLine" />
+          <div className="field-line end-line" id="endLine" />
+          <div className="line-label" id="losLabel">
+            LOS
+          </div>
+          <div className="line-label" id="firstDownLabel">
+            1ST
+          </div>
+          <div className="line-label" id="endLabel">
+            END
+          </div>
+          <div className="football" id="football" />
+        </div>
+      </div>
+      <div className="caption" id="caption">
+        Paste a play animation JSON below, or load the example.
+      </div>
+      <div className="controls">
+        <button type="button" onClick={() => runGameFieldAction("loadExampleJson")}>
+          Load Example JSON
+        </button>
+        <button type="button" onClick={() => runGameFieldAction("runJsonFromBox")}>
+          Run JSON Play
+        </button>
+        <button type="button" onClick={() => runGameFieldAction("resetCurrentPlan")}>
+          Reset Current Play
+        </button>
+      </div>
+      <textarea id="jsonInput" spellCheck={false} placeholder="Paste PlayAnimationPlan JSON here..." />
+      <div className="error-box" id="errorBox" />
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The GameField component used HTML-style attributes and inline string event handlers that caused TypeScript/React build errors and prevented integration with the new UI.
- Convert the field wrapper markup to TSX so it compiles under the app's `jsx: react-jsx` TypeScript settings.

### Description
- Updated `apps/web/src/components/league/GameField.tsx` to use React/TSX attributes by replacing `class` with `className`, `onclick` with `onClick`, and `spellcheck` with `spellCheck`.
- Replaced inline string event handlers with a small typed wrapper `runGameFieldAction` that invokes existing global helpers on `window` and added a `Window` interface declaration for the three expected functions (`loadExampleJson`, `runJsonFromBox`, `resetCurrentPlan`).
- Self-closed empty marker elements and adjusted button and textarea props to be valid TSX (added `type="button"` on buttons and self-closing empty elements where appropriate).
- Kept markup structure and CSS class names intact so existing styles continue to apply.

### Testing
- Ran the production build with `npm run build` (which runs `tsc -b` and the Vite build), and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c25815aa88324bb391f9a3b2ca3cf)