### PR TITLE
Format web source for readability

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,20 +1,24 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap");
 
 :root {
-  --accent-red: #C10206;
-  --accent-red-dark: #A50113;
+  --accent-red: #c10206;
+  --accent-red-dark: #a50113;
   --gray-dark: #121212;
   --gray-medium: #1e1e1e;
   --gray-light: #2c2c2c;
-  --text-light: #F5F5F5;
-  --text-muted: #B0B0B0;
+  --text-light: #f5f5f5;
+  --text-muted: #b0b0b0;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Roboto', Arial, sans-serif;
-  background: linear-gradient(135deg, var(--gray-dark) 0%, var(--gray-medium) 100%);
+  font-family: "Roboto", Arial, sans-serif;
+  background: linear-gradient(
+    135deg,
+    var(--gray-dark) 0%,
+    var(--gray-medium) 100%
+  );
   color: var(--text-light);
 }
 
@@ -105,7 +109,7 @@ body {
 }
 
 .star.half::before {
-  content: '★';
+  content: "★";
   color: gold;
   position: absolute;
   left: 0;
@@ -207,11 +211,21 @@ body {
   transition: width 1s ease;
 }
 
-.progress-bar.red { background: #e74c3c; }
-.progress-bar.orange { background: #e67e22; }
-.progress-bar.yellow { background: #f1c40f; }
-.progress-bar.light-green { background: #2ecc71; }
-.progress-bar.dark-green { background: #27ae60; }
+.progress-bar.red {
+  background: #e74c3c;
+}
+.progress-bar.orange {
+  background: #e67e22;
+}
+.progress-bar.yellow {
+  background: #f1c40f;
+}
+.progress-bar.light-green {
+  background: #2ecc71;
+}
+.progress-bar.dark-green {
+  background: #27ae60;
+}
 
 #jersey-wrapper {
   position: absolute;
@@ -226,7 +240,9 @@ body {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  transition: transform 0.4s ease, opacity 0.4s ease;
+  transition:
+    transform 0.4s ease,
+    opacity 0.4s ease;
   opacity: 1;
 }
 
@@ -264,8 +280,15 @@ body {
 .main-menu-screen {
   position: relative;
   min-height: 100vh;
-  background: url("https://andrew-jacobson06.github.io/public-audio/stadium-menu.png") center/cover no-repeat;
-  font-family: "Segoe UI", system-ui, -apple-system, Roboto, Arial, sans-serif;
+  background: url("https://andrew-jacobson06.github.io/public-audio/stadium-menu.png")
+    center/cover no-repeat;
+  font-family:
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    Roboto,
+    Arial,
+    sans-serif;
   color: #fff;
   overflow: hidden;
 }
@@ -280,68 +303,496 @@ body {
   font-weight: 900;
   font-size: clamp(28px, 8vw, 100px);
   line-height: 1;
-  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5), 0 0 18px rgba(255, 59, 59, 0.6), 0 0 42px rgba(255, 59, 59, 0.25);
+  text-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.5),
+    0 0 18px rgba(255, 59, 59, 0.6),
+    0 0 42px rgba(255, 59, 59, 0.25);
 }
 
-.main-menu-screen .corner { position: absolute; width: 3.6vw; height: 3.6vw; border: 2px solid rgba(255, 255, 255, 0.18); z-index: 2; pointer-events: none; }
-.main-menu-screen .corner.tl { top: 1.6vw; left: 1.6vw; border-right: none; border-bottom: none; }
-.main-menu-screen .corner.tr { top: 1.6vw; right: 1.6vw; border-left: none; border-bottom: none; }
-.main-menu-screen .corner.bl { bottom: 1.6vw; left: 1.6vw; border-right: none; border-top: none; }
-.main-menu-screen .corner.br { bottom: 1.6vw; right: 1.6vw; border-left: none; border-top: none; }
+.main-menu-screen .corner {
+  position: absolute;
+  width: 3.6vw;
+  height: 3.6vw;
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  z-index: 2;
+  pointer-events: none;
+}
+.main-menu-screen .corner.tl {
+  top: 1.6vw;
+  left: 1.6vw;
+  border-right: none;
+  border-bottom: none;
+}
+.main-menu-screen .corner.tr {
+  top: 1.6vw;
+  right: 1.6vw;
+  border-left: none;
+  border-bottom: none;
+}
+.main-menu-screen .corner.bl {
+  bottom: 1.6vw;
+  left: 1.6vw;
+  border-right: none;
+  border-top: none;
+}
+.main-menu-screen .corner.br {
+  bottom: 1.6vw;
+  right: 1.6vw;
+  border-left: none;
+  border-top: none;
+}
 
-.main-menu-screen .menu-wrap { position: absolute; left: 4vw; bottom: 6vh; z-index: 4; display: grid; gap: 1rem; width: 50%; }
-.main-menu-screen .panel { position: relative; padding: 2.6rem 1.2rem 1.2rem; border-radius: 14px; background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.12); outline: 1px solid rgba(255, 59, 59, 0.22); box-shadow: 0 0 0 1px rgba(255, 59, 59, 0.12) inset, 0 12px 30px rgba(0, 0, 0, 0.35), 0 0 28px rgba(255, 59, 59, 0.12); backdrop-filter: blur(3px); display: grid; gap: 0.8rem; max-width: min(92vw, 520px); overflow: hidden; }
-.main-menu-screen .panel::before { content: ""; position: absolute; inset: 0; background: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.03) 0 2px, transparent 2px 12px), repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.02) 0 2px, transparent 2px 16px); transform: translateY(0); animation: scanY 12s linear infinite; pointer-events: none; }
-@keyframes scanY { 0% { transform: translateY(0); } 100% { transform: translateY(-60px); } }
+.main-menu-screen .menu-wrap {
+  position: absolute;
+  left: 4vw;
+  bottom: 6vh;
+  z-index: 4;
+  display: grid;
+  gap: 1rem;
+  width: 50%;
+}
+.main-menu-screen .panel {
+  position: relative;
+  padding: 2.6rem 1.2rem 1.2rem;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  outline: 1px solid rgba(255, 59, 59, 0.22);
+  box-shadow:
+    0 0 0 1px rgba(255, 59, 59, 0.12) inset,
+    0 12px 30px rgba(0, 0, 0, 0.35),
+    0 0 28px rgba(255, 59, 59, 0.12);
+  backdrop-filter: blur(3px);
+  display: grid;
+  gap: 0.8rem;
+  max-width: min(92vw, 520px);
+  overflow: hidden;
+}
+.main-menu-screen .panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.03) 0 2px,
+      transparent 2px 12px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.02) 0 2px,
+      transparent 2px 16px
+    );
+  transform: translateY(0);
+  animation: scanY 12s linear infinite;
+  pointer-events: none;
+}
+@keyframes scanY {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-60px);
+  }
+}
 
-.main-menu-screen .ticker { position: absolute; left: 0; right: 0; top: 0; height: 2.2rem; display: flex; align-items: center; background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)); border-bottom: 1px solid rgba(255, 255, 255, 0.12); box-shadow: inset 0 -1px 0 rgba(255, 59, 59, 0.22); overflow: hidden; }
-.main-menu-screen .ticker::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: linear-gradient(180deg, transparent, var(--accent-red-dark), transparent); filter: drop-shadow(0 0 8px var(--accent-red-dark)); }
-.main-menu-screen .track { white-space: nowrap; display: inline-block; padding-left: 100%; animation: marquee 16s linear infinite; font-size: 0.95rem; letter-spacing: 0.14rem; text-transform: uppercase; opacity: 0.92; }
-.main-menu-screen .sep { margin: 0 0.9rem; opacity: 0.6; }
-@keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-100%); } }
+.main-menu-screen .ticker {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 2.2rem;
+  display: flex;
+  align-items: center;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.06),
+    rgba(255, 255, 255, 0.02)
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 -1px 0 rgba(255, 59, 59, 0.22);
+  overflow: hidden;
+}
+.main-menu-screen .ticker::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    var(--accent-red-dark),
+    transparent
+  );
+  filter: drop-shadow(0 0 8px var(--accent-red-dark));
+}
+.main-menu-screen .track {
+  white-space: nowrap;
+  display: inline-block;
+  padding-left: 100%;
+  animation: marquee 16s linear infinite;
+  font-size: 0.95rem;
+  letter-spacing: 0.14rem;
+  text-transform: uppercase;
+  opacity: 0.92;
+}
+.main-menu-screen .sep {
+  margin: 0 0.9rem;
+  opacity: 0.6;
+}
+@keyframes marquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
 
-.main-menu-screen .rail { position: absolute; pointer-events: none; }
-.main-menu-screen .rail.top, .main-menu-screen .rail.bottom { left: 10px; right: 10px; height: 2px; }
-.main-menu-screen .rail.left, .main-menu-screen .rail.right { top: 10px; bottom: 10px; width: 2px; }
-.main-menu-screen .runnerX, .main-menu-screen .runnerY { position: absolute; background: linear-gradient(90deg, transparent, var(--accent-red-dark), transparent); filter: drop-shadow(0 0 8px var(--accent-red-dark)); }
-.main-menu-screen .rail.top .runnerX { top: 0; left: -30%; height: 2px; width: 30%; animation: runX 3s linear infinite; }
-.main-menu-screen .rail.bottom .runnerX { bottom: 0; left: 100%; height: 2px; width: 30%; animation: runXRev 3s linear infinite; opacity: 0.7; }
-.main-menu-screen .rail.left .runnerY { left: 0; top: -30%; width: 2px; height: 30%; animation: runY 2.4s linear infinite; opacity: 0.75; }
-.main-menu-screen .rail.right .runnerY { right: 0; top: 100%; width: 2px; height: 30%; animation: runYRev 2.4s linear infinite; opacity: 0.6; }
-@keyframes runX { 0% { transform: translateX(0); } 100% { transform: translateX(450%); } }
-@keyframes runXRev { 0% { transform: translateX(0); } 100% { transform: translateX(-450%); } }
-@keyframes runY { 0% { transform: translateY(0); } 100% { transform: translateY(450%); } }
-@keyframes runYRev { 0% { transform: translateY(0); } 100% { transform: translateY(-450%); } }
+.main-menu-screen .rail {
+  position: absolute;
+  pointer-events: none;
+}
+.main-menu-screen .rail.top,
+.main-menu-screen .rail.bottom {
+  left: 10px;
+  right: 10px;
+  height: 2px;
+}
+.main-menu-screen .rail.left,
+.main-menu-screen .rail.right {
+  top: 10px;
+  bottom: 10px;
+  width: 2px;
+}
+.main-menu-screen .runnerX,
+.main-menu-screen .runnerY {
+  position: absolute;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent-red-dark),
+    transparent
+  );
+  filter: drop-shadow(0 0 8px var(--accent-red-dark));
+}
+.main-menu-screen .rail.top .runnerX {
+  top: 0;
+  left: -30%;
+  height: 2px;
+  width: 30%;
+  animation: runX 3s linear infinite;
+}
+.main-menu-screen .rail.bottom .runnerX {
+  bottom: 0;
+  left: 100%;
+  height: 2px;
+  width: 30%;
+  animation: runXRev 3s linear infinite;
+  opacity: 0.7;
+}
+.main-menu-screen .rail.left .runnerY {
+  left: 0;
+  top: -30%;
+  width: 2px;
+  height: 30%;
+  animation: runY 2.4s linear infinite;
+  opacity: 0.75;
+}
+.main-menu-screen .rail.right .runnerY {
+  right: 0;
+  top: 100%;
+  width: 2px;
+  height: 30%;
+  animation: runYRev 2.4s linear infinite;
+  opacity: 0.6;
+}
+@keyframes runX {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(450%);
+  }
+}
+@keyframes runXRev {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-450%);
+  }
+}
+@keyframes runY {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(450%);
+  }
+}
+@keyframes runYRev {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-450%);
+  }
+}
 
-.main-menu-screen .node { position: absolute; width: 8px; height: 8px; border-radius: 50%; background: var(--accent-red-dark); box-shadow: 0 0 12px var(--accent-red-dark), 0 0 28px rgba(255, 59, 59, 0.35); animation: pulse 2.2s ease-in-out infinite; pointer-events: none; }
-.main-menu-screen .node.n1 { top: 10px; left: 10px; }
-.main-menu-screen .node.n2 { top: 10px; right: 10px; animation-delay: 0.25s; }
-.main-menu-screen .node.n3 { bottom: 10px; left: 10px; animation-delay: 0.5s; }
-.main-menu-screen .node.n4 { bottom: 10px; right: 10px; animation-delay: 0.75s; }
-@keyframes pulse { 0%, 100% { transform: scale(1); opacity: 0.85; } 50% { transform: scale(1.25); opacity: 0.55; } }
+.main-menu-screen .node {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-red-dark);
+  box-shadow:
+    0 0 12px var(--accent-red-dark),
+    0 0 28px rgba(255, 59, 59, 0.35);
+  animation: pulse 2.2s ease-in-out infinite;
+  pointer-events: none;
+}
+.main-menu-screen .node.n1 {
+  top: 10px;
+  left: 10px;
+}
+.main-menu-screen .node.n2 {
+  top: 10px;
+  right: 10px;
+  animation-delay: 0.25s;
+}
+.main-menu-screen .node.n3 {
+  bottom: 10px;
+  left: 10px;
+  animation-delay: 0.5s;
+}
+.main-menu-screen .node.n4 {
+  bottom: 10px;
+  right: 10px;
+  animation-delay: 0.75s;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.25);
+    opacity: 0.55;
+  }
+}
 
-.main-menu-screen .tick { position: absolute; width: 34px; height: 2px; background: linear-gradient(90deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); filter: drop-shadow(0 0 6px var(--accent-red-dark)); opacity: 0.9; animation-duration: 2.8s; animation-iteration-count: infinite; animation-timing-function: linear; }
-.main-menu-screen .tick.t1 { top: 10px; left: 10px; animation-name: tMoveX; }
-.main-menu-screen .tick.t2 { bottom: 10px; right: 10px; animation-name: tMoveXRev; }
-.main-menu-screen .tick.t3 { left: 10px; top: 10px; width: 2px; height: 34px; background: linear-gradient(0deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); animation-name: tMoveY; }
-.main-menu-screen .tick.t4 { right: 10px; bottom: 10px; width: 2px; height: 34px; background: linear-gradient(0deg, rgba(255, 255, 255, 0.1), var(--accent-red), rgba(255, 255, 255, 0.1)); animation-name: tMoveYRev; }
-@keyframes tMoveX { 0% { transform: translateX(0); } 100% { transform: translateX(calc(100% - 34px)); } }
-@keyframes tMoveXRev { 0% { transform: translateX(0); } 100% { transform: translateX(calc(-100% + 34px)); } }
-@keyframes tMoveY { 0% { transform: translateY(0); } 100% { transform: translateY(calc(100% - 34px)); } }
-@keyframes tMoveYRev { 0% { transform: translateY(0); } 100% { transform: translateY(calc(-100% + 34px)); } }
+.main-menu-screen .tick {
+  position: absolute;
+  width: 34px;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.1),
+    var(--accent-red),
+    rgba(255, 255, 255, 0.1)
+  );
+  filter: drop-shadow(0 0 6px var(--accent-red-dark));
+  opacity: 0.9;
+  animation-duration: 2.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+.main-menu-screen .tick.t1 {
+  top: 10px;
+  left: 10px;
+  animation-name: tMoveX;
+}
+.main-menu-screen .tick.t2 {
+  bottom: 10px;
+  right: 10px;
+  animation-name: tMoveXRev;
+}
+.main-menu-screen .tick.t3 {
+  left: 10px;
+  top: 10px;
+  width: 2px;
+  height: 34px;
+  background: linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.1),
+    var(--accent-red),
+    rgba(255, 255, 255, 0.1)
+  );
+  animation-name: tMoveY;
+}
+.main-menu-screen .tick.t4 {
+  right: 10px;
+  bottom: 10px;
+  width: 2px;
+  height: 34px;
+  background: linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.1),
+    var(--accent-red),
+    rgba(255, 255, 255, 0.1)
+  );
+  animation-name: tMoveYRev;
+}
+@keyframes tMoveX {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(calc(100% - 34px));
+  }
+}
+@keyframes tMoveXRev {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(calc(-100% + 34px));
+  }
+}
+@keyframes tMoveY {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(calc(100% - 34px));
+  }
+}
+@keyframes tMoveYRev {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(calc(-100% + 34px));
+  }
+}
 
-.main-menu-screen .menu-button { position: relative; isolation: isolate; border: none; color: #fff; cursor: pointer; text-transform: uppercase; letter-spacing: 0.18rem; font-weight: 800; font-size: clamp(14px, 1.2vw, 18px); padding: 1rem 1.4rem 1rem 1.8rem; background: linear-gradient(135deg, rgba(255, 59, 59, 0.22), rgba(255, 59, 59, 0.08) 40%, rgba(255, 255, 255, 0.05) 100%); box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 14px rgba(255, 59, 59, 0.55), 0 0 40px rgba(255, 59, 59, 0.25); clip-path: polygon(0% 0%, 87% 0%, 100% 25%, 100% 100%, 13% 100%, 0% 75%); border-radius: 4px; transition: transform 0.18s ease, box-shadow 0.22s ease, letter-spacing 0.22s ease, filter 0.22s ease; }
-.main-menu-screen .menu-button::before { content: ""; position: absolute; inset: 0; pointer-events: none; clip-path: inherit; background: linear-gradient(135deg, transparent 0 40%, rgba(255, 255, 255, 0.08) 60%, transparent 100%); mix-blend-mode: screen; z-index: -1; }
-.main-menu-screen .menu-button::after { content: ""; position: absolute; top: 0; bottom: 0; left: -30%; width: 30%; background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.34), transparent); transform: skewX(-22deg); filter: blur(4px); transition: left 0.45s ease; }
-.main-menu-screen .menu-button:hover { transform: translateY(-3px) scale(1.02); letter-spacing: 0.22rem; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1), 0 0 18px rgba(255, 59, 59, 0.75), 0 0 60px rgba(255, 59, 59, 0.35); filter: saturate(1.1); }
-.main-menu-screen .menu-button:hover::after { left: 110%; }
-.main-menu-screen .menu-button .underline { position: absolute; left: 10px; right: 18%; bottom: -6px; height: 2px; overflow: hidden; }
-.main-menu-screen .menu-button .underline::before { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, rgba(255, 59, 59, 0.2), rgba(255, 59, 59, 0.9), rgba(255, 59, 59, 0.2)); transform: translateX(-100%); animation: slide 2.2s cubic-bezier(0.35, 0.05, 0.2, 0.95) infinite; }
-@keyframes slide { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+.main-menu-screen .menu-button {
+  position: relative;
+  isolation: isolate;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  font-weight: 800;
+  font-size: clamp(14px, 1.2vw, 18px);
+  padding: 1rem 1.4rem 1rem 1.8rem;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 59, 59, 0.22),
+    rgba(255, 59, 59, 0.08) 40%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 14px rgba(255, 59, 59, 0.55),
+    0 0 40px rgba(255, 59, 59, 0.25);
+  clip-path: polygon(0% 0%, 87% 0%, 100% 25%, 100% 100%, 13% 100%, 0% 75%);
+  border-radius: 4px;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.22s ease,
+    letter-spacing 0.22s ease,
+    filter 0.22s ease;
+}
+.main-menu-screen .menu-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  clip-path: inherit;
+  background: linear-gradient(
+    135deg,
+    transparent 0 40%,
+    rgba(255, 255, 255, 0.08) 60%,
+    transparent 100%
+  );
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+.main-menu-screen .menu-button::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -30%;
+  width: 30%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.34),
+    transparent
+  );
+  transform: skewX(-22deg);
+  filter: blur(4px);
+  transition: left 0.45s ease;
+}
+.main-menu-screen .menu-button:hover {
+  transform: translateY(-3px) scale(1.02);
+  letter-spacing: 0.22rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+    0 0 18px rgba(255, 59, 59, 0.75),
+    0 0 60px rgba(255, 59, 59, 0.35);
+  filter: saturate(1.1);
+}
+.main-menu-screen .menu-button:hover::after {
+  left: 110%;
+}
+.main-menu-screen .menu-button .underline {
+  position: absolute;
+  left: 10px;
+  right: 18%;
+  bottom: -6px;
+  height: 2px;
+  overflow: hidden;
+}
+.main-menu-screen .menu-button .underline::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 59, 59, 0.2),
+    rgba(255, 59, 59, 0.9),
+    rgba(255, 59, 59, 0.2)
+  );
+  transform: translateX(-100%);
+  animation: slide 2.2s cubic-bezier(0.35, 0.05, 0.2, 0.95) infinite;
+}
+@keyframes slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
 
-.main-menu-placeholder { max-width: min(92vw, 520px); box-sizing: border-box; border: 1px solid rgba(255, 59, 59, 0.5); background: rgba(0, 0, 0, 0.55); color: #fff; padding: 0.85rem 1rem; border-radius: 8px; letter-spacing: 0.05rem; box-shadow: 0 0 20px rgba(255, 59, 59, 0.25); }
+.main-menu-placeholder {
+  max-width: min(92vw, 520px);
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 59, 59, 0.5);
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  padding: 0.85rem 1rem;
+  border-radius: 8px;
+  letter-spacing: 0.05rem;
+  box-shadow: 0 0 20px rgba(255, 59, 59, 0.25);
+}
 
 @media (max-width: 780px) {
-  .main-menu-screen .brand { left: 4vw; font-size: clamp(26px, 7vw, 54px); }
-  .main-menu-screen .menu-wrap { left: 4vw; bottom: 6vh; width: 50%; }
+  .main-menu-screen .brand {
+    left: 4vw;
+    font-size: clamp(26px, 7vw, 54px);
+  }
+  .main-menu-screen .menu-wrap {
+    left: 4vw;
+    bottom: 6vh;
+    width: 50%;
+  }
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -8,18 +8,71 @@ async function getJson<T>(path: string, message: string): Promise<T> {
   if (!response.ok) throw new Error(message);
   return response.json();
 }
-async function postJson<T>(path: string, body: unknown, message: string): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+async function postJson<T>(
+  path: string,
+  body: unknown,
+  message: string,
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
   if (!response.ok) throw new Error(message);
   return response.json();
 }
-export async function getApiHealth(): Promise<ApiHealth> { return getJson("/health", "Failed to reach backend API"); }
-export async function getPlayers(): Promise<{ players: Player[] }> { return getJson("/players", "Failed to load players from backend API"); }
-export async function getTeams(): Promise<{ teams: Record<string, unknown>[] }> { return getJson("/teams", "Failed to load teams from backend API"); }
-export async function getGames(): Promise<{ games: Record<string, unknown>[] }> { return getGamesList(); }
-export async function getGamesList(): Promise<{ games: Record<string, unknown>[] }> { return getJson("/games", "Failed to load games from backend API"); }
-export async function getGameState(gameId: string | number): Promise<{ gameState: Record<string, unknown> | null }> { return getJson(`/games/${encodeURIComponent(String(gameId))}/state`, "Failed to load game state"); }
-export async function getPlayHistory(gameId: string | number): Promise<{ plays: Record<string, unknown>[] }> { return getJson(`/games/${encodeURIComponent(String(gameId))}/play-history`, "Failed to load play history"); }
-export async function savePlayAndGame(gameId: string | number, data: unknown): Promise<{ ok: boolean }> { return postJson(`/games/${encodeURIComponent(String(gameId))}/save-play-and-game`, data, "Failed to save play and game"); }
-export async function getPlayerTraits(): Promise<{ players: Record<string, unknown>[] }> { return getJson("/player-traits", "Failed to load player traits"); }
-export async function getFrontendSettings(): Promise<Record<string, unknown>> { return getJson("/frontend-settings", "Failed to load frontend settings"); }
+export async function getApiHealth(): Promise<ApiHealth> {
+  return getJson("/health", "Failed to reach backend API");
+}
+export async function getPlayers(): Promise<{ players: Player[] }> {
+  return getJson("/players", "Failed to load players from backend API");
+}
+export async function getTeams(): Promise<{
+  teams: Record<string, unknown>[];
+}> {
+  return getJson("/teams", "Failed to load teams from backend API");
+}
+export async function getGames(): Promise<{
+  games: Record<string, unknown>[];
+}> {
+  return getGamesList();
+}
+export async function getGamesList(): Promise<{
+  games: Record<string, unknown>[];
+}> {
+  return getJson("/games", "Failed to load games from backend API");
+}
+export async function getGameState(
+  gameId: string | number,
+): Promise<{ gameState: Record<string, unknown> | null }> {
+  return getJson(
+    `/games/${encodeURIComponent(String(gameId))}/state`,
+    "Failed to load game state",
+  );
+}
+export async function getPlayHistory(
+  gameId: string | number,
+): Promise<{ plays: Record<string, unknown>[] }> {
+  return getJson(
+    `/games/${encodeURIComponent(String(gameId))}/play-history`,
+    "Failed to load play history",
+  );
+}
+export async function savePlayAndGame(
+  gameId: string | number,
+  data: unknown,
+): Promise<{ ok: boolean }> {
+  return postJson(
+    `/games/${encodeURIComponent(String(gameId))}/save-play-and-game`,
+    data,
+    "Failed to save play and game",
+  );
+}
+export async function getPlayerTraits(): Promise<{
+  players: Record<string, unknown>[];
+}> {
+  return getJson("/player-traits", "Failed to load player traits");
+}
+export async function getFrontendSettings(): Promise<Record<string, unknown>> {
+  return getJson("/frontend-settings", "Failed to load frontend settings");
+}

--- a/apps/web/src/components/BackendStatus.tsx
+++ b/apps/web/src/components/BackendStatus.tsx
@@ -20,8 +20,7 @@ export function BackendStatus() {
 
   return (
     <aside className={`backend-status ${error ? "backend-status--error" : ""}`}>
-      <strong>Backend:</strong>{" "}
-      {error && <span>{error}</span>}
+      <strong>Backend:</strong> {error && <span>{error}</span>}
       {!error && !apiHealth && <span>Checking...</span>}
       {apiHealth && <span>Connected · {apiHealth.message}</span>}
     </aside>

--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -24,9 +24,13 @@
       rgba(0, 0, 0, 0) 50% 100%
     ),
     url("https://t4.ftcdn.net/jpg/04/24/03/09/360_F_424030921_ToDvrWZoPlJCYmmLdFvHxPyuU77WgITz.jpg");
-  background-size: calc(100% / 6) 100%, cover;
+  background-size:
+    calc(100% / 6) 100%,
+    cover;
   background-repeat: repeat-x, no-repeat;
-  background-position: left top, center;
+  background-position:
+    left top,
+    center;
   border: 3px solid #333;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   transform-style: preserve-3d;
@@ -62,7 +66,6 @@
 }
 
 .label.left {
-  
   text-align: right;
 }
 
@@ -162,7 +165,6 @@
 .play-line--left {
   transform: translate(-100%, -50%);
 }
-
 
 .play-line::after {
   content: "";

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1,60 +1,184 @@
 import { useEffect, useMemo, useState } from "react";
 import type { LeagueGame, GameTab } from "./types";
 import "./GameCenter.css";
-import { formatBallOnForPoss, formatClock, formatDownDistance, formatQuarter, parseInteger } from "./leagueMappers";
-import { getFrontendSettings, getGameState, getPlayerTraits, getPlayHistory, savePlayAndGame } from "../../api/client";
+import {
+  formatBallOnForPoss,
+  formatClock,
+  formatDownDistance,
+  formatQuarter,
+  parseInteger,
+} from "./leagueMappers";
+import {
+  getFrontendSettings,
+  getGameState,
+  getPlayerTraits,
+  getPlayHistory,
+  savePlayAndGame,
+} from "../../api/client";
 import { GameScoreboard } from "./GameScoreboard";
 import GameField from "./GameField";
 import { GameControls } from "./GameControls";
 import { GameLog } from "./GameLog";
-import { goForTwo, handleTimeout, kickFG, kneel, passPlay, punt, runPlay, spikeBall } from "./gameplay/gameEngine";
+import {
+  goForTwo,
+  handleTimeout,
+  kickFG,
+  kneel,
+  passPlay,
+  punt,
+  runPlay,
+  spikeBall,
+} from "./gameplay/gameEngine";
 import { animatePlay } from "./gameplay/engine/animationAdapter";
 import type { FrontendSettings, PlayCallOptions } from "./gameplay/gameEngine";
 
 type Play = Record<string, unknown>;
-type LineStatMatchup = { offensePlayer?: string; defensePlayer?: string; winner?: "OL" | "DL" | string };
+type LineStatMatchup = {
+  offensePlayer?: string;
+  defensePlayer?: string;
+  winner?: "OL" | "DL" | string;
+};
 function parseLineMatchups(value: unknown): LineStatMatchup[] {
   if (Array.isArray(value)) return value as LineStatMatchup[];
   if (typeof value !== "string" || !value.trim()) return [];
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed as LineStatMatchup[] : [];
+    return Array.isArray(parsed) ? (parsed as LineStatMatchup[]) : [];
   } catch {
     return [];
   }
 }
-type Stat = { playername: string; team: string; attempts?: number; completions?: number; yards: number; tds?: number; ints?: number; carries?: number; receptions?: number; targets?: number; sacks?: number; sackYds?: number; tackles?: number; tfl?: number; ff?: number; fr?: number; deflections?: number; fumbles?: number; long?: number; trucks?: number; jukes?: number; dLineWins?: number; dLineLosses?: number; oLineWins?: number; oLineLosses?: number };
+type Stat = {
+  playername: string;
+  team: string;
+  attempts?: number;
+  completions?: number;
+  yards: number;
+  tds?: number;
+  ints?: number;
+  carries?: number;
+  receptions?: number;
+  targets?: number;
+  sacks?: number;
+  sackYds?: number;
+  tackles?: number;
+  tfl?: number;
+  ff?: number;
+  fr?: number;
+  deflections?: number;
+  fumbles?: number;
+  long?: number;
+  trucks?: number;
+  jukes?: number;
+  dLineWins?: number;
+  dLineLosses?: number;
+  oLineWins?: number;
+  oLineLosses?: number;
+};
 const str = (v: unknown) => String(v ?? "");
 const num = (v: unknown) => Number(v) || 0;
-const playField = (p: Play, ...keys: string[]) => keys.map((k) => p[k]).find((v) => v !== undefined && v !== null && v !== "");
-const logoSrc = (value: unknown) => { const src = str(value).trim(); return src || undefined; };
-function TeamLogo({ src, className, alt = "" }: { src: unknown; className: string; alt?: string }) { const resolved = logoSrc(src); return resolved ? <img className={className} src={resolved} alt={alt} /> : <span className={`${className} logo-placeholder`} aria-hidden="true">🏈</span>; }
+const playField = (p: Play, ...keys: string[]) =>
+  keys.map((k) => p[k]).find((v) => v !== undefined && v !== null && v !== "");
+const logoSrc = (value: unknown) => {
+  const src = str(value).trim();
+  return src || undefined;
+};
+function TeamLogo({
+  src,
+  className,
+  alt = "",
+}: {
+  src: unknown;
+  className: string;
+  alt?: string;
+}) {
+  const resolved = logoSrc(src);
+  return resolved ? (
+    <img className={className} src={resolved} alt={alt} />
+  ) : (
+    <span className={`${className} logo-placeholder`} aria-hidden="true">
+      🏈
+    </span>
+  );
+}
 
-function normalizeFrontendSettings(settings: Record<string, unknown>): FrontendSettings {
+function normalizeFrontendSettings(
+  settings: Record<string, unknown>,
+): FrontendSettings {
   const normalized = settings as FrontendSettings;
-  normalized.drainSettings = normalized.drainSettings ?? normalized.staminaDrains;
-  normalized.tackleSettings = normalized.tackleSettings ?? normalized.tackleTable;
-  normalized.timeNeededToOpen = normalized.timeNeededToOpen ?? normalized.timeNeededToThrow;
-  normalized.thresholds = Array.isArray(normalized.thresholds) ? normalized.thresholds : [];
-  normalized.breakaways = Array.isArray(normalized.breakaways) ? normalized.breakaways : [];
-  normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards) ? normalized.accelToLBYards : [];
-  normalized.secondarySpeedYards = Array.isArray(normalized.secondarySpeedYards) ? normalized.secondarySpeedYards : [];
-  normalized.secondaryBreakawayYards = Array.isArray(normalized.secondaryBreakawayYards) ? normalized.secondaryBreakawayYards : [];
-  normalized.negativeYardage = Array.isArray(normalized.negativeYardage) ? normalized.negativeYardage : [];
+  normalized.drainSettings =
+    normalized.drainSettings ?? normalized.staminaDrains;
+  normalized.tackleSettings =
+    normalized.tackleSettings ?? normalized.tackleTable;
+  normalized.timeNeededToOpen =
+    normalized.timeNeededToOpen ?? normalized.timeNeededToThrow;
+  normalized.thresholds = Array.isArray(normalized.thresholds)
+    ? normalized.thresholds
+    : [];
+  normalized.breakaways = Array.isArray(normalized.breakaways)
+    ? normalized.breakaways
+    : [];
+  normalized.accelToLBYards = Array.isArray(normalized.accelToLBYards)
+    ? normalized.accelToLBYards
+    : [];
+  normalized.secondarySpeedYards = Array.isArray(normalized.secondarySpeedYards)
+    ? normalized.secondarySpeedYards
+    : [];
+  normalized.secondaryBreakawayYards = Array.isArray(
+    normalized.secondaryBreakawayYards,
+  )
+    ? normalized.secondaryBreakawayYards
+    : [];
+  normalized.negativeYardage = Array.isArray(normalized.negativeYardage)
+    ? normalized.negativeYardage
+    : [];
   normalized.staminaDrains = normalized.staminaDrains ?? {};
-  normalized.tackleTable = Array.isArray(normalized.tackleTable) ? normalized.tackleTable : [];
-  normalized.completionTable = Array.isArray(normalized.completionTable) ? normalized.completionTable : [];
-  normalized.routeTypeAirYards = Array.isArray(normalized.routeTypeAirYards) ? normalized.routeTypeAirYards : [];
-  normalized.timeNeededToThrow = Array.isArray(normalized.timeNeededToThrow) ? normalized.timeNeededToThrow : [];
-  normalized.completionSeparationAdjustment = Array.isArray(normalized.completionSeparationAdjustment) ? normalized.completionSeparationAdjustment : [];
+  normalized.tackleTable = Array.isArray(normalized.tackleTable)
+    ? normalized.tackleTable
+    : [];
+  normalized.completionTable = Array.isArray(normalized.completionTable)
+    ? normalized.completionTable
+    : [];
+  normalized.routeTypeAirYards = Array.isArray(normalized.routeTypeAirYards)
+    ? normalized.routeTypeAirYards
+    : [];
+  normalized.timeNeededToThrow = Array.isArray(normalized.timeNeededToThrow)
+    ? normalized.timeNeededToThrow
+    : [];
+  normalized.completionSeparationAdjustment = Array.isArray(
+    normalized.completionSeparationAdjustment,
+  )
+    ? normalized.completionSeparationAdjustment
+    : [];
   normalized.yacBySeparation = normalized.yacBySeparation ?? {};
-  normalized.sackLossTable = Array.isArray(normalized.sackLossTable) ? normalized.sackLossTable : [];
+  normalized.sackLossTable = Array.isArray(normalized.sackLossTable)
+    ? normalized.sackLossTable
+    : [];
   return normalized;
 }
 
-function normalizeGame(game: LeagueGame, state: Record<string, unknown> | null): LeagueGame {
+function normalizeGame(
+  game: LeagueGame,
+  state: Record<string, unknown> | null,
+): LeagueGame {
   if (!state) return game;
-  return { ...game, GameId: (state.Id ?? game.GameId) as string | number, Home: str(state.Home ?? game.Home), Away: str(state.Away ?? game.Away), HomeScore: (state.HomeScore ?? game.HomeScore) as string | number, AwayScore: (state.AwayScore ?? game.AwayScore) as string | number, Qtr: (state.Qtr ?? game.Qtr) as string | number, Time: (state.Time ?? game.Time) as string | number, Down: (state.Down ?? game.Down) as string | number, Distance: (state.Distance ?? game.Distance) as string | number, BallOn: (state.BallOn ?? game.BallOn) as string | number, Possession: str(state.Possession ?? game.Possession), HomeLogo: str(state.HomeLogo ?? game.HomeLogo ?? ""), AwayLogo: str(state.AwayLogo ?? game.AwayLogo ?? ""), ...(state as Record<string, unknown>) };
+  return {
+    ...game,
+    GameId: (state.Id ?? game.GameId) as string | number,
+    Home: str(state.Home ?? game.Home),
+    Away: str(state.Away ?? game.Away),
+    HomeScore: (state.HomeScore ?? game.HomeScore) as string | number,
+    AwayScore: (state.AwayScore ?? game.AwayScore) as string | number,
+    Qtr: (state.Qtr ?? game.Qtr) as string | number,
+    Time: (state.Time ?? game.Time) as string | number,
+    Down: (state.Down ?? game.Down) as string | number,
+    Distance: (state.Distance ?? game.Distance) as string | number,
+    BallOn: (state.BallOn ?? game.BallOn) as string | number,
+    Possession: str(state.Possession ?? game.Possession),
+    HomeLogo: str(state.HomeLogo ?? game.HomeLogo ?? ""),
+    AwayLogo: str(state.AwayLogo ?? game.AwayLogo ?? ""),
+    ...(state as Record<string, unknown>),
+  };
 }
 function playText(play: Play, game?: LeagueGame): string {
   const description = str(playField(play, "Description", "description")).trim();
@@ -65,15 +189,22 @@ function playText(play: Play, game?: LeagueGame): string {
   const yards = playField(play, "Yards", "yards") ?? 0;
   const tackler = str(playField(play, "Tackler", "tackler"));
   const possession = str(playField(play, "Possession", "possession"));
-  const newBallOn = (playField(play, "NewBallOn", "newBallOn", "newballon") as string | number) ?? 50;
+  const newBallOn =
+    (playField(play, "NewBallOn", "newBallOn", "newballon") as
+      string | number) ?? 50;
   const recoveredBy = str(playField(play, "RecoveredBy", "recoveredby"));
   if (result === "Timeout") return `${player} Timeout`;
   if (type === "Kick FG") return "Field Goal is Good!";
   if (type === "Kick XP") return "Extra Point is Good!";
   if (type === "2PT") {
     const success = result.toLowerCase().includes("successful");
-    if (receiver) return success ? `${player} ${yards} yard pass to ${receiver}. 2-point conversion is SUCCESSFUL!` : `${player} pass incomplete intended for ${receiver}. 2-point conversion FAILS!`;
-    return success ? `${player} runs for ${yards} yards. 2-point conversion is SUCCESSFUL!` : `${player} run fails. 2-point conversion FAILS!`;
+    if (receiver)
+      return success
+        ? `${player} ${yards} yard pass to ${receiver}. 2-point conversion is SUCCESSFUL!`
+        : `${player} pass incomplete intended for ${receiver}. 2-point conversion FAILS!`;
+    return success
+      ? `${player} runs for ${yards} yards. 2-point conversion is SUCCESSFUL!`
+      : `${player} run fails. 2-point conversion FAILS!`;
   }
   if (description === "Sack") {
     const spot = formatBallOnForPoss(newBallOn, possession);
@@ -81,7 +212,12 @@ function playText(play: Play, game?: LeagueGame): string {
     if (tackler && tackler !== "NA") text += ` (${tackler})`;
     text += ".";
     if (recoveredBy) {
-      const recoveryPoss = recoveredBy === player ? possession : possession === "Home" ? "Away" : "Home";
+      const recoveryPoss =
+        recoveredBy === player
+          ? possession
+          : possession === "Home"
+            ? "Away"
+            : "Home";
       text += ` FUMBLE! Recovered by ${recoveredBy} at the ${formatBallOnForPoss(newBallOn, recoveryPoss)}.`;
     }
     return text;
@@ -102,38 +238,67 @@ function playText(play: Play, game?: LeagueGame): string {
       text = `${player} pass intended for ${receiver}. Incomplete.`;
     } else {
       text = `${player} pass to ${receiver}`;
-      if (!isTouchdown) text += ` to ${formatBallOnForPoss(newBallOn, possession)}`;
+      if (!isTouchdown)
+        text += ` to ${formatBallOnForPoss(newBallOn, possession)}`;
       text += ` for ${yards} yards`;
       if (!isTouchdown && tackler && tackler !== "NA") text += ` (${tackler})`;
       text += ".";
     }
-    if (result && !["Normal", "Fumble", "Interception", "Incomplete"].includes(result)) {
-      if (isTouchdown) text += ` <span style="color:green; font-weight:bold;">Touchdown!</span>`;
-      else if (result === "TO on Downs") text += ` <span style="color:red; font-weight:bold;">${result}!</span>`;
+    if (
+      result &&
+      !["Normal", "Fumble", "Interception", "Incomplete"].includes(result)
+    ) {
+      if (isTouchdown)
+        text += ` <span style="color:green; font-weight:bold;">Touchdown!</span>`;
+      else if (result === "TO on Downs")
+        text += ` <span style="color:red; font-weight:bold;">${result}!</span>`;
       else text += ` <strong>${result}!</strong>`;
     }
     if (result === "Fumble" && recoveredBy) {
-      const recoveryPoss = recoveredBy === receiver ? possession : possession === "Home" ? "Away" : "Home";
+      const recoveryPoss =
+        recoveredBy === receiver
+          ? possession
+          : possession === "Home"
+            ? "Away"
+            : "Home";
       text += ` FUMBLE! Recovered by ${recoveredBy} at the ${formatBallOnForPoss(newBallOn, recoveryPoss)}.`;
     }
     return text;
   }
   let text = `<strong>${player}</strong> runs for ${yards} Yards.`;
   if (result && result !== "Normal" && result !== "Fumble") {
-    if (result === "Touchdown") text += ` <span style="color:green; font-weight:bold;">${result}!</span>`;
-    else if (result === "TO on Downs") text += ` <span style="color:red; font-weight:bold;">${result}!</span>`;
+    if (result === "Touchdown")
+      text += ` <span style="color:green; font-weight:bold;">${result}!</span>`;
+    else if (result === "TO on Downs")
+      text += ` <span style="color:red; font-weight:bold;">${result}!</span>`;
     else text += ` <strong>${result}!</strong>`;
   }
-  if (result !== "Touchdown" && tackler && tackler !== "NA") text += ` Tackle made at the ${formatBallOnForPoss(newBallOn, possession)} by ${tackler}.`;
+  if (result !== "Touchdown" && tackler && tackler !== "NA")
+    text += ` Tackle made at the ${formatBallOnForPoss(newBallOn, possession)} by ${tackler}.`;
   if (result === "Fumble" && recoveredBy) {
-    const recoveryPoss = recoveredBy === player ? possession : possession === "Home" ? "Away" : "Home";
+    const recoveryPoss =
+      recoveredBy === player
+        ? possession
+        : possession === "Home"
+          ? "Away"
+          : "Home";
     text += ` FUMBLE! Recovered by ${recoveredBy} at the ${formatBallOnForPoss(newBallOn, recoveryPoss)}.`;
   }
   void game;
   return text;
 }
 
-type Drive = { key: string; possession: string; driveStart: number; plays: Play[]; result: string; homeScore: unknown; awayScore: unknown; yards: number; playsCount: number };
+type Drive = {
+  key: string;
+  possession: string;
+  driveStart: number;
+  plays: Play[];
+  result: string;
+  homeScore: unknown;
+  awayScore: unknown;
+  yards: number;
+  playsCount: number;
+};
 function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
   const drives: Drive[] = [];
   let current: Drive | null = null;
@@ -145,87 +310,1210 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
     const driveStart = num(playField(play, "DriveStart", "drivestart"));
     const key = `${possession}-${driveStart}`;
     if (!current || current.key !== key) {
-      current = { key, possession, driveStart, plays: [], result: "", homeScore: game.HomeScore, awayScore: game.AwayScore, yards: 0, playsCount: 0 };
+      current = {
+        key,
+        possession,
+        driveStart,
+        plays: [],
+        result: "",
+        homeScore: game.HomeScore,
+        awayScore: game.AwayScore,
+        yards: 0,
+        playsCount: 0,
+      };
       drives.push(current);
     }
     current.plays.push(play);
   });
   drives.forEach((drive) => {
     const last = drive.plays[drive.plays.length - 1];
-    const lastDescription = str(playField(last, "Description", "description")).trim();
+    const lastDescription = str(
+      playField(last, "Description", "description"),
+    ).trim();
     const lastResult = str(playField(last, "Result", "result"));
-    drive.result = lastDescription === "Sack" && playField(last, "RecoveredBy", "recoveredby") ? "Fumble" : lastResult;
-    drive.homeScore = playField(last, "HomeScore", "homescore") ?? game.HomeScore;
-    drive.awayScore = playField(last, "AwayScore", "awayscore") ?? game.AwayScore;
+    drive.result =
+      lastDescription === "Sack" &&
+      playField(last, "RecoveredBy", "recoveredby")
+        ? "Fumble"
+        : lastResult;
+    drive.homeScore =
+      playField(last, "HomeScore", "homescore") ?? game.HomeScore;
+    drive.awayScore =
+      playField(last, "AwayScore", "awayscore") ?? game.AwayScore;
     const end = num(playField(last, "NewBallOn", "newBallOn", "newballon"));
-    drive.yards = drive.possession === "Home" ? end - drive.driveStart : drive.driveStart - end;
+    drive.yards =
+      drive.possession === "Home"
+        ? end - drive.driveStart
+        : drive.driveStart - end;
     drive.playsCount = drive.plays.length;
   });
   return drives;
 }
-function PlayByPlayTab({ game, history }: { game: LeagueGame; history: Play[] }) {
-  return <div className="drive-log" id="playTimeline">{groupPlaysByDrive(history, game).map((drive) => <details className="drive-section" key={drive.key} open><summary className="drive-header"><span className="drive-toggle" aria-hidden="true">^</span><TeamLogo className="drive-logo" src={drive.possession === "Home" ? game.HomeLogo : game.AwayLogo} /><span className="drive-overview"><span className="drive-result">{drive.result}</span><span className="drive-summary">{drive.playsCount} Plays, {drive.yards} Yards</span></span><span className="drive-score"><span><span className="team-name">{game.Home}</span> <span className="score-value">{String(drive.homeScore ?? "")}</span></span><span><span className="team-name">{game.Away}</span> <span className="score-value">{String(drive.awayScore ?? "")}</span></span></span></summary><div className="drive-plays">{drive.plays.map((play, i) => { const downDist = formatDownDistance((playField(play, "Down", "down") as string | number) ?? 1, (playField(play, "Distance", "distance") as string | number) ?? 10); const spot = formatBallOnForPoss((playField(play, "BallOn", "ballon") as string | number) ?? 50, str(playField(play, "Possession", "possession"))); return <div className="play-row" key={String(play.PlayId ?? play.playid ?? `${drive.key}-${i}`)}><div className="play-situation">{downDist} at {spot}</div><div className="play-desc" dangerouslySetInnerHTML={{ __html: `(${formatClock((playField(play, "Time", "time") as string | number) ?? "0:00")} - ${formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? game.Qtr)}) ${playText(play, game)}` }} /></div>; })}</div></details>)}</div>;
+function PlayByPlayTab({
+  game,
+  history,
+}: {
+  game: LeagueGame;
+  history: Play[];
+}) {
+  return (
+    <div className="drive-log" id="playTimeline">
+      {groupPlaysByDrive(history, game).map((drive) => (
+        <details className="drive-section" key={drive.key} open>
+          <summary className="drive-header">
+            <span className="drive-toggle" aria-hidden="true">
+              ^
+            </span>
+            <TeamLogo
+              className="drive-logo"
+              src={drive.possession === "Home" ? game.HomeLogo : game.AwayLogo}
+            />
+            <span className="drive-overview">
+              <span className="drive-result">{drive.result}</span>
+              <span className="drive-summary">
+                {drive.playsCount} Plays, {drive.yards} Yards
+              </span>
+            </span>
+            <span className="drive-score">
+              <span>
+                <span className="team-name">{game.Home}</span>{" "}
+                <span className="score-value">
+                  {String(drive.homeScore ?? "")}
+                </span>
+              </span>
+              <span>
+                <span className="team-name">{game.Away}</span>{" "}
+                <span className="score-value">
+                  {String(drive.awayScore ?? "")}
+                </span>
+              </span>
+            </span>
+          </summary>
+          <div className="drive-plays">
+            {drive.plays.map((play, i) => {
+              const downDist = formatDownDistance(
+                (playField(play, "Down", "down") as string | number) ?? 1,
+                (playField(play, "Distance", "distance") as string | number) ??
+                  10,
+              );
+              const spot = formatBallOnForPoss(
+                (playField(play, "BallOn", "ballon") as string | number) ?? 50,
+                str(playField(play, "Possession", "possession")),
+              );
+              return (
+                <div
+                  className="play-row"
+                  key={String(
+                    play.PlayId ?? play.playid ?? `${drive.key}-${i}`,
+                  )}
+                >
+                  <div className="play-situation">
+                    {downDist} at {spot}
+                  </div>
+                  <div
+                    className="play-desc"
+                    dangerouslySetInnerHTML={{
+                      __html: `(${formatClock((playField(play, "Time", "time") as string | number) ?? "0:00")} - ${formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? game.Qtr)}) ${playText(play, game)}`,
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
 }
 function scoreByQuarter(history: Play[], game: LeagueGame) {
-  const home = [0, 0, 0, 0]; const away = [0, 0, 0, 0]; let ph = 0; let pa = 0;
-  history.forEach((p) => { const q = parseInteger(playField(p, "QTR", "Qtr", "quarter"), 0); const h = num(playField(p, "HomeScore", "homescore")); const a = num(playField(p, "AwayScore", "awayscore")); if (q >= 1 && q <= 4) { home[q - 1] += h - ph; away[q - 1] += a - pa; } ph = h; pa = a; });
-  if (!history.length) { home[0] = num(game.HomeScore); away[0] = num(game.AwayScore); }
+  const home = [0, 0, 0, 0];
+  const away = [0, 0, 0, 0];
+  let ph = 0;
+  let pa = 0;
+  history.forEach((p) => {
+    const q = parseInteger(playField(p, "QTR", "Qtr", "quarter"), 0);
+    const h = num(playField(p, "HomeScore", "homescore"));
+    const a = num(playField(p, "AwayScore", "awayscore"));
+    if (q >= 1 && q <= 4) {
+      home[q - 1] += h - ph;
+      away[q - 1] += a - pa;
+    }
+    ph = h;
+    pa = a;
+  });
+  if (!history.length) {
+    home[0] = num(game.HomeScore);
+    away[0] = num(game.AwayScore);
+  }
   return { home, away };
 }
 function calcStats(history: Play[]) {
-  const pass: Stat[] = [], rush: Stat[] = [], recs: Stat[] = [], def: Stat[] = [], offball: Stat[] = [];
-  const get = (arr: Stat[], name: string, team: string) => { let s = arr.find((x) => x.playername === name && x.team === team); if (!s) { s = { playername: name, team, yards: 0 }; arr.push(s); } return s; };
-  history.forEach((p) => { const team = str(playField(p, "Possession", "possession")); if (!team) return; const defTeam = team === "Home" ? "Away" : "Home"; const type = str(playField(p, "PlayType", "playtype")); const result = str(playField(p, "Result", "ResultCategory", "result")); const desc = str(playField(p, "Description", "description")); const isSack = desc === "Sack" || result === "Sack"; const y = num(playField(p, "Yards", "yards")); const player = str(playField(p, "Player", "player")); const qb = str(playField(p, "Passer", "Player", "player")); const receiver = str(playField(p, "Receiver", "Target", "receiver")); const tackler = str(playField(p, "Tackler", "tackler")); const recoveredBy = str(playField(p, "RecoveredBy", "recoveredby"));
-    if (type === "Run" && player) { const s = get(rush, player, team); s.carries = (s.carries || 0) + 1; s.yards += y; s.long = Math.max(s.long || 0, y); s.trucks = (s.trucks || 0) + num(playField(p, "Trucks", "trucks", "BrokenTackles", "brokenTackles")); s.jukes = (s.jukes || 0) + num(playField(p, "Jukes", "jukes")); if (result === "Touchdown") s.tds = (s.tds || 0) + 1; if (result === "Fumble") s.fumbles = (s.fumbles || 0) + 1; }
-    const matchups = parseLineMatchups(playField(p, "lineMatchups", "LineMatchups"));
-    matchups.forEach((m) => { if (m.offensePlayer) { const s = get(offball, m.offensePlayer, team); if (m.winner === "OL") s.oLineWins = (s.oLineWins || 0) + 1; else if (m.winner === "DL") s.oLineLosses = (s.oLineLosses || 0) + 1; } if (m.defensePlayer) { const s = get(def, m.defensePlayer, defTeam); if (m.winner === "DL") s.dLineWins = (s.dLineWins || 0) + 1; else if (m.winner === "OL") s.dLineLosses = (s.dLineLosses || 0) + 1; } });
-    if (type === "Pass" || isSack) { if (qb) { const s = get(pass, qb, team); if (isSack) { s.sacks = (s.sacks || 0) + 1; s.sackYds = (s.sackYds || 0) + y; } else { s.attempts = (s.attempts || 0) + 1; if (!["Incomplete", "Incompletion", "Interception"].includes(result)) { s.completions = (s.completions || 0) + 1; s.yards += y; if (result === "Touchdown") s.tds = (s.tds || 0) + 1; } if (result === "Interception") s.ints = (s.ints || 0) + 1; } }
-      if (receiver && !isSack) { const s = get(recs, receiver, team); s.targets = (s.targets || 0) + 1; if (!["Incomplete", "Incompletion", "Interception"].includes(result)) { s.receptions = (s.receptions || 0) + 1; s.yards += y; s.long = Math.max(s.long || 0, y); if (result === "Touchdown") s.tds = (s.tds || 0) + 1; } if (result === "Fumble") s.fumbles = (s.fumbles || 0) + 1; } }
-    if (tackler && tackler !== "NA") { const s = get(def, tackler, defTeam); s.tackles = (s.tackles || 0) + 1; if (y < 0 || isSack) s.tfl = (s.tfl || 0) + 1; if (isSack) s.sacks = (s.sacks || 0) + 1; if (result === "Fumble") { s.ff = (s.ff || 0) + 1; if (recoveredBy === tackler) s.fr = (s.fr || 0) + 1; } }
-    if (result === "Interception" && (recoveredBy || tackler)) { const s = get(def, recoveredBy || tackler, defTeam); s.ints = (s.ints || 0) + 1; }
-  }); return { pass, rush, recs, def, offball };
+  const pass: Stat[] = [],
+    rush: Stat[] = [],
+    recs: Stat[] = [],
+    def: Stat[] = [],
+    offball: Stat[] = [];
+  const get = (arr: Stat[], name: string, team: string) => {
+    let s = arr.find((x) => x.playername === name && x.team === team);
+    if (!s) {
+      s = { playername: name, team, yards: 0 };
+      arr.push(s);
+    }
+    return s;
+  };
+  history.forEach((p) => {
+    const team = str(playField(p, "Possession", "possession"));
+    if (!team) return;
+    const defTeam = team === "Home" ? "Away" : "Home";
+    const type = str(playField(p, "PlayType", "playtype"));
+    const result = str(playField(p, "Result", "ResultCategory", "result"));
+    const desc = str(playField(p, "Description", "description"));
+    const isSack = desc === "Sack" || result === "Sack";
+    const y = num(playField(p, "Yards", "yards"));
+    const player = str(playField(p, "Player", "player"));
+    const qb = str(playField(p, "Passer", "Player", "player"));
+    const receiver = str(playField(p, "Receiver", "Target", "receiver"));
+    const tackler = str(playField(p, "Tackler", "tackler"));
+    const recoveredBy = str(playField(p, "RecoveredBy", "recoveredby"));
+    if (type === "Run" && player) {
+      const s = get(rush, player, team);
+      s.carries = (s.carries || 0) + 1;
+      s.yards += y;
+      s.long = Math.max(s.long || 0, y);
+      s.trucks =
+        (s.trucks || 0) +
+        num(playField(p, "Trucks", "trucks", "BrokenTackles", "brokenTackles"));
+      s.jukes = (s.jukes || 0) + num(playField(p, "Jukes", "jukes"));
+      if (result === "Touchdown") s.tds = (s.tds || 0) + 1;
+      if (result === "Fumble") s.fumbles = (s.fumbles || 0) + 1;
+    }
+    const matchups = parseLineMatchups(
+      playField(p, "lineMatchups", "LineMatchups"),
+    );
+    matchups.forEach((m) => {
+      if (m.offensePlayer) {
+        const s = get(offball, m.offensePlayer, team);
+        if (m.winner === "OL") s.oLineWins = (s.oLineWins || 0) + 1;
+        else if (m.winner === "DL") s.oLineLosses = (s.oLineLosses || 0) + 1;
+      }
+      if (m.defensePlayer) {
+        const s = get(def, m.defensePlayer, defTeam);
+        if (m.winner === "DL") s.dLineWins = (s.dLineWins || 0) + 1;
+        else if (m.winner === "OL") s.dLineLosses = (s.dLineLosses || 0) + 1;
+      }
+    });
+    if (type === "Pass" || isSack) {
+      if (qb) {
+        const s = get(pass, qb, team);
+        if (isSack) {
+          s.sacks = (s.sacks || 0) + 1;
+          s.sackYds = (s.sackYds || 0) + y;
+        } else {
+          s.attempts = (s.attempts || 0) + 1;
+          if (
+            !["Incomplete", "Incompletion", "Interception"].includes(result)
+          ) {
+            s.completions = (s.completions || 0) + 1;
+            s.yards += y;
+            if (result === "Touchdown") s.tds = (s.tds || 0) + 1;
+          }
+          if (result === "Interception") s.ints = (s.ints || 0) + 1;
+        }
+      }
+      if (receiver && !isSack) {
+        const s = get(recs, receiver, team);
+        s.targets = (s.targets || 0) + 1;
+        if (!["Incomplete", "Incompletion", "Interception"].includes(result)) {
+          s.receptions = (s.receptions || 0) + 1;
+          s.yards += y;
+          s.long = Math.max(s.long || 0, y);
+          if (result === "Touchdown") s.tds = (s.tds || 0) + 1;
+        }
+        if (result === "Fumble") s.fumbles = (s.fumbles || 0) + 1;
+      }
+    }
+    if (tackler && tackler !== "NA") {
+      const s = get(def, tackler, defTeam);
+      s.tackles = (s.tackles || 0) + 1;
+      if (y < 0 || isSack) s.tfl = (s.tfl || 0) + 1;
+      if (isSack) s.sacks = (s.sacks || 0) + 1;
+      if (result === "Fumble") {
+        s.ff = (s.ff || 0) + 1;
+        if (recoveredBy === tackler) s.fr = (s.fr || 0) + 1;
+      }
+    }
+    if (result === "Interception" && (recoveredBy || tackler)) {
+      const s = get(def, recoveredBy || tackler, defTeam);
+      s.ints = (s.ints || 0) + 1;
+    }
+  });
+  return { pass, rush, recs, def, offball };
 }
 
-const avg = (yards = 0, plays = 0) => plays ? (yards / plays).toFixed(1) : "0.0";
+const avg = (yards = 0, plays = 0) =>
+  plays ? (yards / plays).toFixed(1) : "0.0";
 const sacksText = (s: Stat) => `${s.sacks || 0}-${Math.abs(s.sackYds || 0)}`;
-function parseTimeSeconds(v: unknown) { const parts = str(v).split(":").map(Number); return parts.length === 2 ? (parts[0] || 0) * 60 + (parts[1] || 0) : num(v); }
-function TeamTable({ title, columns, rows }: { title: string; columns: string[]; rows: (string | number)[][] }) { return <div className="stats-group"><div className="stats-title">{title}</div><table className="stats-table"><thead><tr>{columns.map((c) => <th key={c}>{c}</th>)}</tr></thead><tbody>{rows.length ? rows.map((r, i) => <tr key={`${r[0]}-${i}`} className={String(r[0]).toUpperCase() === "TEAM" ? "team-row" : ""}>{r.map((c, j) => <td key={j}>{c}</td>)}</tr>) : <tr><td colSpan={columns.length} className="stats-placeholder">No stats yet</td></tr>}</tbody></table></div>; }
+function parseTimeSeconds(v: unknown) {
+  const parts = str(v).split(":").map(Number);
+  return parts.length === 2 ? (parts[0] || 0) * 60 + (parts[1] || 0) : num(v);
+}
+function TeamTable({
+  title,
+  columns,
+  rows,
+}: {
+  title: string;
+  columns: string[];
+  rows: (string | number)[][];
+}) {
+  return (
+    <div className="stats-group">
+      <div className="stats-title">{title}</div>
+      <table className="stats-table">
+        <thead>
+          <tr>
+            {columns.map((c) => (
+              <th key={c}>{c}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length ? (
+            rows.map((r, i) => (
+              <tr
+                key={`${r[0]}-${i}`}
+                className={
+                  String(r[0]).toUpperCase() === "TEAM" ? "team-row" : ""
+                }
+              >
+                {r.map((c, j) => (
+                  <td key={j}>{c}</td>
+                ))}
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={columns.length} className="stats-placeholder">
+                No stats yet
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
 function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
-  const [subtab, setSubtab] = useState<"Home" | "Overview" | "Away">("Home"); const stats = useMemo(() => calcStats(history), [history]);
-  const passRows = (team: string, condensed = false) => stats.pass.filter((p) => p.team === team).sort((a, b) => b.yards - a.yards).map((p) => condensed ? [p.playername, `${p.completions || 0}/${p.attempts || 0}`, p.yards, p.tds || 0, p.ints || 0, sacksText(p)] : [p.playername, `${p.completions || 0}/${p.attempts || 0}`, p.yards, avg(p.yards, p.completions || 0), p.tds || 0, p.ints || 0, sacksText(p), "0.0"]);
-  const rushRows = (team: string, condensed = false) => { const rows = stats.rush.filter((p) => p.team === team).sort((a, b) => b.yards - a.yards); const total = rows.reduce((t, p) => ({ carries: t.carries + (p.carries || 0), yards: t.yards + p.yards, tds: t.tds + (p.tds || 0), fumbles: t.fumbles + (p.fumbles || 0), trucks: t.trucks + (p.trucks || 0), jukes: t.jukes + (p.jukes || 0), long: Math.max(t.long, p.long || 0) }), { carries: 0, yards: 0, tds: 0, fumbles: 0, trucks: 0, jukes: 0, long: 0 }); const out = rows.map((p) => condensed ? [p.playername, p.carries || 0, p.yards, p.tds || 0, p.long || 0] : [p.playername, p.carries || 0, p.yards, avg(p.yards, p.carries || 0), p.tds || 0, p.fumbles || 0, p.trucks || 0, p.jukes || 0, p.long || 0]); if (rows.length) out.push(condensed ? ["TEAM", total.carries, total.yards, total.tds, total.long] : ["TEAM", total.carries, total.yards, avg(total.yards, total.carries), total.tds, total.fumbles, total.trucks, total.jukes, total.long]); return out; };
-  const recRows = (team: string, condensed = false) => { const rows = stats.recs.filter((p) => p.team === team).sort((a, b) => b.yards - a.yards); const total = rows.reduce((t, p) => ({ receptions: t.receptions + (p.receptions || 0), yards: t.yards + p.yards, tds: t.tds + (p.tds || 0), long: Math.max(t.long, p.long || 0), targets: t.targets + (p.targets || 0) }), { receptions: 0, yards: 0, tds: 0, long: 0, targets: 0 }); const out = rows.map((p) => condensed ? [p.playername, p.receptions || 0, p.yards, p.tds || 0, p.long || 0] : [p.playername, p.receptions || 0, p.yards, avg(p.yards, p.receptions || 0), p.tds || 0, p.long || 0, p.targets || 0]); if (rows.length) out.push(condensed ? ["TEAM", total.receptions, total.yards, total.tds, total.long] : ["TEAM", total.receptions, total.yards, avg(total.yards, total.receptions), total.tds, total.long, total.targets]); return out; };
-  const defRows = (team: string) => stats.def.filter((p) => p.team === team).sort((a, b) => (b.tackles || 0) - (a.tackles || 0) || (b.dLineWins || 0) - (a.dLineWins || 0)).map((p) => [p.playername, p.tackles || 0, p.tfl || 0, p.ff || 0, p.dLineWins || 0, p.dLineLosses || 0, p.sacks || 0, p.fr || 0, p.ints || 0, p.deflections || 0]);
-  const offballRows = (team: string) => stats.offball.filter((p) => p.team === team).sort((a, b) => (b.oLineWins || 0) - (a.oLineWins || 0)).map((p) => [p.playername, p.oLineWins || 0, p.oLineLosses || 0]);
-  const teamName = (t: string) => t === "Home" ? game.Home : game.Away; const renderTeam = (team: string) => <><TeamTable title={`${teamName(team)} Passing`} columns={["Player", "C/ATT", "YDS", "AVG", "TD", "INT", "SACKS", "RTG"]} rows={passRows(team)} /><TeamTable title={`${teamName(team)} Rushing`} columns={["Player", "CAR", "YDS", "AVG", "TD", "FUM", "TRUCK", "JUKE", "LONG"]} rows={rushRows(team)} /><TeamTable title={`${teamName(team)} Receiving`} columns={["Player", "REC", "YDS", "AVG", "TD", "LONG", "TGTS"]} rows={recRows(team)} /><TeamTable title={`${teamName(team)} Defensive`} columns={["Player", "TKL", "TFL", "FF", "DL W", "DL L", "Sack", "FR", "INT", "Defl"]} rows={defRows(team)} /><TeamTable title={`${teamName(team)} Offensive Offball`} columns={["Player", "OL W", "OL L"]} rows={offballRows(team)} /></>;
-  return <div className="boxscore-card"><div className="boxscore-pill-container">{(["Home", "Overview", "Away"] as const).map((t) => <button key={t} className={`boxscore-pill ${subtab === t ? "active" : ""}`} type="button" onClick={() => setSubtab(t)}>{t === "Home" ? game.Home : t === "Away" ? game.Away : t}</button>)}</div>{subtab !== "Overview" ? renderTeam(subtab) : <div className="overview-section">{["Passing", "Rushing", "Receiving"].map((kind) => <div className="stats-row" key={kind}>{(["Home", "Away"] as const).map((team) => <div className="team-table" key={team}>{kind === "Passing" && <TeamTable title={`${teamName(team)} Passing`} columns={["Player", "C/ATT", "YDS", "TD", "INT", "SACKS"]} rows={passRows(team, true)} />}{kind === "Rushing" && <TeamTable title={`${teamName(team)} Rushing`} columns={["Player", "CAR", "YDS", "TD", "LONG"]} rows={rushRows(team, true)} />}{kind === "Receiving" && <TeamTable title={`${teamName(team)} Receiving`} columns={["Player", "REC", "YDS", "TD", "LONG"]} rows={recRows(team, true)} />}</div>)}</div>)}</div>}</div>;
+  const [subtab, setSubtab] = useState<"Home" | "Overview" | "Away">("Home");
+  const stats = useMemo(() => calcStats(history), [history]);
+  const passRows = (team: string, condensed = false) =>
+    stats.pass
+      .filter((p) => p.team === team)
+      .sort((a, b) => b.yards - a.yards)
+      .map((p) =>
+        condensed
+          ? [
+              p.playername,
+              `${p.completions || 0}/${p.attempts || 0}`,
+              p.yards,
+              p.tds || 0,
+              p.ints || 0,
+              sacksText(p),
+            ]
+          : [
+              p.playername,
+              `${p.completions || 0}/${p.attempts || 0}`,
+              p.yards,
+              avg(p.yards, p.completions || 0),
+              p.tds || 0,
+              p.ints || 0,
+              sacksText(p),
+              "0.0",
+            ],
+      );
+  const rushRows = (team: string, condensed = false) => {
+    const rows = stats.rush
+      .filter((p) => p.team === team)
+      .sort((a, b) => b.yards - a.yards);
+    const total = rows.reduce(
+      (t, p) => ({
+        carries: t.carries + (p.carries || 0),
+        yards: t.yards + p.yards,
+        tds: t.tds + (p.tds || 0),
+        fumbles: t.fumbles + (p.fumbles || 0),
+        trucks: t.trucks + (p.trucks || 0),
+        jukes: t.jukes + (p.jukes || 0),
+        long: Math.max(t.long, p.long || 0),
+      }),
+      {
+        carries: 0,
+        yards: 0,
+        tds: 0,
+        fumbles: 0,
+        trucks: 0,
+        jukes: 0,
+        long: 0,
+      },
+    );
+    const out = rows.map((p) =>
+      condensed
+        ? [p.playername, p.carries || 0, p.yards, p.tds || 0, p.long || 0]
+        : [
+            p.playername,
+            p.carries || 0,
+            p.yards,
+            avg(p.yards, p.carries || 0),
+            p.tds || 0,
+            p.fumbles || 0,
+            p.trucks || 0,
+            p.jukes || 0,
+            p.long || 0,
+          ],
+    );
+    if (rows.length)
+      out.push(
+        condensed
+          ? ["TEAM", total.carries, total.yards, total.tds, total.long]
+          : [
+              "TEAM",
+              total.carries,
+              total.yards,
+              avg(total.yards, total.carries),
+              total.tds,
+              total.fumbles,
+              total.trucks,
+              total.jukes,
+              total.long,
+            ],
+      );
+    return out;
+  };
+  const recRows = (team: string, condensed = false) => {
+    const rows = stats.recs
+      .filter((p) => p.team === team)
+      .sort((a, b) => b.yards - a.yards);
+    const total = rows.reduce(
+      (t, p) => ({
+        receptions: t.receptions + (p.receptions || 0),
+        yards: t.yards + p.yards,
+        tds: t.tds + (p.tds || 0),
+        long: Math.max(t.long, p.long || 0),
+        targets: t.targets + (p.targets || 0),
+      }),
+      { receptions: 0, yards: 0, tds: 0, long: 0, targets: 0 },
+    );
+    const out = rows.map((p) =>
+      condensed
+        ? [p.playername, p.receptions || 0, p.yards, p.tds || 0, p.long || 0]
+        : [
+            p.playername,
+            p.receptions || 0,
+            p.yards,
+            avg(p.yards, p.receptions || 0),
+            p.tds || 0,
+            p.long || 0,
+            p.targets || 0,
+          ],
+    );
+    if (rows.length)
+      out.push(
+        condensed
+          ? ["TEAM", total.receptions, total.yards, total.tds, total.long]
+          : [
+              "TEAM",
+              total.receptions,
+              total.yards,
+              avg(total.yards, total.receptions),
+              total.tds,
+              total.long,
+              total.targets,
+            ],
+      );
+    return out;
+  };
+  const defRows = (team: string) =>
+    stats.def
+      .filter((p) => p.team === team)
+      .sort(
+        (a, b) =>
+          (b.tackles || 0) - (a.tackles || 0) ||
+          (b.dLineWins || 0) - (a.dLineWins || 0),
+      )
+      .map((p) => [
+        p.playername,
+        p.tackles || 0,
+        p.tfl || 0,
+        p.ff || 0,
+        p.dLineWins || 0,
+        p.dLineLosses || 0,
+        p.sacks || 0,
+        p.fr || 0,
+        p.ints || 0,
+        p.deflections || 0,
+      ]);
+  const offballRows = (team: string) =>
+    stats.offball
+      .filter((p) => p.team === team)
+      .sort((a, b) => (b.oLineWins || 0) - (a.oLineWins || 0))
+      .map((p) => [p.playername, p.oLineWins || 0, p.oLineLosses || 0]);
+  const teamName = (t: string) => (t === "Home" ? game.Home : game.Away);
+  const renderTeam = (team: string) => (
+    <>
+      <TeamTable
+        title={`${teamName(team)} Passing`}
+        columns={["Player", "C/ATT", "YDS", "AVG", "TD", "INT", "SACKS", "RTG"]}
+        rows={passRows(team)}
+      />
+      <TeamTable
+        title={`${teamName(team)} Rushing`}
+        columns={[
+          "Player",
+          "CAR",
+          "YDS",
+          "AVG",
+          "TD",
+          "FUM",
+          "TRUCK",
+          "JUKE",
+          "LONG",
+        ]}
+        rows={rushRows(team)}
+      />
+      <TeamTable
+        title={`${teamName(team)} Receiving`}
+        columns={["Player", "REC", "YDS", "AVG", "TD", "LONG", "TGTS"]}
+        rows={recRows(team)}
+      />
+      <TeamTable
+        title={`${teamName(team)} Defensive`}
+        columns={[
+          "Player",
+          "TKL",
+          "TFL",
+          "FF",
+          "DL W",
+          "DL L",
+          "Sack",
+          "FR",
+          "INT",
+          "Defl",
+        ]}
+        rows={defRows(team)}
+      />
+      <TeamTable
+        title={`${teamName(team)} Offensive Offball`}
+        columns={["Player", "OL W", "OL L"]}
+        rows={offballRows(team)}
+      />
+    </>
+  );
+  return (
+    <div className="boxscore-card">
+      <div className="boxscore-pill-container">
+        {(["Home", "Overview", "Away"] as const).map((t) => (
+          <button
+            key={t}
+            className={`boxscore-pill ${subtab === t ? "active" : ""}`}
+            type="button"
+            onClick={() => setSubtab(t)}
+          >
+            {t === "Home" ? game.Home : t === "Away" ? game.Away : t}
+          </button>
+        ))}
+      </div>
+      {subtab !== "Overview" ? (
+        renderTeam(subtab)
+      ) : (
+        <div className="overview-section">
+          {["Passing", "Rushing", "Receiving"].map((kind) => (
+            <div className="stats-row" key={kind}>
+              {(["Home", "Away"] as const).map((team) => (
+                <div className="team-table" key={team}>
+                  {kind === "Passing" && (
+                    <TeamTable
+                      title={`${teamName(team)} Passing`}
+                      columns={["Player", "C/ATT", "YDS", "TD", "INT", "SACKS"]}
+                      rows={passRows(team, true)}
+                    />
+                  )}
+                  {kind === "Rushing" && (
+                    <TeamTable
+                      title={`${teamName(team)} Rushing`}
+                      columns={["Player", "CAR", "YDS", "TD", "LONG"]}
+                      rows={rushRows(team, true)}
+                    />
+                  )}
+                  {kind === "Receiving" && (
+                    <TeamTable
+                      title={`${teamName(team)} Receiving`}
+                      columns={["Player", "REC", "YDS", "TD", "LONG"]}
+                      rows={recRows(team, true)}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 function computeTeamStats(history: Play[], game: LeagueGame) {
-  const init = () => ({ firstDowns: 0, thirdAtt: 0, thirdConv: 0, fourthAtt: 0, fourthConv: 0, passYds: 0, rushYds: 0, passAtt: 0, passComp: 0, ints: 0, sacks: 0, sackYds: 0, rushAtt: 0, fumLost: 0, possTime: 0, totalYds: 0, turnovers: 0 });
-  const teams = { Home: init(), Away: init() }; const quarterLen = 15 * 60; let prev = { Possession: str((game as unknown as Play).StartingPossession || "Home"), Time: quarterLen, Qtr: 1 };
-  history.forEach((play) => { const team = str(playField(play, "Possession", "possession")) as "Home" | "Away"; if (!teams[team]) return; const yards = num(playField(play, "Yards", "yards")); const down = num(playField(play, "Down", "down")); const distance = num(playField(play, "Distance", "distance")); const result = str(playField(play, "Result", "result")); const type = str(playField(play, "PlayType", "playtype")); const currTime = parseTimeSeconds(playField(play, "Time", "time")); const currQtr = num(playField(play, "Qtr", "QTR", "quarter")) || prev.Qtr; const diff = currQtr === prev.Qtr ? prev.Time - currTime : prev.Time + (quarterLen * (currQtr - prev.Qtr - 1)) + (quarterLen - currTime); if (teams[prev.Possession as "Home" | "Away"]) teams[prev.Possession as "Home" | "Away"].possTime += Math.max(0, diff); prev = { Possession: team, Time: currTime, Qtr: currQtr };
-    if (type === "Pass") { if (result === "Sack" || str(playField(play, "Description", "description")) === "Sack") { teams[team].sacks++; teams[team].sackYds += yards; teams[team].passYds += yards; } else { teams[team].passAtt++; if (!["Incomplete", "Incompletion", "Interception"].includes(result)) { teams[team].passComp++; teams[team].passYds += yards; } if (result === "Interception") teams[team].ints++; if (result === "Fumble" && playField(play, "RecoveredBy", "recoveredby") && playField(play, "RecoveredBy", "recoveredby") !== (playField(play, "Receiver", "Target", "receiver") || playField(play, "Player", "player"))) teams[team].fumLost++; } } else if (type === "Run") { teams[team].rushAtt++; teams[team].rushYds += yards; if (result === "Fumble" && playField(play, "RecoveredBy", "recoveredby") && playField(play, "RecoveredBy", "recoveredby") !== playField(play, "Player", "player")) teams[team].fumLost++; }
-    if (type === "Run" || type === "Pass") { const converted = yards >= distance || result === "Touchdown"; if (down === 3) { teams[team].thirdAtt++; if (converted) teams[team].thirdConv++; } else if (down === 4) { teams[team].fourthAtt++; if (converted) teams[team].fourthConv++; } if (converted) teams[team].firstDowns++; }
-  }); (["Home", "Away"] as const).forEach((t) => { teams[t].totalYds = teams[t].passYds + teams[t].rushYds; teams[t].turnovers = teams[t].fumLost + teams[t].ints; }); return teams;
+  const init = () => ({
+    firstDowns: 0,
+    thirdAtt: 0,
+    thirdConv: 0,
+    fourthAtt: 0,
+    fourthConv: 0,
+    passYds: 0,
+    rushYds: 0,
+    passAtt: 0,
+    passComp: 0,
+    ints: 0,
+    sacks: 0,
+    sackYds: 0,
+    rushAtt: 0,
+    fumLost: 0,
+    possTime: 0,
+    totalYds: 0,
+    turnovers: 0,
+  });
+  const teams = { Home: init(), Away: init() };
+  const quarterLen = 15 * 60;
+  let prev = {
+    Possession: str((game as unknown as Play).StartingPossession || "Home"),
+    Time: quarterLen,
+    Qtr: 1,
+  };
+  history.forEach((play) => {
+    const team = str(playField(play, "Possession", "possession")) as
+      "Home" | "Away";
+    if (!teams[team]) return;
+    const yards = num(playField(play, "Yards", "yards"));
+    const down = num(playField(play, "Down", "down"));
+    const distance = num(playField(play, "Distance", "distance"));
+    const result = str(playField(play, "Result", "result"));
+    const type = str(playField(play, "PlayType", "playtype"));
+    const currTime = parseTimeSeconds(playField(play, "Time", "time"));
+    const currQtr = num(playField(play, "Qtr", "QTR", "quarter")) || prev.Qtr;
+    const diff =
+      currQtr === prev.Qtr
+        ? prev.Time - currTime
+        : prev.Time +
+          quarterLen * (currQtr - prev.Qtr - 1) +
+          (quarterLen - currTime);
+    if (teams[prev.Possession as "Home" | "Away"])
+      teams[prev.Possession as "Home" | "Away"].possTime += Math.max(0, diff);
+    prev = { Possession: team, Time: currTime, Qtr: currQtr };
+    if (type === "Pass") {
+      if (
+        result === "Sack" ||
+        str(playField(play, "Description", "description")) === "Sack"
+      ) {
+        teams[team].sacks++;
+        teams[team].sackYds += yards;
+        teams[team].passYds += yards;
+      } else {
+        teams[team].passAtt++;
+        if (!["Incomplete", "Incompletion", "Interception"].includes(result)) {
+          teams[team].passComp++;
+          teams[team].passYds += yards;
+        }
+        if (result === "Interception") teams[team].ints++;
+        if (
+          result === "Fumble" &&
+          playField(play, "RecoveredBy", "recoveredby") &&
+          playField(play, "RecoveredBy", "recoveredby") !==
+            (playField(play, "Receiver", "Target", "receiver") ||
+              playField(play, "Player", "player"))
+        )
+          teams[team].fumLost++;
+      }
+    } else if (type === "Run") {
+      teams[team].rushAtt++;
+      teams[team].rushYds += yards;
+      if (
+        result === "Fumble" &&
+        playField(play, "RecoveredBy", "recoveredby") &&
+        playField(play, "RecoveredBy", "recoveredby") !==
+          playField(play, "Player", "player")
+      )
+        teams[team].fumLost++;
+    }
+    if (type === "Run" || type === "Pass") {
+      const converted = yards >= distance || result === "Touchdown";
+      if (down === 3) {
+        teams[team].thirdAtt++;
+        if (converted) teams[team].thirdConv++;
+      } else if (down === 4) {
+        teams[team].fourthAtt++;
+        if (converted) teams[team].fourthConv++;
+      }
+      if (converted) teams[team].firstDowns++;
+    }
+  });
+  (["Home", "Away"] as const).forEach((t) => {
+    teams[t].totalYds = teams[t].passYds + teams[t].rushYds;
+    teams[t].turnovers = teams[t].fumLost + teams[t].ints;
+  });
+  return teams;
 }
-function TeamStatsTab({ game, history }: { game: LeagueGame; history: Play[] }) {
-  const stats = useMemo(() => computeTeamStats(history, game), [history, game]); const row = (label: string, h: string | number, a: string | number, cls: string, indent = "") => <tr className={`${cls} ${indent}`} key={label}><td>{label}</td><td>{h}</td><td>{a}</td></tr>; const rows = [{ label: "1st Downs", key: "firstDowns", cls: "header-row" }, { label: "3rd down efficiency", fmt: (t: typeof stats.Home) => `${t.thirdConv}-${t.thirdAtt}`, cls: "stat-row", indent: "indent-1" }, { label: "4th down efficiency", fmt: (t: typeof stats.Home) => `${t.fourthConv}-${t.fourthAtt}`, cls: "stat-row", indent: "indent-1" }, { label: "Total Yards", key: "totalYds", cls: "header-row" }, { label: "Passing", key: "passYds", cls: "header2-row", indent: "indent-1" }, { label: "Comp/Att", fmt: (t: typeof stats.Home) => `${t.passComp}/${t.passAtt}`, cls: "stat-row", indent: "indent-2" }, { label: "Yards per pass", fmt: (t: typeof stats.Home) => avg(t.passYds, t.passAtt), cls: "stat-row", indent: "indent-2" }, { label: "Interceptions thrown", key: "ints", cls: "stat-row", indent: "indent-2" }, { label: "Rushing", key: "rushYds", cls: "header2-row", indent: "indent-1" }, { label: "Rushing Attempts", key: "rushAtt", cls: "stat-row", indent: "indent-2" }, { label: "Yards per rush", fmt: (t: typeof stats.Home) => avg(t.rushYds, t.rushAtt), cls: "stat-row", indent: "indent-2" }, { label: "Sacks", fmt: (t: typeof stats.Home) => `${t.sacks}-${Math.abs(t.sackYds)}`, cls: "header2-row", indent: "indent-1" }, { label: "Turnovers", key: "turnovers", cls: "header-row" }, { label: "Fumbles lost", key: "fumLost", cls: "stat-row", indent: "indent-1" }, { label: "Interceptions thrown", key: "ints", cls: "stat-row", indent: "indent-1" }, { label: "Possession", fmt: (t: typeof stats.Home) => formatClock(t.possTime), cls: "header-row" }]; return <div className="play-log-card team-stats-card"><div className="team-stats-title">TEAM STATS</div><table className="stats-table team-stats-table"><thead><tr><th /><th><TeamLogo className="team-stats-logo" src={game.HomeLogo} alt={game.Home} /></th><th><TeamLogo className="team-stats-logo" src={game.AwayLogo} alt={game.Away} /></th></tr></thead><tbody>{rows.map((r) => row(r.label, r.key ? stats.Home[r.key as keyof typeof stats.Home] : r.fmt!(stats.Home), r.key ? stats.Away[r.key as keyof typeof stats.Away] : r.fmt!(stats.Away), r.cls, r.indent))}</tbody></table></div>;
+function TeamStatsTab({
+  game,
+  history,
+}: {
+  game: LeagueGame;
+  history: Play[];
+}) {
+  const stats = useMemo(() => computeTeamStats(history, game), [history, game]);
+  const row = (
+    label: string,
+    h: string | number,
+    a: string | number,
+    cls: string,
+    indent = "",
+  ) => (
+    <tr className={`${cls} ${indent}`} key={label}>
+      <td>{label}</td>
+      <td>{h}</td>
+      <td>{a}</td>
+    </tr>
+  );
+  const rows = [
+    { label: "1st Downs", key: "firstDowns", cls: "header-row" },
+    {
+      label: "3rd down efficiency",
+      fmt: (t: typeof stats.Home) => `${t.thirdConv}-${t.thirdAtt}`,
+      cls: "stat-row",
+      indent: "indent-1",
+    },
+    {
+      label: "4th down efficiency",
+      fmt: (t: typeof stats.Home) => `${t.fourthConv}-${t.fourthAtt}`,
+      cls: "stat-row",
+      indent: "indent-1",
+    },
+    { label: "Total Yards", key: "totalYds", cls: "header-row" },
+    {
+      label: "Passing",
+      key: "passYds",
+      cls: "header2-row",
+      indent: "indent-1",
+    },
+    {
+      label: "Comp/Att",
+      fmt: (t: typeof stats.Home) => `${t.passComp}/${t.passAtt}`,
+      cls: "stat-row",
+      indent: "indent-2",
+    },
+    {
+      label: "Yards per pass",
+      fmt: (t: typeof stats.Home) => avg(t.passYds, t.passAtt),
+      cls: "stat-row",
+      indent: "indent-2",
+    },
+    {
+      label: "Interceptions thrown",
+      key: "ints",
+      cls: "stat-row",
+      indent: "indent-2",
+    },
+    {
+      label: "Rushing",
+      key: "rushYds",
+      cls: "header2-row",
+      indent: "indent-1",
+    },
+    {
+      label: "Rushing Attempts",
+      key: "rushAtt",
+      cls: "stat-row",
+      indent: "indent-2",
+    },
+    {
+      label: "Yards per rush",
+      fmt: (t: typeof stats.Home) => avg(t.rushYds, t.rushAtt),
+      cls: "stat-row",
+      indent: "indent-2",
+    },
+    {
+      label: "Sacks",
+      fmt: (t: typeof stats.Home) => `${t.sacks}-${Math.abs(t.sackYds)}`,
+      cls: "header2-row",
+      indent: "indent-1",
+    },
+    { label: "Turnovers", key: "turnovers", cls: "header-row" },
+    {
+      label: "Fumbles lost",
+      key: "fumLost",
+      cls: "stat-row",
+      indent: "indent-1",
+    },
+    {
+      label: "Interceptions thrown",
+      key: "ints",
+      cls: "stat-row",
+      indent: "indent-1",
+    },
+    {
+      label: "Possession",
+      fmt: (t: typeof stats.Home) => formatClock(t.possTime),
+      cls: "header-row",
+    },
+  ];
+  return (
+    <div className="play-log-card team-stats-card">
+      <div className="team-stats-title">TEAM STATS</div>
+      <table className="stats-table team-stats-table">
+        <thead>
+          <tr>
+            <th />
+            <th>
+              <TeamLogo
+                className="team-stats-logo"
+                src={game.HomeLogo}
+                alt={game.Home}
+              />
+            </th>
+            <th>
+              <TeamLogo
+                className="team-stats-logo"
+                src={game.AwayLogo}
+                alt={game.Away}
+              />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) =>
+            row(
+              r.label,
+              r.key
+                ? stats.Home[r.key as keyof typeof stats.Home]
+                : r.fmt!(stats.Home),
+              r.key
+                ? stats.Away[r.key as keyof typeof stats.Away]
+                : r.fmt!(stats.Away),
+              r.cls,
+              r.indent,
+            ),
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
 }
-function LeaderCard({ game, history, players, setTab }: { game: LeagueGame; history: Play[]; players: Play[]; setTab: (t: GameTab) => void }) {
-  const stats = useMemo(() => calcStats(history), [history]); const trait = (name: string) => players.find((p) => str(p.name ?? p.Name) === name);
-  const leader = (arr: Stat[], team: string, field: keyof Stat) => arr.filter((s) => s.team === team).sort((a, b) => num(b[field]) - num(a[field]))[0];
-  const img = (s?: Stat) => { const src = s ? str(trait(s.playername)?.image ?? trait(s.playername)?.Image) : ""; return <div className="player-placeholder">{src ? <img src={src} alt="" /> : <span>👤</span>}</div>; };
-  const section = (label: string, arr: Stat[], field: keyof Stat, line?: (s: Stat) => string) => { const h = leader(arr, "Home", field), a = leader(arr, "Away", field); return <><div className="leader-row values"><div className="leader-left">{img(h)}<span className="leader-value">{h ? num(h[field]) : "--"}</span></div><div /><div className="leader-right"><span className="leader-value">{a ? num(a[field]) : "--"}</span>{img(a)}</div></div><div className="leader-row names"><div className="leader-left">{h?.playername} <span className="leader-pos">{str(trait(h?.playername || "")?.position)}</span></div><div className="leader-center leader-label">{label}</div><div className="leader-right">{a?.playername} <span className="leader-pos">{str(trait(a?.playername || "")?.position)}</span></div></div>{line && <div className="leader-row statlines"><div className="leader-left">{h && line(h)}</div><div /><div className="leader-right">{a && line(a)}</div></div>}<div className="leader-divider" /></>; };
-  return <div className="leaders-card"><div className="leaders-header">GAME LEADERS</div><div className="leaders-team-row"><div className="team"><TeamLogo src={game.HomeLogo} className="team-logo-small" /><span>{game.Home}</span></div><div className="team away"><span>{game.Away}</span><TeamLogo src={game.AwayLogo} className="team-logo-small" /></div></div><div className="leader-divider" />{section("Passing Yards", stats.pass, "yards", (p) => `${p.completions || 0}/${p.attempts || 0}, ${p.yards} YDS, ${p.tds || 0} TD, ${p.ints || 0} INT`)}{section("Rushing Yards", stats.rush, "yards", (p) => `${p.carries || 0} CAR, ${p.yards} YDS, ${p.tds || 0} TD`)}{section("Receiving Yards", stats.recs, "yards", (p) => `${p.receptions || 0} REC, ${p.yards} YDS, ${p.tds || 0} TD`)}{section("Sacks", stats.def, "sacks")}{section("Tackles", stats.def, "tackles")}<button className="boxscore-link" onClick={() => setTab("boxscore")}>Full Box Score</button></div>;
+function LeaderCard({
+  game,
+  history,
+  players,
+  setTab,
+}: {
+  game: LeagueGame;
+  history: Play[];
+  players: Play[];
+  setTab: (t: GameTab) => void;
+}) {
+  const stats = useMemo(() => calcStats(history), [history]);
+  const trait = (name: string) =>
+    players.find((p) => str(p.name ?? p.Name) === name);
+  const leader = (arr: Stat[], team: string, field: keyof Stat) =>
+    arr
+      .filter((s) => s.team === team)
+      .sort((a, b) => num(b[field]) - num(a[field]))[0];
+  const img = (s?: Stat) => {
+    const src = s
+      ? str(trait(s.playername)?.image ?? trait(s.playername)?.Image)
+      : "";
+    return (
+      <div className="player-placeholder">
+        {src ? <img src={src} alt="" /> : <span>👤</span>}
+      </div>
+    );
+  };
+  const section = (
+    label: string,
+    arr: Stat[],
+    field: keyof Stat,
+    line?: (s: Stat) => string,
+  ) => {
+    const h = leader(arr, "Home", field),
+      a = leader(arr, "Away", field);
+    return (
+      <>
+        <div className="leader-row values">
+          <div className="leader-left">
+            {img(h)}
+            <span className="leader-value">{h ? num(h[field]) : "--"}</span>
+          </div>
+          <div />
+          <div className="leader-right">
+            <span className="leader-value">{a ? num(a[field]) : "--"}</span>
+            {img(a)}
+          </div>
+        </div>
+        <div className="leader-row names">
+          <div className="leader-left">
+            {h?.playername}{" "}
+            <span className="leader-pos">
+              {str(trait(h?.playername || "")?.position)}
+            </span>
+          </div>
+          <div className="leader-center leader-label">{label}</div>
+          <div className="leader-right">
+            {a?.playername}{" "}
+            <span className="leader-pos">
+              {str(trait(a?.playername || "")?.position)}
+            </span>
+          </div>
+        </div>
+        {line && (
+          <div className="leader-row statlines">
+            <div className="leader-left">{h && line(h)}</div>
+            <div />
+            <div className="leader-right">{a && line(a)}</div>
+          </div>
+        )}
+        <div className="leader-divider" />
+      </>
+    );
+  };
+  return (
+    <div className="leaders-card">
+      <div className="leaders-header">GAME LEADERS</div>
+      <div className="leaders-team-row">
+        <div className="team">
+          <TeamLogo src={game.HomeLogo} className="team-logo-small" />
+          <span>{game.Home}</span>
+        </div>
+        <div className="team away">
+          <span>{game.Away}</span>
+          <TeamLogo src={game.AwayLogo} className="team-logo-small" />
+        </div>
+      </div>
+      <div className="leader-divider" />
+      {section(
+        "Passing Yards",
+        stats.pass,
+        "yards",
+        (p) =>
+          `${p.completions || 0}/${p.attempts || 0}, ${p.yards} YDS, ${p.tds || 0} TD, ${p.ints || 0} INT`,
+      )}
+      {section(
+        "Rushing Yards",
+        stats.rush,
+        "yards",
+        (p) => `${p.carries || 0} CAR, ${p.yards} YDS, ${p.tds || 0} TD`,
+      )}
+      {section(
+        "Receiving Yards",
+        stats.recs,
+        "yards",
+        (p) => `${p.receptions || 0} REC, ${p.yards} YDS, ${p.tds || 0} TD`,
+      )}
+      {section("Sacks", stats.def, "sacks")}
+      {section("Tackles", stats.def, "tackles")}
+      <button className="boxscore-link" onClick={() => setTab("boxscore")}>
+        Full Box Score
+      </button>
+    </div>
+  );
 }
-function ScoreChart({ game, history }: { game: LeagueGame; history: Play[] }) { const { home, away } = scoreByQuarter(history, game); return <div className="score-chart"><table><thead><tr><th></th><th>1</th><th>2</th><th>3</th><th>4</th><th>T</th></tr></thead><tbody><tr><td className="team-cell"><TeamLogo src={game.HomeLogo} className="team-logo-small" /><span>{game.Home}</span></td>{home.map((s, i) => <td key={i}>{s}</td>)}<td className="total-cell">{game.HomeScore}</td></tr><tr><td className="team-cell"><TeamLogo src={game.AwayLogo} className="team-logo-small" /><span>{game.Away}</span></td>{away.map((s, i) => <td key={i}>{s}</td>)}<td className="total-cell">{game.AwayScore}</td></tr></tbody></table></div>; }
-export function GameCenter({ game, onBack }: { game: LeagueGame; onBack: () => void }) {
-  const [tab, setTab] = useState<GameTab>("gamecast"); const [currentGame, setCurrentGame] = useState(game); const [history, setHistory] = useState<Play[]>([]); const [players, setPlayers] = useState<Play[]>([]); const [settings, setSettings] = useState<FrontendSettings>(normalizeFrontendSettings({})); const [playOptions, setPlayOptions] = useState<PlayCallOptions>({ clockMode: "Normal", formation: {}, routes: {}, reads: {} }); const [log, setLog] = useState(["Loading game state, play history, players, and frontend settings..."]); const [isSavingPlay, setIsSavingPlay] = useState(false); const ctx = useMemo(() => ({ players, settings, historyLength: history.length }), [players, settings, history.length]);
-  useEffect(() => { let active = true; Promise.all([getGameState(game.GameId), getPlayHistory(game.GameId), getPlayerTraits(), getFrontendSettings()]).then(([stateRes, historyRes, playerRes, settingsRes]) => { if (!active) return; setCurrentGame(normalizeGame(game, stateRes.gameState)); setHistory(historyRes.plays); setPlayers(playerRes.players); setSettings(normalizeFrontendSettings(settingsRes)); setLog(historyRes.plays.length ? historyRes.plays.slice(-20).reverse().map((play) => playText(play)) : ["Game loaded. No prior play history found."]); }).catch((error: unknown) => setLog((l) => [`Failed to load live game data: ${error instanceof Error ? error.message : String(error)}`, ...l])); return () => { active = false; }; }, [game]);
-  const persist = async (result: ReturnType<typeof runPlay>) => { const previousGame = currentGame; const previousBallOn = currentGame.BallOn; setIsSavingPlay(true); setCurrentGame(result.game); setHistory((h) => [...h, result.play]); setLog((l) => [result.text, ...l]); const gamePayload = { gameId: result.game.GameId, quarter: result.game.Qtr, time: result.game.Time, down: result.game.Down, distance: result.game.Distance, ballOn: result.game.BallOn, homeScore: result.game.HomeScore, awayScore: result.game.AwayScore, driveStart: (result.game as unknown as Record<string, unknown>).DriveStart, previous: currentGame.BallOn, possession: result.game.Possession, homeTimeouts: (result.game as unknown as Record<string, unknown>).HomeTimeouts, awayTimeouts: (result.game as unknown as Record<string, unknown>).AwayTimeouts }; try { await savePlayAndGame(result.game.GameId, { play: result.play, game: gamePayload }); if (result.play.playtype === "Run") { void animatePlay("Run", null, { ...result.game, Previous: previousBallOn }).catch((error: unknown) => { setLog((l) => [`Play animation skipped: ${error instanceof Error ? error.message : String(error)}`, ...l]); }); } } catch (error) { setCurrentGame(previousGame); setHistory((h) => h.filter((play) => play !== result.play)); setLog((l) => [`Save failed and optimistic play was rolled back: ${error instanceof Error ? error.message : String(error)}`, ...l.filter((entry) => entry !== result.text)]); } finally { setIsSavingPlay(false); } };
-  const action = (label: string, options: PlayCallOptions = playOptions) => { if (isSavingPlay) { setLog((l) => ["Play save in progress; wait for it to finish before snapping again.", ...l]); return; } if (label === "Run Play") void persist(runPlay(currentGame, ctx, options)); else if (label === "Pass Play") void persist(passPlay(currentGame, ctx, options)); else if (label === "Field Goal") void persist(kickFG(currentGame, ctx)); else if (label === "Punt") void persist(punt(currentGame, ctx)); else if (label === "Two Point") void persist(goForTwo(currentGame, ctx)); else if (label === "Timeout") void persist(handleTimeout(currentGame, ctx)); else if (label === "Spike") void persist(spikeBall(currentGame, ctx)); else if (label === "Kneel") void persist(kneel(currentGame, ctx, options)); };
-  const drivePlays = history.filter((p) => str(playField(p, "Possession", "possession")) === currentGame.Possession).length; const driveYards = currentGame.Possession === "Home" ? num(currentGame.BallOn) - num((currentGame as unknown as Play).DriveStart) : num((currentGame as unknown as Play).DriveStart) - num(currentGame.BallOn); const lastPlay = history.length ? playText(history[history.length - 1]) : "";
-  return <div id="gameUI"><button className="back-button league-back-button" type="button" onClick={onBack}>← Back</button><GameScoreboard game={currentGame} /><div className="spectate-control"><label className="spectate-switch"><input type="checkbox" onChange={(e) => setLog((l) => [`Spectate ${e.target.checked ? "ON" : "OFF"}`, ...l])} /><span className="spectate-slider" /></label><div className="spectate-meta"><div className="spectate-label">Spectate</div><div className="spectate-status">OFF</div></div></div><div className="tabs">{(["gamecast", "playbyplay", "boxscore", "teamstats"] as GameTab[]).map((t) => <button key={t} className={`tab-button ${tab === t ? "active" : ""}`} type="button" onClick={() => setTab(t)}>{t === "gamecast" ? "Gamecast" : t === "playbyplay" ? "Play-by-Play" : t === "boxscore" ? "Box Score" : "Team Stats"}</button>)}</div>{tab === "gamecast" && <div className="tab-content active"><div className="game-info"><div className="info-block"><div className="info-label">DOWN:</div><div className="info-value">{formatDownDistance(currentGame.Down, currentGame.Distance)}</div></div><div className="info-block"><div className="info-label">BALL ON:</div><div className="info-value">{formatBallOnForPoss(currentGame.BallOn, currentGame.Possession)}</div></div><div className="info-block"><div className="info-label">DRIVE:</div><div className="info-value">{drivePlays} plays, {driveYards} yards</div></div></div>
-  <GameField  />
-{lastPlay && <div className="last-play-desc"><strong>Last Play:</strong> {lastPlay}</div>}<GameControls game={currentGame} players={players} options={playOptions} onOptionsChange={setPlayOptions} onAction={action} /><ScoreChart game={currentGame} history={history} /><LeaderCard game={currentGame} history={history} players={players} setTab={setTab} /><GameLog messages={log} /></div>}{tab === "playbyplay" && <div className="tab-content active"><PlayByPlayTab game={currentGame} history={history} /></div>}{tab === "boxscore" && <div className="tab-content active"><BoxScoreTab game={currentGame} history={history} /></div>}{tab === "teamstats" && <div className="tab-content active"><TeamStatsTab game={currentGame} history={history} /></div>}</div>;
+function ScoreChart({ game, history }: { game: LeagueGame; history: Play[] }) {
+  const { home, away } = scoreByQuarter(history, game);
+  return (
+    <div className="score-chart">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>1</th>
+            <th>2</th>
+            <th>3</th>
+            <th>4</th>
+            <th>T</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="team-cell">
+              <TeamLogo src={game.HomeLogo} className="team-logo-small" />
+              <span>{game.Home}</span>
+            </td>
+            {home.map((s, i) => (
+              <td key={i}>{s}</td>
+            ))}
+            <td className="total-cell">{game.HomeScore}</td>
+          </tr>
+          <tr>
+            <td className="team-cell">
+              <TeamLogo src={game.AwayLogo} className="team-logo-small" />
+              <span>{game.Away}</span>
+            </td>
+            {away.map((s, i) => (
+              <td key={i}>{s}</td>
+            ))}
+            <td className="total-cell">{game.AwayScore}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+export function GameCenter({
+  game,
+  onBack,
+}: {
+  game: LeagueGame;
+  onBack: () => void;
+}) {
+  const [tab, setTab] = useState<GameTab>("gamecast");
+  const [currentGame, setCurrentGame] = useState(game);
+  const [history, setHistory] = useState<Play[]>([]);
+  const [players, setPlayers] = useState<Play[]>([]);
+  const [settings, setSettings] = useState<FrontendSettings>(
+    normalizeFrontendSettings({}),
+  );
+  const [playOptions, setPlayOptions] = useState<PlayCallOptions>({
+    clockMode: "Normal",
+    formation: {},
+    routes: {},
+    reads: {},
+  });
+  const [log, setLog] = useState([
+    "Loading game state, play history, players, and frontend settings...",
+  ]);
+  const [isSavingPlay, setIsSavingPlay] = useState(false);
+  const ctx = useMemo(
+    () => ({ players, settings, historyLength: history.length }),
+    [players, settings, history.length],
+  );
+  useEffect(() => {
+    let active = true;
+    Promise.all([
+      getGameState(game.GameId),
+      getPlayHistory(game.GameId),
+      getPlayerTraits(),
+      getFrontendSettings(),
+    ])
+      .then(([stateRes, historyRes, playerRes, settingsRes]) => {
+        if (!active) return;
+        setCurrentGame(normalizeGame(game, stateRes.gameState));
+        setHistory(historyRes.plays);
+        setPlayers(playerRes.players);
+        setSettings(normalizeFrontendSettings(settingsRes));
+        setLog(
+          historyRes.plays.length
+            ? historyRes.plays
+                .slice(-20)
+                .reverse()
+                .map((play) => playText(play))
+            : ["Game loaded. No prior play history found."],
+        );
+      })
+      .catch((error: unknown) =>
+        setLog((l) => [
+          `Failed to load live game data: ${error instanceof Error ? error.message : String(error)}`,
+          ...l,
+        ]),
+      );
+    return () => {
+      active = false;
+    };
+  }, [game]);
+  const persist = async (result: ReturnType<typeof runPlay>) => {
+    const previousGame = currentGame;
+    const previousBallOn = currentGame.BallOn;
+    setIsSavingPlay(true);
+    setCurrentGame(result.game);
+    setHistory((h) => [...h, result.play]);
+    setLog((l) => [result.text, ...l]);
+    const gamePayload = {
+      gameId: result.game.GameId,
+      quarter: result.game.Qtr,
+      time: result.game.Time,
+      down: result.game.Down,
+      distance: result.game.Distance,
+      ballOn: result.game.BallOn,
+      homeScore: result.game.HomeScore,
+      awayScore: result.game.AwayScore,
+      driveStart: (result.game as unknown as Record<string, unknown>)
+        .DriveStart,
+      previous: currentGame.BallOn,
+      possession: result.game.Possession,
+      homeTimeouts: (result.game as unknown as Record<string, unknown>)
+        .HomeTimeouts,
+      awayTimeouts: (result.game as unknown as Record<string, unknown>)
+        .AwayTimeouts,
+    };
+    try {
+      await savePlayAndGame(result.game.GameId, {
+        play: result.play,
+        game: gamePayload,
+      });
+      if (result.play.playtype === "Run") {
+        void animatePlay("Run", null, {
+          ...result.game,
+          Previous: previousBallOn,
+        }).catch((error: unknown) => {
+          setLog((l) => [
+            `Play animation skipped: ${error instanceof Error ? error.message : String(error)}`,
+            ...l,
+          ]);
+        });
+      }
+    } catch (error) {
+      setCurrentGame(previousGame);
+      setHistory((h) => h.filter((play) => play !== result.play));
+      setLog((l) => [
+        `Save failed and optimistic play was rolled back: ${error instanceof Error ? error.message : String(error)}`,
+        ...l.filter((entry) => entry !== result.text),
+      ]);
+    } finally {
+      setIsSavingPlay(false);
+    }
+  };
+  const action = (label: string, options: PlayCallOptions = playOptions) => {
+    if (isSavingPlay) {
+      setLog((l) => [
+        "Play save in progress; wait for it to finish before snapping again.",
+        ...l,
+      ]);
+      return;
+    }
+    if (label === "Run Play") void persist(runPlay(currentGame, ctx, options));
+    else if (label === "Pass Play")
+      void persist(passPlay(currentGame, ctx, options));
+    else if (label === "Field Goal") void persist(kickFG(currentGame, ctx));
+    else if (label === "Punt") void persist(punt(currentGame, ctx));
+    else if (label === "Two Point") void persist(goForTwo(currentGame, ctx));
+    else if (label === "Timeout") void persist(handleTimeout(currentGame, ctx));
+    else if (label === "Spike") void persist(spikeBall(currentGame, ctx));
+    else if (label === "Kneel") void persist(kneel(currentGame, ctx, options));
+  };
+  const drivePlays = history.filter(
+    (p) =>
+      str(playField(p, "Possession", "possession")) === currentGame.Possession,
+  ).length;
+  const driveYards =
+    currentGame.Possession === "Home"
+      ? num(currentGame.BallOn) -
+        num((currentGame as unknown as Play).DriveStart)
+      : num((currentGame as unknown as Play).DriveStart) -
+        num(currentGame.BallOn);
+  const lastPlay = history.length ? playText(history[history.length - 1]) : "";
+  return (
+    <div id="gameUI">
+      <button
+        className="back-button league-back-button"
+        type="button"
+        onClick={onBack}
+      >
+        ← Back
+      </button>
+      <GameScoreboard game={currentGame} />
+      <div className="spectate-control">
+        <label className="spectate-switch">
+          <input
+            type="checkbox"
+            onChange={(e) =>
+              setLog((l) => [
+                `Spectate ${e.target.checked ? "ON" : "OFF"}`,
+                ...l,
+              ])
+            }
+          />
+          <span className="spectate-slider" />
+        </label>
+        <div className="spectate-meta">
+          <div className="spectate-label">Spectate</div>
+          <div className="spectate-status">OFF</div>
+        </div>
+      </div>
+      <div className="tabs">
+        {(["gamecast", "playbyplay", "boxscore", "teamstats"] as GameTab[]).map(
+          (t) => (
+            <button
+              key={t}
+              className={`tab-button ${tab === t ? "active" : ""}`}
+              type="button"
+              onClick={() => setTab(t)}
+            >
+              {t === "gamecast"
+                ? "Gamecast"
+                : t === "playbyplay"
+                  ? "Play-by-Play"
+                  : t === "boxscore"
+                    ? "Box Score"
+                    : "Team Stats"}
+            </button>
+          ),
+        )}
+      </div>
+      {tab === "gamecast" && (
+        <div className="tab-content active">
+          <div className="game-info">
+            <div className="info-block">
+              <div className="info-label">DOWN:</div>
+              <div className="info-value">
+                {formatDownDistance(currentGame.Down, currentGame.Distance)}
+              </div>
+            </div>
+            <div className="info-block">
+              <div className="info-label">BALL ON:</div>
+              <div className="info-value">
+                {formatBallOnForPoss(
+                  currentGame.BallOn,
+                  currentGame.Possession,
+                )}
+              </div>
+            </div>
+            <div className="info-block">
+              <div className="info-label">DRIVE:</div>
+              <div className="info-value">
+                {drivePlays} plays, {driveYards} yards
+              </div>
+            </div>
+          </div>
+          <GameField />
+          {lastPlay && (
+            <div className="last-play-desc">
+              <strong>Last Play:</strong> {lastPlay}
+            </div>
+          )}
+          <GameControls
+            game={currentGame}
+            players={players}
+            options={playOptions}
+            onOptionsChange={setPlayOptions}
+            onAction={action}
+          />
+          <ScoreChart game={currentGame} history={history} />
+          <LeaderCard
+            game={currentGame}
+            history={history}
+            players={players}
+            setTab={setTab}
+          />
+          <GameLog messages={log} />
+        </div>
+      )}
+      {tab === "playbyplay" && (
+        <div className="tab-content active">
+          <PlayByPlayTab game={currentGame} history={history} />
+        </div>
+      )}
+      {tab === "boxscore" && (
+        <div className="tab-content active">
+          <BoxScoreTab game={currentGame} history={history} />
+        </div>
+      )}
+      {tab === "teamstats" && (
+        <div className="tab-content active">
+          <TeamStatsTab game={currentGame} history={history} />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -1,71 +1,278 @@
 import { useMemo, useState } from "react";
 import type { LeagueGame } from "./types";
-import type { PlayCallOptions, FormationSlot, DefensiveAssignment } from "./gameplay/gameEngine";
+import type {
+  PlayCallOptions,
+  FormationSlot,
+  DefensiveAssignment,
+} from "./gameplay/gameEngine";
 
 const str = (v: unknown) => String(v ?? "");
-const LINE_SLOTS: FormationSlot[] = ["WR1", "TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5", "WR2", "WR3"];
+const LINE_SLOTS: FormationSlot[] = [
+  "WR1",
+  "TEOL1",
+  "TEOL2",
+  "TEOL3",
+  "TEOL4",
+  "TEOL5",
+  "WR2",
+  "WR3",
+];
 const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3"];
 const RB_SLOTS: FormationSlot[] = ["RB1", "RB2"];
-const TEOL_SLOTS: FormationSlot[] = ["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"];
+const TEOL_SLOTS: FormationSlot[] = [
+  "TEOL1",
+  "TEOL2",
+  "TEOL3",
+  "TEOL4",
+  "TEOL5",
+];
 const REQUIRED = new Set<FormationSlot>(["QB", "TEOL2", "TEOL3", "TEOL4"]);
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
 
 type Player = Record<string, unknown>;
-type Props = { game: LeagueGame; players: Player[]; options: PlayCallOptions; onOptionsChange: (next: PlayCallOptions) => void; onAction: (label: string, options?: PlayCallOptions) => void; };
+type Props = {
+  game: LeagueGame;
+  players: Player[];
+  options: PlayCallOptions;
+  onOptionsChange: (next: PlayCallOptions) => void;
+  onAction: (label: string, options?: PlayCallOptions) => void;
+};
 
-function nameOf(p: Player) { return str(p.name ?? p.Name); }
-function posOf(p: Player) { return str(p.position ?? p.Pos).toUpperCase(); }
-function teamOf(p: Player) { return str(p.team ?? p.Team); }
-function imgOf(p?: Player) { return str(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo); }
-function trait(p: Player | undefined, key: string) { return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0); }
-function ControlModal({ children, onClose, wide = false, full = false }: { children: React.ReactNode; onClose: () => void; wide?: boolean; full?: boolean }) { return <div className="game-modal open"><div className={`game-modal-panel formation-panel ${wide ? "routes-panel" : ""} ${full ? "formation-full-panel" : ""}`}><button className="close-button" onClick={onClose} type="button">×</button>{children}</div></div>; }
+function nameOf(p: Player) {
+  return str(p.name ?? p.Name);
+}
+function posOf(p: Player) {
+  return str(p.position ?? p.Pos).toUpperCase();
+}
+function teamOf(p: Player) {
+  return str(p.team ?? p.Team);
+}
+function imgOf(p?: Player) {
+  return str(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo);
+}
+function trait(p: Player | undefined, key: string) {
+  return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0);
+}
+function ControlModal({
+  children,
+  onClose,
+  wide = false,
+  full = false,
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+  wide?: boolean;
+  full?: boolean;
+}) {
+  return (
+    <div className="game-modal open">
+      <div
+        className={`game-modal-panel formation-panel ${wide ? "routes-panel" : ""} ${full ? "formation-full-panel" : ""}`}
+      >
+        <button className="close-button" onClick={onClose} type="button">
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}
 function eligibleReceivers(formation: Partial<Record<FormationSlot, string>>) {
   const occupiedTeols = TEOL_SLOTS.filter((slot) => formation[slot]);
-  const exposedTeols = occupiedTeols.length > 1 ? [occupiedTeols[0], occupiedTeols[occupiedTeols.length - 1]] : occupiedTeols;
+  const exposedTeols =
+    occupiedTeols.length > 1
+      ? [occupiedTeols[0], occupiedTeols[occupiedTeols.length - 1]]
+      : occupiedTeols;
   const eligibleSlots = [...WR_SLOTS, ...RB_SLOTS, ...exposedTeols];
   return eligibleSlots
     .map((slot) => ({ slot, player: formation[slot] }))
-    .filter((x): x is { slot: FormationSlot; player: string } => Boolean(x.player));
+    .filter((x): x is { slot: FormationSlot; player: string } =>
+      Boolean(x.player),
+    );
 }
-function PlayerBubble({ name, player, small = false }: { name?: string; player?: Player; small?: boolean }) { const src = imgOf(player); return <div className={`${small ? "los-player" : "player-circle-static"} ${name ? "" : "empty"}`}>{name && (src ? <img src={src} alt={name} /> : <span>👤</span>)}</div>; }
-function normalizeReads(nextRoutes: Record<string, string>, orderedPlayers: string[], preferred?: { player: string; readIndex: number }) { const used = new Set<string>(); const nextReads: Record<string, string> = {}; if (preferred && nextRoutes[preferred.player] && nextRoutes[preferred.player] !== "No Route") { nextReads[preferred.player] = READS[Math.min(preferred.readIndex, READS.length - 1)] || ""; used.add(nextReads[preferred.player]); } orderedPlayers.filter((player) => nextRoutes[player] && nextRoutes[player] !== "No Route" && player !== preferred?.player).forEach((player) => { const read = READS.find((r) => !used.has(r)); if (read) { nextReads[player] = read; used.add(read); } }); return nextReads; }
+function PlayerBubble({
+  name,
+  player,
+  small = false,
+}: {
+  name?: string;
+  player?: Player;
+  small?: boolean;
+}) {
+  const src = imgOf(player);
+  return (
+    <div
+      className={`${small ? "los-player" : "player-circle-static"} ${name ? "" : "empty"}`}
+    >
+      {name && (src ? <img src={src} alt={name} /> : <span>👤</span>)}
+    </div>
+  );
+}
+function normalizeReads(
+  nextRoutes: Record<string, string>,
+  orderedPlayers: string[],
+  preferred?: { player: string; readIndex: number },
+) {
+  const used = new Set<string>();
+  const nextReads: Record<string, string> = {};
+  if (
+    preferred &&
+    nextRoutes[preferred.player] &&
+    nextRoutes[preferred.player] !== "No Route"
+  ) {
+    nextReads[preferred.player] =
+      READS[Math.min(preferred.readIndex, READS.length - 1)] || "";
+    used.add(nextReads[preferred.player]);
+  }
+  orderedPlayers
+    .filter(
+      (player) =>
+        nextRoutes[player] &&
+        nextRoutes[player] !== "No Route" &&
+        player !== preferred?.player,
+    )
+    .forEach((player) => {
+      const read = READS.find((r) => !used.has(r));
+      if (read) {
+        nextReads[player] = read;
+        used.add(read);
+      }
+    });
+  return nextReads;
+}
 
-function buildDefense(game: LeagueGame, players: Player[], formation: Partial<Record<FormationSlot, string>>): DefensiveAssignment[] {
+function buildDefense(
+  game: LeagueGame,
+  players: Player[],
+  formation: Partial<Record<FormationSlot, string>>,
+): DefensiveAssignment[] {
   const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
   const defenders = players.filter((p) => teamOf(p) === defenseTeam);
-  const by = (d: string) => defenders.filter((p) => str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d).sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
-  const dbs = by("DB"), dls = by("DL"), lbs = by("LB"), safeties = by("S");
+  const by = (d: string) =>
+    defenders
+      .filter(
+        (p) =>
+          str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d,
+      )
+      .sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
+  const dbs = by("DB"),
+    dls = by("DL"),
+    lbs = by("LB"),
+    safeties = by("S");
   const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
   const wrs = WR_SLOTS.filter((s) => formation[s]);
   const ol = TEOL_SLOTS.filter((s) => formation[s]);
   const out: DefensiveAssignment[] = [];
-  wrs.forEach((slot, i) => out.push({ position: `DB${i + 1}`, player: nameOf(take([dbs, lbs]) ?? {}), align: slot }));
-  ol.forEach((slot, i) => out.push({ position: `DL${i + 1}`, player: nameOf(take([dls, lbs]) ?? {}), align: slot }));
+  wrs.forEach((slot, i) =>
+    out.push({
+      position: `DB${i + 1}`,
+      player: nameOf(take([dbs, lbs]) ?? {}),
+      align: slot,
+    }),
+  );
+  ol.forEach((slot, i) =>
+    out.push({
+      position: `DL${i + 1}`,
+      player: nameOf(take([dls, lbs]) ?? {}),
+      align: slot,
+    }),
+  );
   let remaining = Math.max(0, 7 - out.length);
-  (["QB", "RB1", "RB2"] as FormationSlot[]).slice(0, remaining).forEach((slot, i) => { const p = take([lbs, dls, dbs]); if (p) out.push({ position: `LB${i + 1}`, player: nameOf(p), align: slot }); });
-  remaining = Math.max(0, 7 - out.length); if (remaining) { const p = take([safeties, lbs, dbs, dls]); if (p) out.push({ position: "S", player: nameOf(p) }); }
+  (["QB", "RB1", "RB2"] as FormationSlot[])
+    .slice(0, remaining)
+    .forEach((slot, i) => {
+      const p = take([lbs, dls, dbs]);
+      if (p)
+        out.push({ position: `LB${i + 1}`, player: nameOf(p), align: slot });
+    });
+  remaining = Math.max(0, 7 - out.length);
+  if (remaining) {
+    const p = take([safeties, lbs, dbs, dls]);
+    if (p) out.push({ position: "S", player: nameOf(p) });
+  }
   return out;
 }
 
-export function GameControls({ game, players, options, onOptionsChange, onAction }: Props) {
-  const [collapsed, setCollapsed] = useState(false); 
-  const [modal, setModal] = useState<"formation" | "los" | "routes" | "run" | "clock" | null>(null); 
-  const [selected, setSelected] = useState<string>(""); 
+export function GameControls({
+  game,
+  players,
+  options,
+  onOptionsChange,
+  onAction,
+}: Props) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [modal, setModal] = useState<
+    "formation" | "los" | "routes" | "run" | "clock" | null
+  >(null);
+  const [selected, setSelected] = useState<string>("");
   const [detail, setDetail] = useState<string>("");
 
-  
-  const offenseTeam = game.Possession === "Home" ? game.Home : game.Away; 
-  const roster = useMemo(() => players.filter((p) => teamOf(p) === offenseTeam), [players, offenseTeam]); 
+  const offenseTeam = game.Possession === "Home" ? game.Home : game.Away;
+  const roster = useMemo(
+    () => players.filter((p) => teamOf(p) === offenseTeam),
+    [players, offenseTeam],
+  );
   const byName = (n?: string) => players.find((p) => nameOf(p) === n);
-  const formation = options.formation ?? {}; const routes = options.routes ?? {}; const reads = options.reads ?? {}; const receivers = eligibleReceivers(formation); const runners = (["QB", ...RB_SLOTS, ...WR_SLOTS] as FormationSlot[]).map((s) => formation[s]).filter((r): r is string => Boolean(r));
-  const validFormation = [...REQUIRED].every((slot) => formation[slot]); const canPass = receivers.some((r) => routes[r.player] && routes[r.player] !== "No Route"); const setOpt = (patch: Partial<PlayCallOptions>) => onOptionsChange({ ...options, ...patch });
-  const putPlayer = (slot: FormationSlot, player: string) => { const next = Object.fromEntries(Object.entries(formation).filter(([, v]) => v !== player)) as Partial<Record<FormationSlot, string>>; if (player) next[slot] = player; setOpt({ formation: next }); setSelected(""); };
-  const removePlayer = (slot: FormationSlot) => { const player = formation[slot]; const nextFormation = { ...formation }; delete nextFormation[slot]; const nextRoutes = { ...routes }; const nextReads = { ...reads }; if (player) { delete nextRoutes[player]; delete nextReads[player]; } setOpt({ formation: nextFormation, routes: nextRoutes, reads: nextReads, runner: options.runner === player ? undefined : options.runner }); };
-  const bench = roster.filter((p) => !Object.values(formation).includes(nameOf(p)));
-  const setRouteAndRead = (player: string, route: string, readIndex: number) => { const nextRoutes = { ...routes, [player]: route }; const nextReads = normalizeReads(nextRoutes, receivers.map((r) => r.player), { player, readIndex }); setOpt({ routes: nextRoutes, reads: nextReads }); };
+  const formation = options.formation ?? {};
+  const routes = options.routes ?? {};
+  const reads = options.reads ?? {};
+  const receivers = eligibleReceivers(formation);
+  const runners = (["QB", ...RB_SLOTS, ...WR_SLOTS] as FormationSlot[])
+    .map((s) => formation[s])
+    .filter((r): r is string => Boolean(r));
+  const validFormation = [...REQUIRED].every((slot) => formation[slot]);
+  const canPass = receivers.some(
+    (r) => routes[r.player] && routes[r.player] !== "No Route",
+  );
+  const setOpt = (patch: Partial<PlayCallOptions>) =>
+    onOptionsChange({ ...options, ...patch });
+  const putPlayer = (slot: FormationSlot, player: string) => {
+    const next = Object.fromEntries(
+      Object.entries(formation).filter(([, v]) => v !== player),
+    ) as Partial<Record<FormationSlot, string>>;
+    if (player) next[slot] = player;
+    setOpt({ formation: next });
+    setSelected("");
+  };
+  const removePlayer = (slot: FormationSlot) => {
+    const player = formation[slot];
+    const nextFormation = { ...formation };
+    delete nextFormation[slot];
+    const nextRoutes = { ...routes };
+    const nextReads = { ...reads };
+    if (player) {
+      delete nextRoutes[player];
+      delete nextReads[player];
+    }
+    setOpt({
+      formation: nextFormation,
+      routes: nextRoutes,
+      reads: nextReads,
+      runner: options.runner === player ? undefined : options.runner,
+    });
+  };
+  const bench = roster.filter(
+    (p) => !Object.values(formation).includes(nameOf(p)),
+  );
+  const setRouteAndRead = (
+    player: string,
+    route: string,
+    readIndex: number,
+  ) => {
+    const nextRoutes = { ...routes, [player]: route };
+    const nextReads = normalizeReads(
+      nextRoutes,
+      receivers.map((r) => r.player),
+      { player, readIndex },
+    );
+    setOpt({ routes: nextRoutes, reads: nextReads });
+  };
 
-  const defense = useMemo(() => buildDefense(game, players, options.formation ?? {}), [game, players, options.formation]);
+  const defense = useMemo(
+    () => buildDefense(game, players, options.formation ?? {}),
+    [game, players, options.formation],
+  );
 
   const optionsWithDefense = (): PlayCallOptions => ({
     ...options,
@@ -76,17 +283,432 @@ export function GameControls({ game, players, options, onOptionsChange, onAction
     defense.filter((d) => d.position.startsWith("S")),
     defense.filter((d) => d.position.startsWith("LB")),
   ].filter((row) => row.length > 0);
-  return <div className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}><button className="control-panel-toggle" type="button" onClick={() => setCollapsed(!collapsed)}>{collapsed ? "Open Play Caller" : "Collapse Play Caller"}</button>{!collapsed && <><h3>{offenseTeam} Play Caller</h3><div className="game-controls"><button onClick={() => setModal("formation")}>Formation</button><button onClick={() => setModal("los")}>View LOS</button><button onClick={() => setModal("routes")}>Routes</button><button onClick={() => setModal("run")}>Run Modal</button><button onClick={() => setModal("clock")}>Clock</button></div><div className="play-call-summary"><span>{validFormation ? "Formation ready" : "Set required formation"}</span><span>Runner: {options.runner || "Auto"}</span><span>Clock: {options.clockMode || "Normal"}</span></div><div className="game-controls primary">
-    
-  <button disabled={!validFormation} onClick={() => onAction("Run Play", optionsWithDefense())}>Run Play</button>
-  
-  <button disabled={!validFormation || !canPass} onClick={() => onAction("Pass Play", options)}>Pass Play</button><button onClick={() => onAction("Field Goal", options)}>FG</button><button onClick={() => onAction("Punt", options)}>Punt</button><button onClick={() => onAction("Two Point", options)}>2PT</button><button onClick={() => onAction("Timeout", options)}>Timeout</button></div></>}
-    {modal === "formation" && <ControlModal full onClose={() => setModal(null)}><h3>Offensive Formation</h3><div className="formation-field"><div className="formation-row top-row">{LINE_SLOTS.map((slot) => <div key={slot} className={`formation-slot ${slot.startsWith("WR") ? "wr" : "teol"} ${REQUIRED.has(slot) ? "required" : ""} ${formation[slot] ? "filled" : ""}`} data-label={slot} onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer(slot, e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer(slot, selected)}>{formation[slot] && <div draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", formation[slot] || "")}><button type="button" className="formation-remove" aria-label={`Remove ${formation[slot]} from ${slot}`} onClick={(e) => { e.stopPropagation(); removePlayer(slot); }}>×</button><PlayerBubble name={formation[slot]} player={byName(formation[slot])} /></div>}</div>)}</div><div className="formation-row middle-row"><div className={`formation-slot qb required ${formation.QB ? "filled" : ""}`} data-label="QB" onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer("QB", e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer("QB", selected)}>{formation.QB && <div draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", formation.QB || "")}><button type="button" className="formation-remove" aria-label={`Remove ${formation.QB} from QB`} onClick={(e) => { e.stopPropagation(); removePlayer("QB"); }}>×</button><PlayerBubble name={formation.QB} player={byName(formation.QB)} /></div>}</div></div><div className="formation-row bottom-row">{(["RB1", "RB2"] as FormationSlot[]).map((slot) => <div key={slot} className={`formation-slot rb ${formation[slot] ? "filled" : ""}`} data-label={slot} onDragOver={(e) => e.preventDefault()} onDrop={(e) => putPlayer(slot, e.dataTransfer.getData("text/plain"))} onClick={() => selected && putPlayer(slot, selected)}>{formation[slot] && <div draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", formation[slot] || "")}><button type="button" className="formation-remove" aria-label={`Remove ${formation[slot]} from ${slot}`} onClick={(e) => { e.stopPropagation(); removePlayer(slot); }}>×</button><PlayerBubble name={formation[slot]} player={byName(formation[slot])} /></div>}</div>)}</div></div><div className="bench-wrapper"><h4>Bench</h4><div className="bench">{bench.map((p) => <button type="button" draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", nameOf(p))} onClick={() => setSelected(selected === nameOf(p) ? "" : nameOf(p))} className={`player-item ${selected === nameOf(p) ? "selected" : ""}`} key={nameOf(p)}><PlayerBubble name={nameOf(p)} player={p} /><span className="player-name">{nameOf(p)} - {posOf(p)}</span></button>)}</div></div><div className="formation-actions"><button onClick={() => setOpt({ formation: {}, routes: {}, reads: {} })}>Clear</button><button disabled={!validFormation} onClick={() => setModal(null)}>Save</button></div></ControlModal>}
-    {modal === "los" && <ControlModal wide onClose={() => setModal(null)}><h3>Line of Scrimmage</h3><div className="los-field"><div className="los-line" />{supplementalDefenseRows.map((row, index) => <div className="los-row" key={`defense-row-${index}`}>{row.map((d) => <PlayerBubble key={d.position} small name={d.player} player={byName(d.player)} />)}</div>)}<div className="los-grid">{LINE_SLOTS.map((slot) => <div className="los-col" key={slot}><PlayerBubble small name={defense.find((d) => d.align === slot)?.player} player={byName(defense.find((d) => d.align === slot)?.player)} /><PlayerBubble small name={formation[slot]} player={byName(formation[slot])} /></div>)}</div><div className="los-row"><PlayerBubble small name={formation.QB} player={byName(formation.QB)} /></div><div className="los-row">{(["RB1", "RB2"] as FormationSlot[]).map((s) => <PlayerBubble key={s} small name={formation[s]} player={byName(formation[s])} />)}</div></div></ControlModal>}
-    {modal === "routes" && <ControlModal wide onClose={() => setModal(null)}><h3>Receiver Routes</h3><div className="eligible-receiver-list"><span>Eligible receivers:</span>{receivers.map(({ slot, player }) => <button type="button" draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", player)} onClick={() => setDetail(detail === player ? "" : player)} className="eligible-receiver-chip" key={`${slot}-${player}`}><PlayerBubble small name={player} player={byName(player)} /><span>{slot}: {player}</span></button>)}</div><div className="routes-board">{ROUTES.map((r) => <div className="route-zone" key={r}><span>{r}</span>{READS.map((read, readIndex) => <div className="route-read-lane" key={read} style={{ left: `${readIndex * 20}%`, width: "20%" }} onDragOver={(e) => e.preventDefault()} onDrop={(e) => setRouteAndRead(e.dataTransfer.getData("text/plain"), r, readIndex)}><span className="route-read-label">{read}</span></div>)}{receivers.map(({ player }) => { const route = routes[player] || "Short"; const readIndex = Math.max(0, READS.indexOf(reads[player] || READS[0])); return route === r && <button type="button" draggable onDragStart={(e) => e.dataTransfer.setData("text/plain", player)} onClick={() => setDetail(detail === player ? "" : player)} className="player-circle" style={{ left: `calc(${readIndex * 20}% + 10%)` }} key={player}><span className="read-badge">{route === "No Route" ? "" : reads[player] || READS[readIndex]}</span><PlayerBubble name={player} player={byName(player)} /></button>; })}</div>)}</div>{detail && <div className="player-detail"><h4>{detail}</h4><div>Size: {trait(byName(detail), "size")}</div><div>Speed: {trait(byName(detail), "speed")}</div><div>RR: {trait(byName(detail), "routeRunning")}</div><div>JMP: {trait(byName(detail), "jump")}</div><div>HND: {trait(byName(detail), "hands")}</div></div>}<div className="read-summary"><div className="summary-title">Read Summary:</div>{READS.map((r) => { const player = Object.keys(reads).find((p) => reads[p] === r); return <div className="summary-row" key={r}><span className="summary-label">{r}:</span><span>{player ? `${player} - ${routes[player] || ""}` : ""}</span></div>; })}</div><div className="formation-actions"><button onClick={() => setOpt({ routes: {}, reads: {} })}>Clear</button><button onClick={() => setModal(null)}>Save</button></div></ControlModal>}
-    {modal === "run" && <ControlModal onClose={() => setModal(null)}><h3>Run Play</h3><div className="rusher-options">{runners.map((r) => <button className={`rusher-option ${options.runner === r ? "selected" : ""}`} onClick={() => setOpt({ runner: r })} type="button" key={r}><PlayerBubble name={r} player={byName(r)} /><span>{r}</span></button>)}</div>
-    <button disabled={!validFormation} onClick={() => { setModal(null); onAction("Run Play", optionsWithDefense()); }}>Execute Run</button>
-    </ControlModal>}
-    {modal === "clock" && <ControlModal onClose={() => setModal(null)}><h3>Manage Clock</h3><div className="clock-options">{["Normal", "Hurry Up", "Chew Clock"].map((c) => <button className={options.clockMode === c ? "active" : ""} onClick={() => setOpt({ clockMode: c as PlayCallOptions["clockMode"] })} key={c}>{c}</button>)}<button onClick={() => onAction("Spike", options)}>Spike Ball</button><button onClick={() => onAction("Kneel", options)}>Kneel</button></div></ControlModal>}
-  </div>;
+  return (
+    <div
+      className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}
+    >
+      <button
+        className="control-panel-toggle"
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        {collapsed ? "Open Play Caller" : "Collapse Play Caller"}
+      </button>
+      {!collapsed && (
+        <>
+          <h3>{offenseTeam} Play Caller</h3>
+          <div className="game-controls">
+            <button onClick={() => setModal("formation")}>Formation</button>
+            <button onClick={() => setModal("los")}>View LOS</button>
+            <button onClick={() => setModal("routes")}>Routes</button>
+            <button onClick={() => setModal("run")}>Run Modal</button>
+            <button onClick={() => setModal("clock")}>Clock</button>
+          </div>
+          <div className="play-call-summary">
+            <span>
+              {validFormation ? "Formation ready" : "Set required formation"}
+            </span>
+            <span>Runner: {options.runner || "Auto"}</span>
+            <span>Clock: {options.clockMode || "Normal"}</span>
+          </div>
+          <div className="game-controls primary">
+            <button
+              disabled={!validFormation}
+              onClick={() => onAction("Run Play", optionsWithDefense())}
+            >
+              Run Play
+            </button>
+
+            <button
+              disabled={!validFormation || !canPass}
+              onClick={() => onAction("Pass Play", options)}
+            >
+              Pass Play
+            </button>
+            <button onClick={() => onAction("Field Goal", options)}>FG</button>
+            <button onClick={() => onAction("Punt", options)}>Punt</button>
+            <button onClick={() => onAction("Two Point", options)}>2PT</button>
+            <button onClick={() => onAction("Timeout", options)}>
+              Timeout
+            </button>
+          </div>
+        </>
+      )}
+      {modal === "formation" && (
+        <ControlModal full onClose={() => setModal(null)}>
+          <h3>Offensive Formation</h3>
+          <div className="formation-field">
+            <div className="formation-row top-row">
+              {LINE_SLOTS.map((slot) => (
+                <div
+                  key={slot}
+                  className={`formation-slot ${slot.startsWith("WR") ? "wr" : "teol"} ${REQUIRED.has(slot) ? "required" : ""} ${formation[slot] ? "filled" : ""}`}
+                  data-label={slot}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) =>
+                    putPlayer(slot, e.dataTransfer.getData("text/plain"))
+                  }
+                  onClick={() => selected && putPlayer(slot, selected)}
+                >
+                  {formation[slot] && (
+                    <div
+                      draggable
+                      onDragStart={(e) =>
+                        e.dataTransfer.setData(
+                          "text/plain",
+                          formation[slot] || "",
+                        )
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="formation-remove"
+                        aria-label={`Remove ${formation[slot]} from ${slot}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removePlayer(slot);
+                        }}
+                      >
+                        ×
+                      </button>
+                      <PlayerBubble
+                        name={formation[slot]}
+                        player={byName(formation[slot])}
+                      />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="formation-row middle-row">
+              <div
+                className={`formation-slot qb required ${formation.QB ? "filled" : ""}`}
+                data-label="QB"
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) =>
+                  putPlayer("QB", e.dataTransfer.getData("text/plain"))
+                }
+                onClick={() => selected && putPlayer("QB", selected)}
+              >
+                {formation.QB && (
+                  <div
+                    draggable
+                    onDragStart={(e) =>
+                      e.dataTransfer.setData("text/plain", formation.QB || "")
+                    }
+                  >
+                    <button
+                      type="button"
+                      className="formation-remove"
+                      aria-label={`Remove ${formation.QB} from QB`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removePlayer("QB");
+                      }}
+                    >
+                      ×
+                    </button>
+                    <PlayerBubble
+                      name={formation.QB}
+                      player={byName(formation.QB)}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="formation-row bottom-row">
+              {(["RB1", "RB2"] as FormationSlot[]).map((slot) => (
+                <div
+                  key={slot}
+                  className={`formation-slot rb ${formation[slot] ? "filled" : ""}`}
+                  data-label={slot}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) =>
+                    putPlayer(slot, e.dataTransfer.getData("text/plain"))
+                  }
+                  onClick={() => selected && putPlayer(slot, selected)}
+                >
+                  {formation[slot] && (
+                    <div
+                      draggable
+                      onDragStart={(e) =>
+                        e.dataTransfer.setData(
+                          "text/plain",
+                          formation[slot] || "",
+                        )
+                      }
+                    >
+                      <button
+                        type="button"
+                        className="formation-remove"
+                        aria-label={`Remove ${formation[slot]} from ${slot}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removePlayer(slot);
+                        }}
+                      >
+                        ×
+                      </button>
+                      <PlayerBubble
+                        name={formation[slot]}
+                        player={byName(formation[slot])}
+                      />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="bench-wrapper">
+            <h4>Bench</h4>
+            <div className="bench">
+              {bench.map((p) => (
+                <button
+                  type="button"
+                  draggable
+                  onDragStart={(e) =>
+                    e.dataTransfer.setData("text/plain", nameOf(p))
+                  }
+                  onClick={() =>
+                    setSelected(selected === nameOf(p) ? "" : nameOf(p))
+                  }
+                  className={`player-item ${selected === nameOf(p) ? "selected" : ""}`}
+                  key={nameOf(p)}
+                >
+                  <PlayerBubble name={nameOf(p)} player={p} />
+                  <span className="player-name">
+                    {nameOf(p)} - {posOf(p)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="formation-actions">
+            <button
+              onClick={() => setOpt({ formation: {}, routes: {}, reads: {} })}
+            >
+              Clear
+            </button>
+            <button disabled={!validFormation} onClick={() => setModal(null)}>
+              Save
+            </button>
+          </div>
+        </ControlModal>
+      )}
+      {modal === "los" && (
+        <ControlModal wide onClose={() => setModal(null)}>
+          <h3>Line of Scrimmage</h3>
+          <div className="los-field">
+            <div className="los-line" />
+            {supplementalDefenseRows.map((row, index) => (
+              <div className="los-row" key={`defense-row-${index}`}>
+                {row.map((d) => (
+                  <PlayerBubble
+                    key={d.position}
+                    small
+                    name={d.player}
+                    player={byName(d.player)}
+                  />
+                ))}
+              </div>
+            ))}
+            <div className="los-grid">
+              {LINE_SLOTS.map((slot) => (
+                <div className="los-col" key={slot}>
+                  <PlayerBubble
+                    small
+                    name={defense.find((d) => d.align === slot)?.player}
+                    player={byName(
+                      defense.find((d) => d.align === slot)?.player,
+                    )}
+                  />
+                  <PlayerBubble
+                    small
+                    name={formation[slot]}
+                    player={byName(formation[slot])}
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="los-row">
+              <PlayerBubble
+                small
+                name={formation.QB}
+                player={byName(formation.QB)}
+              />
+            </div>
+            <div className="los-row">
+              {(["RB1", "RB2"] as FormationSlot[]).map((s) => (
+                <PlayerBubble
+                  key={s}
+                  small
+                  name={formation[s]}
+                  player={byName(formation[s])}
+                />
+              ))}
+            </div>
+          </div>
+        </ControlModal>
+      )}
+      {modal === "routes" && (
+        <ControlModal wide onClose={() => setModal(null)}>
+          <h3>Receiver Routes</h3>
+          <div className="eligible-receiver-list">
+            <span>Eligible receivers:</span>
+            {receivers.map(({ slot, player }) => (
+              <button
+                type="button"
+                draggable
+                onDragStart={(e) =>
+                  e.dataTransfer.setData("text/plain", player)
+                }
+                onClick={() => setDetail(detail === player ? "" : player)}
+                className="eligible-receiver-chip"
+                key={`${slot}-${player}`}
+              >
+                <PlayerBubble small name={player} player={byName(player)} />
+                <span>
+                  {slot}: {player}
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="routes-board">
+            {ROUTES.map((r) => (
+              <div className="route-zone" key={r}>
+                <span>{r}</span>
+                {READS.map((read, readIndex) => (
+                  <div
+                    className="route-read-lane"
+                    key={read}
+                    style={{ left: `${readIndex * 20}%`, width: "20%" }}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={(e) =>
+                      setRouteAndRead(
+                        e.dataTransfer.getData("text/plain"),
+                        r,
+                        readIndex,
+                      )
+                    }
+                  >
+                    <span className="route-read-label">{read}</span>
+                  </div>
+                ))}
+                {receivers.map(({ player }) => {
+                  const route = routes[player] || "Short";
+                  const readIndex = Math.max(
+                    0,
+                    READS.indexOf(reads[player] || READS[0]),
+                  );
+                  return (
+                    route === r && (
+                      <button
+                        type="button"
+                        draggable
+                        onDragStart={(e) =>
+                          e.dataTransfer.setData("text/plain", player)
+                        }
+                        onClick={() =>
+                          setDetail(detail === player ? "" : player)
+                        }
+                        className="player-circle"
+                        style={{ left: `calc(${readIndex * 20}% + 10%)` }}
+                        key={player}
+                      >
+                        <span className="read-badge">
+                          {route === "No Route"
+                            ? ""
+                            : reads[player] || READS[readIndex]}
+                        </span>
+                        <PlayerBubble name={player} player={byName(player)} />
+                      </button>
+                    )
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+          {detail && (
+            <div className="player-detail">
+              <h4>{detail}</h4>
+              <div>Size: {trait(byName(detail), "size")}</div>
+              <div>Speed: {trait(byName(detail), "speed")}</div>
+              <div>RR: {trait(byName(detail), "routeRunning")}</div>
+              <div>JMP: {trait(byName(detail), "jump")}</div>
+              <div>HND: {trait(byName(detail), "hands")}</div>
+            </div>
+          )}
+          <div className="read-summary">
+            <div className="summary-title">Read Summary:</div>
+            {READS.map((r) => {
+              const player = Object.keys(reads).find((p) => reads[p] === r);
+              return (
+                <div className="summary-row" key={r}>
+                  <span className="summary-label">{r}:</span>
+                  <span>
+                    {player ? `${player} - ${routes[player] || ""}` : ""}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="formation-actions">
+            <button onClick={() => setOpt({ routes: {}, reads: {} })}>
+              Clear
+            </button>
+            <button onClick={() => setModal(null)}>Save</button>
+          </div>
+        </ControlModal>
+      )}
+      {modal === "run" && (
+        <ControlModal onClose={() => setModal(null)}>
+          <h3>Run Play</h3>
+          <div className="rusher-options">
+            {runners.map((r) => (
+              <button
+                className={`rusher-option ${options.runner === r ? "selected" : ""}`}
+                onClick={() => setOpt({ runner: r })}
+                type="button"
+                key={r}
+              >
+                <PlayerBubble name={r} player={byName(r)} />
+                <span>{r}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            disabled={!validFormation}
+            onClick={() => {
+              setModal(null);
+              onAction("Run Play", optionsWithDefense());
+            }}
+          >
+            Execute Run
+          </button>
+        </ControlModal>
+      )}
+      {modal === "clock" && (
+        <ControlModal onClose={() => setModal(null)}>
+          <h3>Manage Clock</h3>
+          <div className="clock-options">
+            {["Normal", "Hurry Up", "Chew Clock"].map((c) => (
+              <button
+                className={options.clockMode === c ? "active" : ""}
+                onClick={() =>
+                  setOpt({ clockMode: c as PlayCallOptions["clockMode"] })
+                }
+                key={c}
+              >
+                {c}
+              </button>
+            ))}
+            <button onClick={() => onAction("Spike", options)}>
+              Spike Ball
+            </button>
+            <button onClick={() => onAction("Kneel", options)}>Kneel</button>
+          </div>
+        </ControlModal>
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,5 +1,4 @@
 export default function GameField() {
-  
   return (
     <div className="field-wrapper">
       <img
@@ -9,63 +8,63 @@ export default function GameField() {
       />
       <div id="field3D">
         <div className="yardline" style={{ left: "8.3333%" }}></div>
-        <div className="yardline" style={{ left: "16.6667%"}}>                    
+        <div className="yardline" style={{ left: "16.6667%" }}>
           <span className="label top left">1</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">1</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "25%"}}>                
+        <div className="yardline" style={{ left: "25%" }}>
           <span className="label top left">2</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">2</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "33.3333%"}}>                
+        <div className="yardline" style={{ left: "33.3333%" }}>
           <span className="label top left">3</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">3</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "41.6667%"}}>                 
+        <div className="yardline" style={{ left: "41.6667%" }}>
           <span className="label top left">4</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">4</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "50%"}}>                
+        <div className="yardline" style={{ left: "50%" }}>
           <span className="label top left">5</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">5</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "58.3333%"}}>              
+        <div className="yardline" style={{ left: "58.3333%" }}>
           <span className="label top left">4</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">4</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "66.6667%"}}>                
+        <div className="yardline" style={{ left: "66.6667%" }}>
           <span className="label top left">3</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">3</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "75%"}}>               
+        <div className="yardline" style={{ left: "75%" }}>
           <span className="label top left">2</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">2</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "83.3333%"}}>              
+        <div className="yardline" style={{ left: "83.3333%" }}>
           <span className="label top left">1</span>
-          <span className="label top right">0</span>               
+          <span className="label top right">0</span>
           <span className="label bottom left">1</span>
           <span className="label bottom right">0</span>
         </div>
-        <div className="yardline" style={{ left: "91.6667%"}}></div>
-        <div className="yardline" style={{ left: "100%"}}></div>
-        
+        <div className="yardline" style={{ left: "91.6667%" }}></div>
+        <div className="yardline" style={{ left: "100%" }}></div>
+
         <div id="firstDownLine" className="yardline first-down-line"></div>
       </div>
       <img
@@ -74,8 +73,6 @@ export default function GameField() {
         alt="Field Goal Post"
       />
       <div className="driveWrapper">
-
-        
         <div
           id="catchPoint"
           style={{
@@ -88,7 +85,7 @@ export default function GameField() {
             transition: "opacity 0.5s ease",
           }}
         ></div>
-        
+
         <div className="drive-line" id="drive"></div>
         <div className="play-line" id="play"></div>
         <div id="arc-container" className="arc-container"></div>

--- a/apps/web/src/components/league/gameplay/engine/animationAdapter.ts
+++ b/apps/web/src/components/league/gameplay/engine/animationAdapter.ts
@@ -1,157 +1,188 @@
 type AnimationGameState = {
-    DriveStart?: string | number;
-    Previous?: string | number;
-    BallOn: string | number;
-    Possession: string;
+  DriveStart?: string | number;
+  Previous?: string | number;
+  BallOn: string | number;
+  Possession: string;
 };
 
 type AnimationPassResult = Record<string, unknown> | null;
 
-declare function buildArcWithArrow(mountEl: HTMLElement, options: Record<string, unknown>): Promise<void>;
+declare function buildArcWithArrow(
+  mountEl: HTMLElement,
+  options: Record<string, unknown>,
+): Promise<void>;
 
-export async function animatePlay(playType: string, passResult: AnimationPassResult = null, currentState: AnimationGameState){
-    // use current game state to drive the animation in the proper direction
-    const normalizedPassResult = passResult && typeof passResult === 'object'
-        ? { ...passResult, airYards: Number(passResult.airYards) || 0 }
-        : { airYards: 0 };
-    const normalizedPlayType = playType.toLowerCase() === 'run' ? 'Run' : playType;
-    await show3DDrive(currentState, currentState.DriveStart ?? currentState.Previous ?? currentState.BallOn, currentState.Previous ?? currentState.BallOn, currentState.BallOn, normalizedPlayType, normalizedPassResult); //CHANGE - dont hardcode run and pass
+export async function animatePlay(
+  playType: string,
+  passResult: AnimationPassResult = null,
+  currentState: AnimationGameState,
+) {
+  // use current game state to drive the animation in the proper direction
+  const normalizedPassResult =
+    passResult && typeof passResult === "object"
+      ? { ...passResult, airYards: Number(passResult.airYards) || 0 }
+      : { airYards: 0 };
+  const normalizedPlayType =
+    playType.toLowerCase() === "run" ? "Run" : playType;
+  await show3DDrive(
+    currentState,
+    currentState.DriveStart ?? currentState.Previous ?? currentState.BallOn,
+    currentState.Previous ?? currentState.BallOn,
+    currentState.BallOn,
+    normalizedPlayType,
+    normalizedPassResult,
+  ); //CHANGE - dont hardcode run and pass
 }
 
 //UI Functions ONLY - ANIMATIONS BELOW!
-  export function show3DDrive(state: AnimationGameState, startYard: string | number, prevYard: string | number, currentYard: string | number, playType = 'Run', passResult: Record<string, unknown>) {
-    //hid incomplete if nec.
-    const catchPoint = document.getElementById("catchPoint")!;
-    catchPoint.style.display = 'none';
+export function show3DDrive(
+  state: AnimationGameState,
+  startYard: string | number,
+  prevYard: string | number,
+  currentYard: string | number,
+  playType = "Run",
+  passResult: Record<string, unknown>,
+) {
+  //hid incomplete if nec.
+  const catchPoint = document.getElementById("catchPoint")!;
+  catchPoint.style.display = "none";
 
-    const passComplete = Boolean(passResult.completed);
-    if(playType == "Pass" && !passComplete){
-      let airYds = Number(passResult.airYards) || 0;
-      if (state.Possession === 'Away') {
-        airYds = - (Number(passResult.airYards) || 0);
-      }
-      currentYard = Number(prevYard) + airYds;
+  const passComplete = Boolean(passResult.completed);
+  if (playType == "Pass" && !passComplete) {
+    let airYds = Number(passResult.airYards) || 0;
+    if (state.Possession === "Away") {
+      airYds = -(Number(passResult.airYards) || 0);
     }
-    if(passResult.sack){
-      playType = 'Run';
-    }
-
-    const touchdown = Boolean(passResult.touchdown) || (playType === 'Run' && (Number(currentYard) <= 0 || Number(currentYard) >= 100));
-
-    // Hide previous play visuals until we know which animation to show
-    const runDiv = document.getElementById("play")!;
-    const passDiv = document.getElementById("arc-container")!;
-    runDiv.style.display = "none";
-    passDiv.style.display = "none";
-
-    return new Promise<void>(resolve => {
-      const field = document.getElementById("field3D")!;
-      const fieldWidth = field.offsetWidth;
-      const yardPx = fieldWidth / 120;
-      //const canvas = document.getElementById("arcCanvas");
-      //canvas.width = fieldWidth;
-      //canvas.height = fieldHeight;
-      const endYard = touchdown ? (state.Possession === 'Home' ? 102 : -2) : currentYard;
-      let drivePX = (Number(startYard) + 10) * yardPx;
-      let prevPX = (Number(prevYard) + 10) * yardPx;
-      let currPX = (Number(endYard) + 10) * yardPx;
-      const drive = document.getElementById("drive")!;
-      // Handle drive line based on direction
-      if (state.Possession == "Home") {
-        drive.style.left = `${drivePX}px`;
-        drive.style.right = `auto`;
-        drive.style.width = `${prevPX - drivePX}px`;
-        drive.style.setProperty('--left-pos', `-5px`);
-      } else {
-        drivePX = fieldWidth - drivePX;
-        prevPX = fieldWidth - prevPX;
-        currPX = fieldWidth - currPX;
-        drive.style.left = `auto`;
-        drive.style.right = `${drivePX}px`;
-        drive.style.width = `${prevPX - drivePX}px`;
-        drive.style.setProperty('--left-pos', `${prevPX - drivePX - 5}px`);
-      }
-
-      const lastPlay = runDiv;
-      // Fade out old marker
-      lastPlay.style.opacity = "0";// lastDot.style.opacity = arrow.style.opacity = 0;
-      setTimeout(() => {
-        // Prepare the element for the upcoming animation
-        if (playType === 'Run') {
-          runDiv.style.display = "block";
-        } else {
-          passDiv.style.display = "block";
-        }
-        lastPlay.style.transition = "none";
-        lastPlay.style.backgroundColor = playType === 'Pass' ? 'transparent' : 'black';
-        lastPlay.style.width = `0px`;
-        lastPlay.style.opacity = "1";
-        if(state.Possession == "Home"){
-          lastPlay.style.left = `${prevPX}px`;
-        } else{
-          lastPlay.style.right = `${prevPX}px`;
-        }
-
-        if (playType === 'Run') {
-          lastPlay.style.top = `50%`;
-          lastPlay.style.height = `6px`;
-          setTimeout(() => {
-            // Animate based on direction of play
-            if (state.Possession == "Home") {
-              lastPlay.style.transition = "width 1.4s ease, left 1.4s ease";
-              lastPlay.style.left = `${prevPX}px`;
-              lastPlay.style.right = `auto`;
-              lastPlay.style.width = `${currPX - prevPX}px`;
-              if(lastPlay.classList.contains("swapped")){                
-                lastPlay.classList.remove("swapped");
-              }
-            } else {
-              lastPlay.style.transition = "width 1.4s ease, right 1.4s ease";
-              lastPlay.style.left = `auto`;
-              lastPlay.style.right = `${prevPX}px`;
-              lastPlay.style.width = `${(currPX - prevPX)}px`;
-              if(!lastPlay.classList.contains("swapped")){                
-                lastPlay.classList.add("swapped");
-              }
-            }
-            const playWidth = currPX - prevPX;
-            if (playWidth <= 0) {
-              // No animation to wait for; resolve manually after short delay
-              setTimeout(() => {
-                resolve();
-              }, 300);
-            } else {
-              const onEnd = (e: TransitionEvent) => {
-                if (e.propertyName === 'width') {
-                  lastPlay.removeEventListener('transitionend', onEnd);
-                  resolve();
-                }
-              };
-              lastPlay.addEventListener('transitionend', onEnd);
-            }
-          }, 50);
-        } else {
-          //lastDot.style.opacity = arrow.style.opacity = 0;
-          buildArcWithArrow(passDiv, {
-            prevPx: prevPX,
-            currPx: currPX,
-            rise: 150,
-            direction: "up",
-            completion: passComplete,
-          }).then(resolve);
-        }
-      }, 400);
-    });
+    currentYard = Number(prevYard) + airYds;
   }
+  if (passResult.sack) {
+    playType = "Run";
+  }
+
+  const touchdown =
+    Boolean(passResult.touchdown) ||
+    (playType === "Run" &&
+      (Number(currentYard) <= 0 || Number(currentYard) >= 100));
+
+  // Hide previous play visuals until we know which animation to show
+  const runDiv = document.getElementById("play")!;
+  const passDiv = document.getElementById("arc-container")!;
+  runDiv.style.display = "none";
+  passDiv.style.display = "none";
+
+  return new Promise<void>((resolve) => {
+    const field = document.getElementById("field3D")!;
+    const fieldWidth = field.offsetWidth;
+    const yardPx = fieldWidth / 120;
+    //const canvas = document.getElementById("arcCanvas");
+    //canvas.width = fieldWidth;
+    //canvas.height = fieldHeight;
+    const endYard = touchdown
+      ? state.Possession === "Home"
+        ? 102
+        : -2
+      : currentYard;
+    let drivePX = (Number(startYard) + 10) * yardPx;
+    let prevPX = (Number(prevYard) + 10) * yardPx;
+    let currPX = (Number(endYard) + 10) * yardPx;
+    const drive = document.getElementById("drive")!;
+    // Handle drive line based on direction
+    if (state.Possession == "Home") {
+      drive.style.left = `${drivePX}px`;
+      drive.style.right = `auto`;
+      drive.style.width = `${prevPX - drivePX}px`;
+      drive.style.setProperty("--left-pos", `-5px`);
+    } else {
+      drivePX = fieldWidth - drivePX;
+      prevPX = fieldWidth - prevPX;
+      currPX = fieldWidth - currPX;
+      drive.style.left = `auto`;
+      drive.style.right = `${drivePX}px`;
+      drive.style.width = `${prevPX - drivePX}px`;
+      drive.style.setProperty("--left-pos", `${prevPX - drivePX - 5}px`);
+    }
+
+    const lastPlay = runDiv;
+    // Fade out old marker
+    lastPlay.style.opacity = "0"; // lastDot.style.opacity = arrow.style.opacity = 0;
+    setTimeout(() => {
+      // Prepare the element for the upcoming animation
+      if (playType === "Run") {
+        runDiv.style.display = "block";
+      } else {
+        passDiv.style.display = "block";
+      }
+      lastPlay.style.transition = "none";
+      lastPlay.style.backgroundColor =
+        playType === "Pass" ? "transparent" : "black";
+      lastPlay.style.width = `0px`;
+      lastPlay.style.opacity = "1";
+      if (state.Possession == "Home") {
+        lastPlay.style.left = `${prevPX}px`;
+      } else {
+        lastPlay.style.right = `${prevPX}px`;
+      }
+
+      if (playType === "Run") {
+        lastPlay.style.top = `50%`;
+        lastPlay.style.height = `6px`;
+        setTimeout(() => {
+          // Animate based on direction of play
+          if (state.Possession == "Home") {
+            lastPlay.style.transition = "width 1.4s ease, left 1.4s ease";
+            lastPlay.style.left = `${prevPX}px`;
+            lastPlay.style.right = `auto`;
+            lastPlay.style.width = `${currPX - prevPX}px`;
+            if (lastPlay.classList.contains("swapped")) {
+              lastPlay.classList.remove("swapped");
+            }
+          } else {
+            lastPlay.style.transition = "width 1.4s ease, right 1.4s ease";
+            lastPlay.style.left = `auto`;
+            lastPlay.style.right = `${prevPX}px`;
+            lastPlay.style.width = `${currPX - prevPX}px`;
+            if (!lastPlay.classList.contains("swapped")) {
+              lastPlay.classList.add("swapped");
+            }
+          }
+          const playWidth = currPX - prevPX;
+          if (playWidth <= 0) {
+            // No animation to wait for; resolve manually after short delay
+            setTimeout(() => {
+              resolve();
+            }, 300);
+          } else {
+            const onEnd = (e: TransitionEvent) => {
+              if (e.propertyName === "width") {
+                lastPlay.removeEventListener("transitionend", onEnd);
+                resolve();
+              }
+            };
+            lastPlay.addEventListener("transitionend", onEnd);
+          }
+        }, 50);
+      } else {
+        //lastDot.style.opacity = arrow.style.opacity = 0;
+        buildArcWithArrow(passDiv, {
+          prevPx: prevPX,
+          currPx: currPX,
+          rise: 150,
+          direction: "up",
+          completion: passComplete,
+        }).then(resolve);
+      }
+    }, 400);
+  });
+}
 
 //   //New UI functionality
 //   export function makeArcPath(x, y, width, rise, direction = "up", completion) {
 //     let x0 = x, y0 = y;
-//     let x1 = x + width, y1 = y;           // baseline anchors  
+//     let x1 = x + width, y1 = y;           // baseline anchors
 //     if(!completion){
 //       y1 = y-20;
 //     }
-//     let cx = x + width / 2;  
+//     let cx = x + width / 2;
 //     const cy = direction === "up" ? y - rise : y + rise;
 //     if(state.Possession == "Away"){
 //       x0 = width-1;
@@ -164,7 +195,7 @@ export async function animatePlay(playType: string, passResult: AnimationPassRes
 //       end:   { x: x1, y: y1 }
 //     };
 //   }
-  
+
 //   export function buildArcWithArrow(mountEl, { prevPx, currPx, rise, direction = "up", completion }) {
 //     return new Promise(resolve => {
 //       let width = Math.abs(currPx - prevPx);
@@ -290,4 +321,3 @@ export async function animatePlay(playType: string, passResult: AnimationPassRes
 //       }, 100);
 //     });
 //   }
-  

--- a/apps/web/src/components/league/gameplay/engine/backendAdapter.ts
+++ b/apps/web/src/components/league/gameplay/engine/backendAdapter.ts
@@ -1,7 +1,14 @@
-export async function savePlayAndGameWithRetry<T>(save: () => Promise<T>, retries = 2): Promise<T> {
+export async function savePlayAndGameWithRetry<T>(
+  save: () => Promise<T>,
+  retries = 2,
+): Promise<T> {
   let lastError: unknown;
   for (let attempt = 0; attempt <= retries; attempt++) {
-    try { return await save(); } catch (error) { lastError = error; }
+    try {
+      return await save();
+    } catch (error) {
+      lastError = error;
+    }
   }
   throw lastError;
 }

--- a/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
@@ -1,8 +1,21 @@
 import type { EngineContext } from "./types";
 import { byName, n } from "./utils";
-export function applyFatigue(ctx: EngineContext, playerName: string, actionType: string) {
-  const player = byName(ctx, playerName); if (!player) return;
-  const drain = n((ctx.settings.drainSettings as Record<string, unknown> | undefined)?.[actionType] ?? (ctx.settings as Record<string, unknown>)[actionType] ?? 0);
+export function applyFatigue(
+  ctx: EngineContext,
+  playerName: string,
+  actionType: string,
+) {
+  const player = byName(ctx, playerName);
+  if (!player) return;
+  const drain = n(
+    (ctx.settings.drainSettings as Record<string, unknown> | undefined)?.[
+      actionType
+    ] ??
+      (ctx.settings as Record<string, unknown>)[actionType] ??
+      0,
+  );
   player.fatigue = Math.max(0, n(player.fatigue ?? 100) - drain);
 }
-export function applyFatigueFromPlayHistory() { return undefined; }
+export function applyFatigueFromPlayHistory() {
+  return undefined;
+}

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -2,23 +2,75 @@ import type { LeagueGame } from "../../types";
 import type { EngineContext, FormationSlot, PlayerTrait } from "./types";
 import { defenseTeam, playerName, str, teamPlayers, trait } from "./utils";
 
-export type FormationEntry = { position: FormationSlot | string; player: string; align?: string };
+export type FormationEntry = {
+  position: FormationSlot | string;
+  player: string;
+  align?: string;
+};
 const REQUIRED: FormationSlot[] = ["QB", "TEOL2", "TEOL3", "TEOL4"];
-export function validateOffensiveFormation(formation: Partial<Record<FormationSlot, string>>) {
+export function validateOffensiveFormation(
+  formation: Partial<Record<FormationSlot, string>>,
+) {
   return REQUIRED.every((slot) => Boolean(formation[slot]));
 }
-export function saveOffensiveFormation(formation: Partial<Record<FormationSlot, string>>): FormationEntry[] {
-  return Object.entries(formation).filter(([, player]) => Boolean(player)).map(([position, player]) => ({ position, player: String(player) }));
+export function saveOffensiveFormation(
+  formation: Partial<Record<FormationSlot, string>>,
+): FormationEntry[] {
+  return Object.entries(formation)
+    .filter(([, player]) => Boolean(player))
+    .map(([position, player]) => ({ position, player: String(player) }));
 }
-export function generateDefensiveFormation(game: LeagueGame, ctx: EngineContext, offense: FormationEntry[] = []): FormationEntry[] {
+export function generateDefensiveFormation(
+  game: LeagueGame,
+  ctx: EngineContext,
+  offense: FormationEntry[] = [],
+): FormationEntry[] {
   const defenders = teamPlayers(ctx, defenseTeam(game));
-  const group = (defPos: string) => defenders.filter((p) => str(p.defPos ?? p.DefPos).toUpperCase() === defPos).sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
-  const dbs = group("DB"), dls = group("DL"), lbs = group("LB"), safeties = group("S");
+  const group = (defPos: string) =>
+    defenders
+      .filter((p) => str(p.defPos ?? p.DefPos).toUpperCase() === defPos)
+      .sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
+  const dbs = group("DB"),
+    dls = group("DL"),
+    lbs = group("LB"),
+    safeties = group("S");
   const used = new Set<PlayerTrait>();
-  const take = (pool: PlayerTrait[]) => { const player = pool.find((p) => !used.has(p)); if (player) used.add(player); return player; };
+  const take = (pool: PlayerTrait[]) => {
+    const player = pool.find((p) => !used.has(p));
+    if (player) used.add(player);
+    return player;
+  };
   const out: FormationEntry[] = [];
-  offense.filter((s) => s.position.startsWith("WR")).forEach((slot, i) => { const p = take(dbs); if (p) out.push({ position: `DB${i + 1}`, player: playerName(p), align: slot.position }); });
-  offense.filter((s) => s.position.startsWith("TEOL")).forEach((slot, i) => { const p = take(i % 2 ? lbs : dls) ?? take(dls) ?? take(lbs); if (p) out.push({ position: `${str(p.defPos ?? "DL")}${i + 1}`, player: playerName(p), align: slot.position }); });
-  [take(lbs), take(lbs), take(safeties)].filter(Boolean).forEach((p, i) => out.push({ position: i === 2 ? "S1" : `LB${i + 1}`, player: playerName(p), align: i === 2 ? "deep" : "box" }));
+  offense
+    .filter((s) => s.position.startsWith("WR"))
+    .forEach((slot, i) => {
+      const p = take(dbs);
+      if (p)
+        out.push({
+          position: `DB${i + 1}`,
+          player: playerName(p),
+          align: slot.position,
+        });
+    });
+  offense
+    .filter((s) => s.position.startsWith("TEOL"))
+    .forEach((slot, i) => {
+      const p = take(i % 2 ? lbs : dls) ?? take(dls) ?? take(lbs);
+      if (p)
+        out.push({
+          position: `${str(p.defPos ?? "DL")}${i + 1}`,
+          player: playerName(p),
+          align: slot.position,
+        });
+    });
+  [take(lbs), take(lbs), take(safeties)]
+    .filter(Boolean)
+    .forEach((p, i) =>
+      out.push({
+        position: i === 2 ? "S1" : `LB${i + 1}`,
+        player: playerName(p),
+        align: i === 2 ? "deep" : "box",
+      }),
+    );
   return out;
 }

--- a/apps/web/src/components/league/gameplay/engine/gameStateEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/gameStateEngine.ts
@@ -1,6 +1,14 @@
 import type { LeagueGame } from "../../types";
 import { buildGameData } from "./playLogger";
-export function updateGameState(game: LeagueGame, previous: unknown) { return buildGameData(game, previous); }
-export function handleTouchdown(game: LeagueGame) { return { ...game, pendingFGTeam: game.Possession }; }
-export function handleSafety(game: LeagueGame) { return game; }
-export function handleTOonDowns(game: LeagueGame) { return game; }
+export function updateGameState(game: LeagueGame, previous: unknown) {
+  return buildGameData(game, previous);
+}
+export function handleTouchdown(game: LeagueGame) {
+  return { ...game, pendingFGTeam: game.Possession };
+}
+export function handleSafety(game: LeagueGame) {
+  return game;
+}
+export function handleTOonDowns(game: LeagueGame) {
+  return game;
+}

--- a/apps/web/src/components/league/gameplay/engine/passEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/passEngine.ts
@@ -1,14 +1,52 @@
 import type { LeagueGame } from "../../types";
 import type { EngineContext, PlayCallOptions } from "./types";
-import { advanceBall, advanceQuarter, byName, byPosition, choose, clockRunoff, defenseTeam, isSafety, isTouchdown, n, nextDownDistance, offenseTeam, playerName, switchPoss, teamPlayers, trait, weightedChoose } from "./utils";
+import {
+  advanceBall,
+  advanceQuarter,
+  byName,
+  byPosition,
+  choose,
+  clockRunoff,
+  defenseTeam,
+  isSafety,
+  isTouchdown,
+  n,
+  nextDownDistance,
+  offenseTeam,
+  playerName,
+  switchPoss,
+  teamPlayers,
+  trait,
+  weightedChoose,
+} from "./utils";
 import { buildResult } from "./playLogger";
 import { checkForFumble, determineTackler } from "./runEngine";
 
-export function determineTimeToThrow(game: LeagueGame, ctx: EngineContext, options: PlayCallOptions = {}) {
-  const defense = defenseTeam(game); const formation = options.formation ?? {};
-  const rush = teamPlayers(ctx, defense).filter((p) => ["DL", "LB"].includes(String(p.defPos ?? "").toUpperCase())).reduce((s, p) => s + trait(p, "passRush") + trait(p, "defStars") / 2, 0);
-  const protectors = [formation.RB1, formation.RB2, formation.TEOL1, formation.TEOL2, formation.TEOL3, formation.TEOL4, formation.TEOL5].map((name) => byName(ctx, name)).filter(Boolean);
-  const protection = protectors.reduce((s, p) => s + trait(p, "passProtect") + trait(p, "offStars") / 2, 0);
+export function determineTimeToThrow(
+  game: LeagueGame,
+  ctx: EngineContext,
+  options: PlayCallOptions = {},
+) {
+  const defense = defenseTeam(game);
+  const formation = options.formation ?? {};
+  const rush = teamPlayers(ctx, defense)
+    .filter((p) => ["DL", "LB"].includes(String(p.defPos ?? "").toUpperCase()))
+    .reduce((s, p) => s + trait(p, "passRush") + trait(p, "defStars") / 2, 0);
+  const protectors = [
+    formation.RB1,
+    formation.RB2,
+    formation.TEOL1,
+    formation.TEOL2,
+    formation.TEOL3,
+    formation.TEOL4,
+    formation.TEOL5,
+  ]
+    .map((name) => byName(ctx, name))
+    .filter(Boolean);
+  const protection = protectors.reduce(
+    (s, p) => s + trait(p, "passProtect") + trait(p, "offStars") / 2,
+    0,
+  );
   const diff = protection - rush + (Math.random() * 80 - 40);
   if (diff < -80) return -1;
   if (diff < -45) return 0;
@@ -18,65 +56,341 @@ export function determineTimeToThrow(game: LeagueGame, ctx: EngineContext, optio
   if (diff < 60) return 4;
   return 5;
 }
-export function handleSack(game: LeagueGame, ctx: EngineContext, qbName: string, options: PlayCallOptions = {}) {
-  const rushers = teamPlayers(ctx, defenseTeam(game)).filter((p) => ["DL", "LB"].includes(String(p.defPos ?? "").toUpperCase()));
+export function handleSack(
+  game: LeagueGame,
+  ctx: EngineContext,
+  qbName: string,
+  options: PlayCallOptions = {},
+) {
+  const rushers = teamPlayers(ctx, defenseTeam(game)).filter((p) =>
+    ["DL", "LB"].includes(String(p.defPos ?? "").toUpperCase()),
+  );
   const sacker = weightedChoose(rushers, (p) => trait(p, "sackChance"));
-  const loss = Math.max(1, Math.floor(Math.random() * 9) + 1 - (Math.random() * 100 < trait(byName(ctx, qbName), "juke") ? 2 : 0));
-  const yards = -loss; const newBall = advanceBall(game, yards); const safety = isSafety(game, newBall);
+  const loss = Math.max(
+    1,
+    Math.floor(Math.random() * 9) +
+      1 -
+      (Math.random() * 100 < trait(byName(ctx, qbName), "juke") ? 2 : 0),
+  );
+  const yards = -loss;
+  const newBall = advanceBall(game, yards);
+  const safety = isSafety(game, newBall);
   const fumble = checkForFumble(ctx, qbName, playerName(sacker, "NA"));
   const next = nextDownDistance(game, yards, newBall);
-  let hs = n(game.HomeScore), as = n(game.AwayScore); if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
-  const result = safety ? "Safety" : fumble.fumble ? "Fumble" : next.turnover ? "TO on Downs" : "Sack";
-  const clock = advanceQuarter(game, clockRunoff(options.clockMode, 6, ["Safety", "Fumble", "TO on Downs"].includes(result)));
-  const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: next.down, Distance: next.distance, BallOn: next.ballOn, Previous: game.BallOn, Possession: safety || next.turnover || (fumble.fumble && fumble.recoveredBy !== qbName) ? switchPoss(game) : game.Possession };
-  return buildResult(game, updated, "Pass", qbName, "", yards, playerName(sacker, "NA"), result, ctx.historyLength, { airyards: 0, recoveredby: fumble.recoveredBy });
+  let hs = n(game.HomeScore),
+    as = n(game.AwayScore);
+  if (safety) {
+    if (game.Possession === "Home") as += 2;
+    else hs += 2;
+  }
+  const result = safety
+    ? "Safety"
+    : fumble.fumble
+      ? "Fumble"
+      : next.turnover
+        ? "TO on Downs"
+        : "Sack";
+  const clock = advanceQuarter(
+    game,
+    clockRunoff(
+      options.clockMode,
+      6,
+      ["Safety", "Fumble", "TO on Downs"].includes(result),
+    ),
+  );
+  const updated = {
+    ...game,
+    HomeScore: hs,
+    AwayScore: as,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: next.down,
+    Distance: next.distance,
+    BallOn: next.ballOn,
+    Previous: game.BallOn,
+    Possession:
+      safety ||
+      next.turnover ||
+      (fumble.fumble && fumble.recoveredBy !== qbName)
+        ? switchPoss(game)
+        : game.Possession,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Pass",
+    qbName,
+    "",
+    yards,
+    playerName(sacker, "NA"),
+    result,
+    ctx.historyLength,
+    { airyards: 0, recoveredby: fumble.recoveredBy },
+  );
 }
-export function assignRoutes(game: LeagueGame, ctx: EngineContext, options: PlayCallOptions = {}) {
-  const offense = offenseTeam(game), routes = options.routes ?? {};
-  const names = Object.keys(routes).length ? Object.keys(routes) : [...byPosition(ctx, offense, "WR"), ...byPosition(ctx, offense, "RB"), ...byPosition(ctx, offense, "TE")].map((p) => playerName(p));
-  return names.filter((name) => routes[name] !== "No Route").map((name, i) => ({ player: name, routeType: routes[name] || "Go", airYards: routes[name] === "Screen" ? 0 : routes[name] === "Slant" ? 5 : routes[name] === "Post" ? 14 : 8, TTO: routes[name] === "Go" ? 4 : 2, defender: teamPlayers(ctx, defenseTeam(game))[i]?.name as string | undefined, position: i }));
+export function assignRoutes(
+  game: LeagueGame,
+  ctx: EngineContext,
+  options: PlayCallOptions = {},
+) {
+  const offense = offenseTeam(game),
+    routes = options.routes ?? {};
+  const names = Object.keys(routes).length
+    ? Object.keys(routes)
+    : [
+        ...byPosition(ctx, offense, "WR"),
+        ...byPosition(ctx, offense, "RB"),
+        ...byPosition(ctx, offense, "TE"),
+      ].map((p) => playerName(p));
+  return names
+    .filter((name) => routes[name] !== "No Route")
+    .map((name, i) => ({
+      player: name,
+      routeType: routes[name] || "Go",
+      airYards:
+        routes[name] === "Screen"
+          ? 0
+          : routes[name] === "Slant"
+            ? 5
+            : routes[name] === "Post"
+              ? 14
+              : 8,
+      TTO: routes[name] === "Go" ? 4 : 2,
+      defender: teamPlayers(ctx, defenseTeam(game))[i]?.name as
+        string | undefined,
+      position: i,
+    }));
 }
-export function determineSeparation(ctx: EngineContext, routes: ReturnType<typeof assignRoutes>, timeToThrow: number) {
-  return routes.map((route) => { const rec = byName(ctx, route.player), def = byName(ctx, route.defender); let separation = 0; if (route.airYards > 10) separation += trait(rec, "speed") + trait(rec, "acceleration") > trait(def, "speed") + trait(def, "acceleration") ? 1 : -1; for (let i = 0; i < 3; i++) if (Math.random() * 100 < trait(rec, "routeRunning")) separation++; for (let i = 0; i < 2; i++) if (Math.random() * 100 < trait(def, "coverage")) separation--; separation += Math.max(-2, Math.min(0, timeToThrow - route.TTO)); return { ...route, separation }; });
+export function determineSeparation(
+  ctx: EngineContext,
+  routes: ReturnType<typeof assignRoutes>,
+  timeToThrow: number,
+) {
+  return routes.map((route) => {
+    const rec = byName(ctx, route.player),
+      def = byName(ctx, route.defender);
+    let separation = 0;
+    if (route.airYards > 10)
+      separation +=
+        trait(rec, "speed") + trait(rec, "acceleration") >
+        trait(def, "speed") + trait(def, "acceleration")
+          ? 1
+          : -1;
+    for (let i = 0; i < 3; i++)
+      if (Math.random() * 100 < trait(rec, "routeRunning")) separation++;
+    for (let i = 0; i < 2; i++)
+      if (Math.random() * 100 < trait(def, "coverage")) separation--;
+    separation += Math.max(-2, Math.min(0, timeToThrow - route.TTO));
+    return { ...route, separation };
+  });
 }
-export function choosePassTarget(ctx: EngineContext, qbName: string, routes: ReturnType<typeof determineSeparation>, options: PlayCallOptions = {}) {
-  const qb = byName(ctx, qbName); const readOk = Math.random() * 100 < trait(qb, "readDefense");
-  return weightedChoose(routes, (r) => { const read = options.reads?.[r.player] ?? ""; const readVal = read === "Primary" ? 5 : read === "2nd" ? 4 : read === "3rd" ? 3 : read === "4th" ? 2 : read === "Checkdown" ? 1 : 0; return Math.max(1, 10 - r.airYards / 3 + readVal + (readOk ? r.separation * 3 : 0)); });
+export function choosePassTarget(
+  ctx: EngineContext,
+  qbName: string,
+  routes: ReturnType<typeof determineSeparation>,
+  options: PlayCallOptions = {},
+) {
+  const qb = byName(ctx, qbName);
+  const readOk = Math.random() * 100 < trait(qb, "readDefense");
+  return weightedChoose(routes, (r) => {
+    const read = options.reads?.[r.player] ?? "";
+    const readVal =
+      read === "Primary"
+        ? 5
+        : read === "2nd"
+          ? 4
+          : read === "3rd"
+            ? 3
+            : read === "4th"
+              ? 2
+              : read === "Checkdown"
+                ? 1
+                : 0;
+    return Math.max(
+      1,
+      10 - r.airYards / 3 + readVal + (readOk ? r.separation * 3 : 0),
+    );
+  });
 }
-export function determineCompletionPct(ctx: EngineContext, qbName: string, target: NonNullable<ReturnType<typeof choosePassTarget>>) {
-  const qb = byName(ctx, qbName), rec = byName(ctx, target.player), def = byName(ctx, target.defender);
-  let pct = 72 - target.airYards * 1.7 + (trait(qb, "accuracy") - 50) / 2 + target.separation * 8 + (trait(rec, "hands") - 50) / 3 - trait(def, "defStars", 0) / 8;
-  if (target.airYards > 20 && Math.random() * 100 < trait(qb, "armStrength")) pct += 8;
+export function determineCompletionPct(
+  ctx: EngineContext,
+  qbName: string,
+  target: NonNullable<ReturnType<typeof choosePassTarget>>,
+) {
+  const qb = byName(ctx, qbName),
+    rec = byName(ctx, target.player),
+    def = byName(ctx, target.defender);
+  let pct =
+    72 -
+    target.airYards * 1.7 +
+    (trait(qb, "accuracy") - 50) / 2 +
+    target.separation * 8 +
+    (trait(rec, "hands") - 50) / 3 -
+    trait(def, "defStars", 0) / 8;
+  if (target.airYards > 20 && Math.random() * 100 < trait(qb, "armStrength"))
+    pct += 8;
   if (Math.random() * 100 < trait(rec, "offStars")) pct += 5;
   return { pct: Math.max(5, Math.min(95, pct)), log: [] as string[] };
 }
-export function calcYAC(ctx: EngineContext, playerNameArg: string, separation: number) {
-  const p = byName(ctx, playerNameArg); let yac = Math.max(-2, Math.floor(Math.random() * (separation >= 2 ? 12 : 5)) - (separation < 0 ? 2 : 0));
+export function calcYAC(
+  ctx: EngineContext,
+  playerNameArg: string,
+  separation: number,
+) {
+  const p = byName(ctx, playerNameArg);
+  let yac = Math.max(
+    -2,
+    Math.floor(Math.random() * (separation >= 2 ? 12 : 5)) -
+      (separation < 0 ? 2 : 0),
+  );
   if (Math.random() * 100 < trait(p, "acceleration")) yac += 2;
   if (yac < 0 && Math.random() * 100 < trait(p, "strength")) yac = 0;
   if (yac >= 8 && Math.random() * 100 < trait(p, "speed")) yac += 6;
   if (Math.random() * 100 < trait(p, "juke")) yac += 1;
   return yac;
 }
-export function determinePassOutcome(ctx: EngineContext, qbName: string, target: NonNullable<ReturnType<typeof choosePassTarget>>, completionPct: number) {
+export function determinePassOutcome(
+  ctx: EngineContext,
+  qbName: string,
+  target: NonNullable<ReturnType<typeof choosePassTarget>>,
+  completionPct: number,
+) {
   const completionRoll = Math.random() * 100;
-  if (completionRoll <= completionPct) return { completed: true, intercepted: false, yards: target.airYards + calcYAC(ctx, target.player, target.separation), airYards: target.airYards, caughtBy: target.player, completionRoll };
-  const qb = byName(ctx, qbName), def = byName(ctx, target.defender); const intChance = Math.max(1, (trait(def, "ballHawk") + trait(def, "readQB") - trait(qb, "accuracy") - trait(qb, "readDefense")) / 8);
-  if (Math.random() * 100 < intChance) return { completed: false, intercepted: true, yards: calcYAC(ctx, target.defender || "", target.separation), airYards: target.airYards, caughtBy: target.defender || "Defense", completionRoll };
-  return { completed: false, intercepted: false, yards: 0, airYards: target.airYards, completionRoll };
+  if (completionRoll <= completionPct)
+    return {
+      completed: true,
+      intercepted: false,
+      yards: target.airYards + calcYAC(ctx, target.player, target.separation),
+      airYards: target.airYards,
+      caughtBy: target.player,
+      completionRoll,
+    };
+  const qb = byName(ctx, qbName),
+    def = byName(ctx, target.defender);
+  const intChance = Math.max(
+    1,
+    (trait(def, "ballHawk") +
+      trait(def, "readQB") -
+      trait(qb, "accuracy") -
+      trait(qb, "readDefense")) /
+      8,
+  );
+  if (Math.random() * 100 < intChance)
+    return {
+      completed: false,
+      intercepted: true,
+      yards: calcYAC(ctx, target.defender || "", target.separation),
+      airYards: target.airYards,
+      caughtBy: target.defender || "Defense",
+      completionRoll,
+    };
+  return {
+    completed: false,
+    intercepted: false,
+    yards: 0,
+    airYards: target.airYards,
+    completionRoll,
+  };
 }
-export function passPlay(game: LeagueGame, ctx: EngineContext, options: PlayCallOptions = {}) {
-  const qb = byName(ctx, options.formation?.QB) ?? choose(byPosition(ctx, offenseTeam(game), "QB")); const qbName = playerName(qb, `${offenseTeam(game)} QB`);
-  const ttt = determineTimeToThrow(game, ctx, options); if (ttt < 0) return handleSack(game, ctx, qbName, options);
-  const target = choosePassTarget(ctx, qbName, determineSeparation(ctx, assignRoutes(game, ctx, options), ttt), options);
+export function passPlay(
+  game: LeagueGame,
+  ctx: EngineContext,
+  options: PlayCallOptions = {},
+) {
+  const qb =
+    byName(ctx, options.formation?.QB) ??
+    choose(byPosition(ctx, offenseTeam(game), "QB"));
+  const qbName = playerName(qb, `${offenseTeam(game)} QB`);
+  const ttt = determineTimeToThrow(game, ctx, options);
+  if (ttt < 0) return handleSack(game, ctx, qbName, options);
+  const target = choosePassTarget(
+    ctx,
+    qbName,
+    determineSeparation(ctx, assignRoutes(game, ctx, options), ttt),
+    options,
+  );
   if (!target) return handleSack(game, ctx, qbName, options);
-  const pct = determineCompletionPct(ctx, qbName, target).pct; const outcome = determinePassOutcome(ctx, qbName, target, pct);
-  const rawYards = outcome.intercepted ? 0 : outcome.yards; const newBall = advanceBall(game, rawYards); const td = outcome.completed && isTouchdown(game, newBall); const safety = outcome.completed && isSafety(game, newBall);
-  const tackler = outcome.completed && !td ? determineTackler(ctx, defenseTeam(game), rawYards) : outcome.intercepted ? String(outcome.caughtBy ?? "Defense") : "NA";
-  const next = nextDownDistance(game, rawYards, newBall); const result = outcome.intercepted ? "Interception" : !outcome.completed ? "Incomplete" : td ? "Touchdown" : safety ? "Safety" : next.turnover ? "TO on Downs" : rawYards >= n(game.Distance) ? "First Down" : "Normal";
-  let hs = n(game.HomeScore), as = n(game.AwayScore); if (td) { if (game.Possession === "Home") hs += 6; else as += 6; } if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
-  const possession = td || safety || next.turnover || outcome.intercepted ? switchPoss(game) : game.Possession;
-  const clock = advanceQuarter(game, clockRunoff(options.clockMode, 5, ["Touchdown", "Safety", "TO on Downs", "Interception", "Incomplete"].includes(result)));
-  const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: result === "Incomplete" ? Math.min(4, n(game.Down) + 1) : next.down, Distance: result === "Incomplete" ? game.Distance : next.distance, BallOn: result === "Incomplete" ? game.BallOn : next.ballOn, Previous: game.BallOn, Possession: possession };
-  return buildResult(game, updated, "Pass", qbName, target.player, rawYards, tackler, result, ctx.historyLength, { airyards: outcome.airYards, recoveredby: outcome.intercepted ? String(outcome.caughtBy ?? "Defense") : "" });
+  const pct = determineCompletionPct(ctx, qbName, target).pct;
+  const outcome = determinePassOutcome(ctx, qbName, target, pct);
+  const rawYards = outcome.intercepted ? 0 : outcome.yards;
+  const newBall = advanceBall(game, rawYards);
+  const td = outcome.completed && isTouchdown(game, newBall);
+  const safety = outcome.completed && isSafety(game, newBall);
+  const tackler =
+    outcome.completed && !td
+      ? determineTackler(ctx, defenseTeam(game), rawYards)
+      : outcome.intercepted
+        ? String(outcome.caughtBy ?? "Defense")
+        : "NA";
+  const next = nextDownDistance(game, rawYards, newBall);
+  const result = outcome.intercepted
+    ? "Interception"
+    : !outcome.completed
+      ? "Incomplete"
+      : td
+        ? "Touchdown"
+        : safety
+          ? "Safety"
+          : next.turnover
+            ? "TO on Downs"
+            : rawYards >= n(game.Distance)
+              ? "First Down"
+              : "Normal";
+  let hs = n(game.HomeScore),
+    as = n(game.AwayScore);
+  if (td) {
+    if (game.Possession === "Home") hs += 6;
+    else as += 6;
+  }
+  if (safety) {
+    if (game.Possession === "Home") as += 2;
+    else hs += 2;
+  }
+  const possession =
+    td || safety || next.turnover || outcome.intercepted
+      ? switchPoss(game)
+      : game.Possession;
+  const clock = advanceQuarter(
+    game,
+    clockRunoff(
+      options.clockMode,
+      5,
+      [
+        "Touchdown",
+        "Safety",
+        "TO on Downs",
+        "Interception",
+        "Incomplete",
+      ].includes(result),
+    ),
+  );
+  const updated = {
+    ...game,
+    HomeScore: hs,
+    AwayScore: as,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: result === "Incomplete" ? Math.min(4, n(game.Down) + 1) : next.down,
+    Distance: result === "Incomplete" ? game.Distance : next.distance,
+    BallOn: result === "Incomplete" ? game.BallOn : next.ballOn,
+    Previous: game.BallOn,
+    Possession: possession,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Pass",
+    qbName,
+    target.player,
+    rawYards,
+    tackler,
+    result,
+    ctx.historyLength,
+    {
+      airyards: outcome.airYards,
+      recoveredby: outcome.intercepted
+        ? String(outcome.caughtBy ?? "Defense")
+        : "",
+    },
+  );
 }

--- a/apps/web/src/components/league/gameplay/engine/playLogger.ts
+++ b/apps/web/src/components/league/gameplay/engine/playLogger.ts
@@ -2,21 +2,79 @@ import type { LeagueGame } from "../../types";
 import type { NormalizedOutcome, PlayKind } from "./types";
 import { n } from "./utils";
 
-export function determinePlayOutcome(result: string, playType: PlayKind, yards: number, receiver = "", tackler = "", recoveredBy = "", currentDown: unknown = 1): NormalizedOutcome {
-  const turnover = ["Fumble", "Interception", "TO on Downs"].includes(result) || (result === "Fumble" && recoveredBy && recoveredBy !== receiver) ? "Yes" : "";
-  const defenseResult = result === "Sack" ? "Sack" : result === "Interception" ? "Interception" : result === "Fumble" ? "Fumble" : yards < 0 ? "TFL" : "";
-  const description = result === "Sack" ? "Sack" : result || (playType === "Pass" && !receiver ? "Incomplete" : "Normal");
-  const outcome = result || (n(currentDown) === 4 && yards <= 0 ? "TO on Downs" : "Normal");
+export function determinePlayOutcome(
+  result: string,
+  playType: PlayKind,
+  yards: number,
+  receiver = "",
+  tackler = "",
+  recoveredBy = "",
+  currentDown: unknown = 1,
+): NormalizedOutcome {
+  const turnover =
+    ["Fumble", "Interception", "TO on Downs"].includes(result) ||
+    (result === "Fumble" && recoveredBy && recoveredBy !== receiver)
+      ? "Yes"
+      : "";
+  const defenseResult =
+    result === "Sack"
+      ? "Sack"
+      : result === "Interception"
+        ? "Interception"
+        : result === "Fumble"
+          ? "Fumble"
+          : yards < 0
+            ? "TFL"
+            : "";
+  const description =
+    result === "Sack"
+      ? "Sack"
+      : result || (playType === "Pass" && !receiver ? "Incomplete" : "Normal");
+  const outcome =
+    result || (n(currentDown) === 4 && yards <= 0 ? "TO on Downs" : "Normal");
   void tackler;
   return { outcome, defenseResult, turnover, description };
 }
 
 export function buildGameData(game: LeagueGame, previous: unknown) {
-  return { gameId: game.GameId, quarter: game.Qtr, time: game.Time, down: game.Down, distance: game.Distance, ballOn: game.BallOn, homeScore: game.HomeScore, awayScore: game.AwayScore, driveStart: (game as unknown as Record<string, unknown>).DriveStart, previous, possession: game.Possession, homeTimeouts: (game as unknown as Record<string, unknown>).HomeTimeouts, awayTimeouts: (game as unknown as Record<string, unknown>).AwayTimeouts };
+  return {
+    gameId: game.GameId,
+    quarter: game.Qtr,
+    time: game.Time,
+    down: game.Down,
+    distance: game.Distance,
+    ballOn: game.BallOn,
+    homeScore: game.HomeScore,
+    awayScore: game.AwayScore,
+    driveStart: (game as unknown as Record<string, unknown>).DriveStart,
+    previous,
+    possession: game.Possession,
+    homeTimeouts: (game as unknown as Record<string, unknown>).HomeTimeouts,
+    awayTimeouts: (game as unknown as Record<string, unknown>).AwayTimeouts,
+  };
 }
 
-export function logPlayToDB(prev: LeagueGame, game: LeagueGame, playtype: PlayKind, player: string, receiver: string, yards: number, tackler: string, result: string, historyLength: number, extra: Record<string, unknown> = {}) {
-  const normalized = determinePlayOutcome(result, playtype, yards, receiver, tackler, String(extra.recoveredby ?? ""), prev.Down);
+export function logPlayToDB(
+  prev: LeagueGame,
+  game: LeagueGame,
+  playtype: PlayKind,
+  player: string,
+  receiver: string,
+  yards: number,
+  tackler: string,
+  result: string,
+  historyLength: number,
+  extra: Record<string, unknown> = {},
+) {
+  const normalized = determinePlayOutcome(
+    result,
+    playtype,
+    yards,
+    receiver,
+    tackler,
+    String(extra.recoveredby ?? ""),
+    prev.Down,
+  );
   const playid = `${prev.GameId}-${Date.now()}-${historyLength + 1}`;
   return {
     gameid: prev.GameId,
@@ -32,7 +90,7 @@ export function logPlayToDB(prev: LeagueGame, game: LeagueGame, playtype: PlayKi
     receiver,
     yards,
     defensepredicted: extra.defensepredicted ?? "Run",
-    predictioncorrect: extra.predictioncorrect ?? (playtype === "Run"),
+    predictioncorrect: extra.predictioncorrect ?? playtype === "Run",
     tackler,
     result: normalized.outcome,
     defenseresult: normalized.defenseResult,
@@ -44,14 +102,37 @@ export function logPlayToDB(prev: LeagueGame, game: LeagueGame, playtype: PlayKi
     newdown: game.Down,
     newdist: game.Distance,
     newballon: game.BallOn,
-    drivestart: (prev as unknown as Record<string, unknown>).DriveStart ?? prev.BallOn,
+    drivestart:
+      (prev as unknown as Record<string, unknown>).DriveStart ?? prev.BallOn,
     homescore: game.HomeScore,
     awayscore: game.AwayScore,
     ...extra,
   };
 }
 
-export function buildResult(prev: LeagueGame, game: LeagueGame, playtype: PlayKind, player: string, receiver: string, yards: number, tackler: string, result: string, historyLength: number, extra: Record<string, unknown> = {}) {
-  const play = logPlayToDB(prev, game, playtype, player, receiver, yards, tackler, result, historyLength, extra);
+export function buildResult(
+  prev: LeagueGame,
+  game: LeagueGame,
+  playtype: PlayKind,
+  player: string,
+  receiver: string,
+  yards: number,
+  tackler: string,
+  result: string,
+  historyLength: number,
+  extra: Record<string, unknown> = {},
+) {
+  const play = logPlayToDB(
+    prev,
+    game,
+    playtype,
+    player,
+    receiver,
+    yards,
+    tackler,
+    result,
+    historyLength,
+    extra,
+  );
   return { game, play, text: `${playtype}: ${result}` };
 }

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -1,7 +1,23 @@
 import type { LeagueGame } from "../../types";
 import type { EngineContext, PlayCallOptions } from "./types";
 import { buildResult } from "./playLogger";
-import { advanceBall, advanceQuarter, byName, clockRunoff, defenseTeam, isSafety, isTouchdown, n, nextDownDistance, offenseTeam, playerName, switchPoss, teamPlayers, trait, weightedChoose } from "./utils";
+import {
+  advanceBall,
+  advanceQuarter,
+  byName,
+  clockRunoff,
+  defenseTeam,
+  isSafety,
+  isTouchdown,
+  n,
+  nextDownDistance,
+  offenseTeam,
+  playerName,
+  switchPoss,
+  teamPlayers,
+  trait,
+  weightedChoose,
+} from "./utils";
 import {
   performLineWinLoss,
   performVisionCheck,
@@ -25,14 +41,35 @@ import {
 } from "./runEngineHelper";
 
 /** Chooses the most plausible tackler after a run or pass play has ended, weighting nearby defender groups by tackling ability. It is used by `runPlay` and pass-play fumble/tackle resolution when no specific tackler was already recorded. */
-export function determineTackler(ctx: EngineContext, defense: string, yards: number) {
+export function determineTackler(
+  ctx: EngineContext,
+  defense: string,
+  yards: number,
+) {
   const defenders = teamPlayers(ctx, defense);
-  const preferred = yards <= 2 ? ["DL", "LB"] : yards <= 8 ? ["LB", "DB", "S"] : ["DB", "S", "LB"];
-  const pool = defenders.filter((p) => preferred.includes(String(p.defPos ?? "").toUpperCase())) || defenders;
-  return playerName(weightedChoose(pool.length ? pool : defenders, (p) => trait(p, "tackleChance")), "NA"); // TRAIT USED: TackleChance
+  const preferred =
+    yards <= 2
+      ? ["DL", "LB"]
+      : yards <= 8
+        ? ["LB", "DB", "S"]
+        : ["DB", "S", "LB"];
+  const pool =
+    defenders.filter((p) =>
+      preferred.includes(String(p.defPos ?? "").toUpperCase()),
+    ) || defenders;
+  return playerName(
+    weightedChoose(pool.length ? pool : defenders, (p) =>
+      trait(p, "tackleChance"),
+    ),
+    "NA",
+  ); // TRAIT USED: TackleChance
 }
 /** Resolves whether a tackle knocks the ball loose, then stubs recovery as 55% tackler / 45% runner. */
-export function fumbleCheck(ctx: EngineContext, runnerName: string, tacklerName: string) {
+export function fumbleCheck(
+  ctx: EngineContext,
+  runnerName: string,
+  tacklerName: string,
+) {
   const runner = byName(ctx, runnerName);
   const tackler = byName(ctx, tacklerName);
 
@@ -60,7 +97,11 @@ export function fumbleCheck(ctx: EngineContext, runnerName: string, tacklerName:
   };
 }
 
-export function checkForFumble(ctx: EngineContext, runnerName: string, tacklerName: string) {
+export function checkForFumble(
+  ctx: EngineContext,
+  runnerName: string,
+  tacklerName: string,
+) {
   return fumbleCheck(ctx, runnerName, tacklerName);
 }
 // ---------------------------------------------------------------------------
@@ -71,7 +112,7 @@ export function checkForFumble(ctx: EngineContext, runnerName: string, tacklerNa
 export function runPlay(
   game: LeagueGame,
   ctx: EngineContext,
-  options: PlayCallOptions = {}
+  options: PlayCallOptions = {},
 ) {
   const offense = offenseTeam(game);
   const defense = defenseTeam(game);
@@ -84,7 +125,8 @@ export function runPlay(
   const defenseFormation = options.defense ?? [];
 
   // The runner is explicitly selected by the caller when possible, then falls back to the primary back or quarterback in the formation.
-  const runnerName = options.runner ?? offenseFormation.RB1 ?? offenseFormation.QB ?? "";
+  const runnerName =
+    options.runner ?? offenseFormation.RB1 ?? offenseFormation.QB ?? "";
 
   if (!runnerName) {
     throw new Error("No runner available for run play.");
@@ -96,11 +138,15 @@ export function runPlay(
   const lineWinLossArray = performLineWinLoss(
     offenseFormation,
     defenseFormation,
-    ctx.players
+    ctx.players,
   );
 
-  const olWins = lineWinLossArray.filter((battle) => battle.winner === "OL").length;
-  const dlWins = lineWinLossArray.filter((battle) => battle.winner === "DL").length;
+  const olWins = lineWinLossArray.filter(
+    (battle) => battle.winner === "OL",
+  ).length;
+  const dlWins = lineWinLossArray.filter(
+    (battle) => battle.winner === "DL",
+  ).length;
   // More OL wins make the runner's vision target easier; more DL wins make the hole harder to find.
   const runBlockingModifier = (olWins - dlWins) * 10;
 
@@ -109,24 +155,27 @@ export function runPlay(
     runnerName,
     ctx.players,
     lineWinLossArray,
-    runBlockingModifier
+    runBlockingModifier,
   );
 
   // The lane target records the blocker who sprung the lane or the defender who created penetration.
   const runLaneTarget = pickRunLaneTarget(
     lineWinLossArray,
     visionCheck,
-    ctx.players
+    ctx.players,
   );
 
   let dlWrapResult: ReturnType<typeof performDlWrapCheck> | null = null;
   let dlSwipeResult: ReturnType<typeof performDlSwipeCheck> | null = null;
-  let fallForwardResult: ReturnType<typeof handleRunnerTackle> | null = null;    
+  let fallForwardResult: ReturnType<typeof handleRunnerTackle> | null = null;
   let dlJukeResult: ReturnType<typeof performDlJukeCheck> | null = null;
   let otherWinningDLsAfterJuke: ReturnType<typeof getOtherWinningDLs> = [];
-  let dlPursuitResult: ReturnType<typeof resolveRemainingDlPursuit> | null = null;
+  let dlPursuitResult: ReturnType<typeof resolveRemainingDlPursuit> | null =
+    null;
   let bruiserResult: ReturnType<typeof performBruiserCheck> | null = null;
-  let bruiserCarryDefenderResult: ReturnType<typeof performCarryDefenderChecks> | null = null;
+  let bruiserCarryDefenderResult: ReturnType<
+    typeof performCarryDefenderChecks
+  > | null = null;
 
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
@@ -136,7 +185,7 @@ export function runPlay(
     addYards(
       runState,
       backfieldYards,
-      `${runState.runner} fails to hit the hole and is forced into the backfield`
+      `${runState.runner} fails to hit the hole and is forced into the backfield`,
     );
 
     bruiserResult = performBruiserCheck(runState.runner, ctx.players);
@@ -145,28 +194,32 @@ export function runPlay(
       const bruiserTackler = runLaneTarget.selectedPlayer;
       runState.yards = 0;
       runState.log.push(
-        `${runState.runner} powers out of the backfield loss (roll ${bruiserResult.roll.toFixed(2)} <= ${bruiserResult.bruiserScore.toFixed(2)}%) and gets back to the line of scrimmage.`
+        `${runState.runner} powers out of the backfield loss (roll ${bruiserResult.roll.toFixed(2)} <= ${bruiserResult.bruiserScore.toFixed(2)}%) and gets back to the line of scrimmage.`,
       );
 
-      bruiserCarryDefenderResult = performCarryDefenderChecks(runState.runner, ctx.players);
+      bruiserCarryDefenderResult = performCarryDefenderChecks(
+        runState.runner,
+        ctx.players,
+      );
 
       if (bruiserCarryDefenderResult.yardsAdded > 0) {
         runState.yards += bruiserCarryDefenderResult.yardsAdded;
         runState.log.push(
-          `${runState.runner} carries ${bruiserTackler} for +${bruiserCarryDefenderResult.yardsAdded} ${bruiserCarryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`
+          `${runState.runner} carries ${bruiserTackler} for +${bruiserCarryDefenderResult.yardsAdded} ${bruiserCarryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`,
         );
       }
 
       runState.tackler = bruiserTackler;
       runState.stopped = true;
       runState.stopReason = "Bruiser Check Tackle";
-      runState.log.push(`${bruiserTackler} tackles ${runState.runner}. Reason: Bruiser Check Tackle.`);
-    }
-    else{
+      runState.log.push(
+        `${bruiserTackler} tackles ${runState.runner}. Reason: Bruiser Check Tackle.`,
+      );
+    } else {
       // The first penetrating DL gets a clean wrap attempt before the runner can choose a counter move.
       dlWrapResult = performDlWrapCheck(
         runLaneTarget.selectedPlayer,
-        ctx.players
+        ctx.players,
       );
 
       if (dlWrapResult.wrapped) {
@@ -174,20 +227,19 @@ export function runPlay(
           runState,
           dlWrapResult.defender,
           "DL Backfield Wrap",
-          ctx.players
+          ctx.players,
         );
-      } 
-      else {
+      } else {
         // If the wrap fails, the runner chooses the more natural second-chance move for the size matchup.
         const dlSecondChanceAttempt = chooseRunnerDefenderSecondChanceAttempt(
           runState.runner,
           dlWrapResult.defender,
-          ctx.players
+          ctx.players,
         );
 
         runState.log.push(
           `${runState.runner} chooses to ${dlSecondChanceAttempt.attempt.toLowerCase()} ${dlWrapResult.defender} ` +
-          `(truck chance ${dlSecondChanceAttempt.truckChance.toFixed(2)}%, size diff ${dlSecondChanceAttempt.cappedSizeDifference}).`
+            `(truck chance ${dlSecondChanceAttempt.truckChance.toFixed(2)}%, size diff ${dlSecondChanceAttempt.cappedSizeDifference}).`,
         );
 
         if (dlSecondChanceAttempt.attempt === "Truck") {
@@ -195,54 +247,53 @@ export function runPlay(
           const truckResult = performTruckAttempt(
             runState.runner,
             dlWrapResult.defender,
-            ctx.players
+            ctx.players,
           );
 
           if (!truckResult.trucked) {
             runState.log.push(
-              `${runState.runner} fails to truck ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`
+              `${runState.runner} fails to truck ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`,
             );
             fallForwardResult = handleRunnerTackle(
               runState,
               dlWrapResult.defender,
               "DL Backfield Truck Failed",
-              ctx.players
+              ctx.players,
             );
           } else {
             runState.log.push(
-              `${runState.runner} trucks ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to restart downhill.`
+              `${runState.runner} trucks ${dlWrapResult.defender} (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to restart downhill.`,
             );
 
             const otherWinningDLsAfterTruck = getOtherWinningDLs(
               lineWinLossArray,
-              dlWrapResult.defender
+              dlWrapResult.defender,
             );
             if (otherWinningDLsAfterTruck.length === 0) {
               runState.log.push(
-                `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`
+                `${runState.runner} has no remaining penetrating defensive linemen to beat after the truck and escapes toward the second level.`,
               );
             } else {
               runState.log.push(
-                `${runState.runner} trucks ${dlWrapResult.defender}, but other defensive linemen are still in pursuit.`
+                `${runState.runner} trucks ${dlWrapResult.defender}, but other defensive linemen are still in pursuit.`,
               );
 
               dlPursuitResult = resolveRemainingDlPursuit(
                 runState,
                 otherWinningDLsAfterTruck,
                 ctx.players,
-                "truck"
+                "truck",
               );
 
               console.log("DL pursuit result:", dlPursuitResult);
             }
           }
-        } 
-        else {
+        } else {
           // Juke attempts are the agility counter to a failed DL wrap.
           dlJukeResult = performDlJukeCheck(
             runState.runner,
             dlWrapResult.defender,
-            ctx.players
+            ctx.players,
           );
         }
 
@@ -252,35 +303,34 @@ export function runPlay(
             runState,
             dlWrapResult.defender,
             "DL Backfield Juke Failed",
-            ctx.players
+            ctx.players,
           );
-        } 
-        else if (dlJukeResult?.juked) {
+        } else if (dlJukeResult?.juked) {
           // After beating the first DL, only other DLs that won their matchups can continue the backfield pursuit chain.
           otherWinningDLsAfterJuke = getOtherWinningDLs(
             lineWinLossArray,
-            dlWrapResult.defender
+            dlWrapResult.defender,
           );
 
           if (otherWinningDLsAfterJuke.length === 0) {
             runState.log.push(
-              `${runState.runner} jukes ${dlWrapResult.defender} and escapes toward the second level.`
+              `${runState.runner} jukes ${dlWrapResult.defender} and escapes toward the second level.`,
             );
           } else {
             runState.log.push(
-              `${runState.runner} jukes ${dlWrapResult.defender}, but other defensive linemen are still in pursuit.`
+              `${runState.runner} jukes ${dlWrapResult.defender}, but other defensive linemen are still in pursuit.`,
             );
 
             dlPursuitResult = resolveRemainingDlPursuit(
               runState,
               otherWinningDLsAfterJuke,
               ctx.players,
-              "juke"
+              "juke",
             );
 
             console.log("DL pursuit result:", dlPursuitResult);
           }
-      }
+        }
       }
     }
   }
@@ -300,9 +350,9 @@ export function runPlay(
         runState,
         dlSwipeResult.defender,
         "DL Swipe Tackle",
-        ctx.players
+        ctx.players,
       );
-    } 
+    }
   }
 
   console.log("OL wins:", olWins);
@@ -333,7 +383,7 @@ export function runPlay(
     const accelToSecondLevelYards = getAccelToLBYards(
       byName(ctx, runState.runner),
       ctx.settings,
-      runState.log
+      runState.log,
     );
 
     const jukedBackfieldDefenders = [
@@ -353,20 +403,20 @@ export function runPlay(
             offenseFormation,
             runState.runner,
             jukedBackfieldDefenders,
-            ctx.players
+            ctx.players,
           )
         : undefined;
-    
+
     addYards(
       runState,
       accelToSecondLevelYards,
       secondLevelDefender?.position.startsWith("DL")
         ? `${runState.runner} accelerates through a short crease before meeting a defensive lineman`
-        : `${runState.runner} accelerates to the second level before meeting a linebacker`
+        : `${runState.runner} accelerates to the second level before meeting a linebacker`,
     );
 
     runState.log.push(
-      `${runState.runner} hits the hole behind ${runLaneTarget.selectedPlayer} and clears the defensive line.`
+      `${runState.runner} hits the hole behind ${runLaneTarget.selectedPlayer} and clears the defensive line.`,
     );
 
     // The second-level resolver owns all LB contact, recursive juke/truck restarts, and secondary breakaway handling.
@@ -379,7 +429,7 @@ export function runPlay(
       secondLevelDefender,
       ctx.settings,
       lineWinLossArray,
-      jukedBackfieldDefenders
+      jukedBackfieldDefenders,
     );
 
     console.log("LB second level result:", lbSecondLevelResult);
@@ -395,21 +445,76 @@ export function runPlay(
     : safety
       ? -Math.abs(n(game.BallOn) - (game.Possession === "Home" ? 0 : 100))
       : rawYards;
-  const tackler = td ? "NA" : runState.tackler || determineTackler(ctx, defense, yards);
-  const fumble = td || safety ? { fumble: false, recoveredBy: "" } : fumbleCheck(ctx, runnerName, tackler);
+  const tackler = td
+    ? "NA"
+    : runState.tackler || determineTackler(ctx, defense, yards);
+  const fumble =
+    td || safety
+      ? { fumble: false, recoveredBy: "" }
+      : fumbleCheck(ctx, runnerName, tackler);
   const next = nextDownDistance(game, yards, newBall);
   // Final result priority mirrors football outcomes: scoring, turnover events, then first down or normal play.
-  const result = td ? "Touchdown" : safety ? "Safety" : fumble.fumble ? "Fumble" : next.turnover ? "TO on Downs" : yards >= n(game.Distance) ? "First Down" : "Normal";
-  let hs = n(game.HomeScore), as = n(game.AwayScore);
-  if (td) { if (game.Possession === "Home") hs += 6; else as += 6; }
-  if (safety) { if (game.Possession === "Home") as += 2; else hs += 2; }
-  const possession = td || safety || next.turnover || (fumble.fumble && fumble.recoveredBy === tackler) ? switchPoss(game) : game.Possession;
+  const result = td
+    ? "Touchdown"
+    : safety
+      ? "Safety"
+      : fumble.fumble
+        ? "Fumble"
+        : next.turnover
+          ? "TO on Downs"
+          : yards >= n(game.Distance)
+            ? "First Down"
+            : "Normal";
+  let hs = n(game.HomeScore),
+    as = n(game.AwayScore);
+  if (td) {
+    if (game.Possession === "Home") hs += 6;
+    else as += 6;
+  }
+  if (safety) {
+    if (game.Possession === "Home") as += 2;
+    else hs += 2;
+  }
+  const possession =
+    td ||
+    safety ||
+    next.turnover ||
+    (fumble.fumble && fumble.recoveredBy === tackler)
+      ? switchPoss(game)
+      : game.Possession;
   const runner = byName(ctx, runnerName);
-  const clock = advanceQuarter(game, clockRunoff(options.clockMode, Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)), ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result))); // TRAIT USED: Speed
-  const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: next.down, Distance: next.distance, BallOn: next.ballOn, Previous: game.BallOn, DriveStart: next.turnover || td || safety ? next.ballOn : (game as unknown as Record<string, unknown>).DriveStart ?? game.BallOn, Possession: possession };
+  const clock = advanceQuarter(
+    game,
+    clockRunoff(
+      options.clockMode,
+      Math.max(3, 12 - Math.floor(trait(runner, "speed") / 15)),
+      ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result),
+    ),
+  ); // TRAIT USED: Speed
+  const updated = {
+    ...game,
+    HomeScore: hs,
+    AwayScore: as,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: next.down,
+    Distance: next.distance,
+    BallOn: next.ballOn,
+    Previous: game.BallOn,
+    DriveStart:
+      next.turnover || td || safety
+        ? next.ballOn
+        : ((game as unknown as Record<string, unknown>).DriveStart ??
+          game.BallOn),
+    Possession: possession,
+  };
 
-  const successfulTrucks = runState.log.filter((entry) => /\btrucks\b/i.test(entry)).length;
-  const successfulJukes = runState.log.filter((entry) => /\bjukes\b/i.test(entry)).length;
+  const successfulTrucks = runState.log.filter((entry) =>
+    /\btrucks\b/i.test(entry),
+  ).length;
+  const successfulJukes = runState.log.filter((entry) =>
+    /\bjukes\b/i.test(entry),
+  ).length;
   const lineMatchups = lineWinLossArray.map((battle) => ({
     slot: battle.slot,
     offensePlayer: battle.offensePlayer,
@@ -417,17 +522,28 @@ export function runPlay(
     winner: battle.winner,
   }));
 
-  return buildResult(game, updated, "Run", runnerName, "", yards, tackler, result, ctx.historyLength, {
-    recoveredby: fumble.recoveredBy,
-    runLog: runState.log,
-    stopReason: runState.stopReason ?? "",
-    lineMatchups,
-    olWins,
-    olLosses: dlWins,
-    dlWins,
-    dlLosses: olWins,
-    trucks: successfulTrucks,
-    brokenTackles: successfulTrucks,
-    jukes: successfulJukes,
-  });
+  return buildResult(
+    game,
+    updated,
+    "Run",
+    runnerName,
+    "",
+    yards,
+    tackler,
+    result,
+    ctx.historyLength,
+    {
+      recoveredby: fumble.recoveredBy,
+      runLog: runState.log,
+      stopReason: runState.stopReason ?? "",
+      lineMatchups,
+      olWins,
+      olLosses: dlWins,
+      dlWins,
+      dlLosses: olWins,
+      trucks: successfulTrucks,
+      brokenTackles: successfulTrucks,
+      jukes: successfulJukes,
+    },
+  );
 }

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -7,14 +7,23 @@ import type {
   RunSecondaryBreakawaySetting,
   RunNegativeYardageSetting,
   FrontendSettings,
-  RunPlayState
+  RunPlayState,
 } from "./types";
 
-const TEOL_SLOTS: FormationSlot[] = ["TEOL1", "TEOL2", "TEOL3", "TEOL4", "TEOL5"];
+const TEOL_SLOTS: FormationSlot[] = [
+  "TEOL1",
+  "TEOL2",
+  "TEOL3",
+  "TEOL4",
+  "TEOL5",
+];
 const CENTER_SLOT: FormationSlot = "TEOL3";
 
 /** Reads an optional frontend setting array and returns an empty list when the setting is absent. Run-yardage helpers use this to stay safe when tuning data is not loaded. */
-function settingArray<T>(settings: FrontendSettings | undefined, key: keyof FrontendSettings): T[] {
+function settingArray<T>(
+  settings: FrontendSettings | undefined,
+  key: keyof FrontendSettings,
+): T[] {
   const value = settings?.[key];
   return Array.isArray(value) ? (value as T[]) : [];
 }
@@ -33,22 +42,20 @@ export type OlDlMatchup = {
 /** Builds the offensive-line versus defensive-line battles for each trench slot. It is used by `performLineWinLoss` to decide who controls each run lane. */
 export function buildOlDlMatchups(
   offense: Partial<Record<FormationSlot, string>>,
-  defense: DefensiveAssignment[]
+  defense: DefensiveAssignment[],
 ): OlDlMatchup[] {
-  return TEOL_SLOTS
-    .map((slot) => {
-      const defender = defense.find(
-        (d) => d.align === slot && d.position.startsWith("DL")
-      );
+  return TEOL_SLOTS.map((slot) => {
+    const defender = defense.find(
+      (d) => d.align === slot && d.position.startsWith("DL"),
+    );
 
-      return {
-        slot,
-        offensePlayer: offense[slot] ?? "",
-        defensePlayer: defender?.player ?? "",
-        defensePosition: defender?.position ?? "",
-      };
-    })
-    .filter((matchup) => matchup.offensePlayer || matchup.defensePlayer);
+    return {
+      slot,
+      offensePlayer: offense[slot] ?? "",
+      defensePlayer: defender?.player ?? "",
+      defensePosition: defender?.position ?? "",
+    };
+  }).filter((matchup) => matchup.offensePlayer || matchup.defensePlayer);
 }
 
 /** Normalizes trait-name spelling and casing before reading a numeric player trait. It is the central trait accessor used by every helper in this file and by run-engine callers. */
@@ -71,7 +78,7 @@ export function trait(player: PlayerTrait | undefined, key: string): number {
 /** Looks up a player object by the display/name fields used across roster data. It is used anywhere the run engine has a player name but needs trait values. */
 export function findPlayerByName(
   players: PlayerTrait[],
-  playerName: string
+  playerName: string,
 ): PlayerTrait | undefined {
   return players.find((p) => {
     const name = String(p.name ?? p.Name ?? p.playername ?? p.PlayerName ?? "");
@@ -102,7 +109,7 @@ export type LineWinLossResult = {
 export function performLineWinLoss(
   offenseFormation: Partial<Record<FormationSlot, string>>,
   defenseFormation: DefensiveAssignment[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): LineWinLossResult[] {
   const olDlMatchups = buildOlDlMatchups(offenseFormation, defenseFormation);
 
@@ -114,7 +121,8 @@ export function performLineWinLoss(
     const dlRunStop = trait(defensivePlayer, "RunStop"); // TRAIT USED: RunStop - measures how likely this defender is to penetrate the lane.
 
     // Start the trench battle at 50/50, then shift it by the defender-minus-blocker trait gap.
-    const rawDlWinChance = 50 + ((dlRunStop/20) ** 2.8) - ((olRunBlocking/20) ** 2.8);
+    const rawDlWinChance =
+      50 + (dlRunStop / 20) ** 2.8 - (olRunBlocking / 20) ** 2.8;
 
     // Clamp the chance so great players matter without making a single matchup completely deterministic.
     const dlWinChance = Math.max(5, Math.min(95, rawDlWinChance));
@@ -153,21 +161,25 @@ export function performVisionCheck(
   runnerName: string,
   players: PlayerTrait[],
   lineWinLossArray: LineWinLossResult[],
-  runBlockingModifier: number
+  runBlockingModifier: number,
 ): VisionCheckResult {
   const runner = findPlayerByName(players, runnerName);
   const runnerVision = trait(runner, "vision"); // TRAIT USED: Vision - determines whether the runner can identify and hit the crease.
 
   // Count line wins to detect automatic outcomes and explain how blocking modifies the vision target.
-  const olWins = lineWinLossArray.filter((battle) => battle.winner === "OL").length;
-  const dlWins = lineWinLossArray.filter((battle) => battle.winner === "DL").length;
+  const olWins = lineWinLossArray.filter(
+    (battle) => battle.winner === "OL",
+  ).length;
+  const dlWins = lineWinLossArray.filter(
+    (battle) => battle.winner === "DL",
+  ).length;
   const totalBattles = lineWinLossArray.length;
 
   const allOlWon = totalBattles > 0 && olWins === totalBattles;
   const allDlWon = totalBattles > 0 && dlWins === totalBattles;
 
   // Vision starts from the runner trait plus the line result; the clamp keeps the target in percent-roll bounds.
-  const rawVisionTarget = ((runnerVision * 0.19) + 75) + runBlockingModifier;
+  const rawVisionTarget = runnerVision * 0.19 + 75 + runBlockingModifier;
 
   const visionTarget = Math.max(0, Math.min(100, rawVisionTarget));
 
@@ -231,17 +243,21 @@ export type RunLaneTargetResult = {
 
 /** Chooses one candidate proportionally to its trait value. Lane and defender selection helpers use it when several successful blockers or defenders could become the focal point. */
 function weightedPick<T extends { traitValue: number }>(
-  candidates: T[]
+  candidates: T[],
 ): { selected: T; totalWeight: number; roll: number } {
-  const validCandidates = candidates.filter((candidate) => candidate.traitValue > 0);
+  const validCandidates = candidates.filter(
+    (candidate) => candidate.traitValue > 0,
+  );
 
   const totalWeight = validCandidates.reduce(
     (sum, candidate) => sum + candidate.traitValue,
-    0
+    0,
   );
 
   if (totalWeight <= 0 || validCandidates.length === 0) {
-    throw new Error("weightedPick was called with no valid weighted candidates.");
+    throw new Error(
+      "weightedPick was called with no valid weighted candidates.",
+    );
   }
 
   const roll = Math.random() * totalWeight;
@@ -271,7 +287,7 @@ function weightedPick<T extends { traitValue: number }>(
 export function pickRunLaneTarget(
   lineWinLossArray: LineWinLossResult[],
   visionCheck: VisionCheckResult,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): RunLaneTargetResult {
   const visionPassed =
     visionCheck.result === "Auto Release" || visionCheck.result === "Hit Hole";
@@ -335,7 +351,7 @@ export function createRunPlayState(runner: string): RunPlayState {
 export function addYards(
   state: RunPlayState,
   yards: number,
-  reason: string
+  reason: string,
 ): RunPlayState {
   state.yards += yards;
   state.log.push(`${reason}: ${yards >= 0 ? "+" : ""}${yards} yards.`);
@@ -346,7 +362,7 @@ export function addYards(
 export function stopRun(
   state: RunPlayState,
   tackler: string,
-  reason: string
+  reason: string,
 ): RunPlayState {
   state.tackler = tackler;
   state.stopped = true;
@@ -354,7 +370,6 @@ export function stopRun(
   state.log.push(`${tackler} stops ${state.runner}. Reason: ${reason}.`);
   return state;
 }
-
 
 export type RunnerDefenderSecondChanceAttempt = {
   attempt: "Juke" | "Truck";
@@ -368,7 +383,7 @@ export type RunnerDefenderSecondChanceAttempt = {
 export function chooseRunnerDefenderSecondChanceAttempt(
   runnerName: string,
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): RunnerDefenderSecondChanceAttempt {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
@@ -386,7 +401,6 @@ export function chooseRunnerDefenderSecondChanceAttempt(
   };
 }
 
-
 export type TruckAttemptResult = {
   runner: string;
   defender: string;
@@ -401,14 +415,15 @@ export type TruckAttemptResult = {
 export function performTruckAttempt(
   runnerName: string,
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): TruckAttemptResult {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
   const runnerPower = trait(runner, "size") + trait(runner, "strength"); // TRAIT USED: Size TRAIT USED: Strength
   const defenderPower = trait(defender, "size") + trait(defender, "strength"); // TRAIT USED: Size TRAIT USED: Strength
   const totalPower = runnerPower + defenderPower;
-  const truckChance = totalPower > 0 ? (runnerPower / (totalPower + 100)) * 100 : 0;
+  const truckChance =
+    totalPower > 0 ? (runnerPower / (totalPower + 100)) * 100 : 0;
   const roll = Math.random() * 100;
 
   return {
@@ -437,14 +452,14 @@ export type TruckOrJukeAccelerationResult = {
 export function performPostTruckorJukeAccelerationCheck(
   runnerName: string,
   players: PlayerTrait[],
-  checkType: PostContactAccelerationCheckType
+  checkType: PostContactAccelerationCheckType,
 ): TruckOrJukeAccelerationResult {
   const runner = findPlayerByName(players, runnerName);
   const runnerAcceleration = trait(runner, "acceleration"); // TRAIT USED: Acceleration
   const accelPastChance =
     checkType === "juke"
       ? runnerAcceleration
-      : ((runnerAcceleration / 9) ** 2) / 2;
+      : (runnerAcceleration / 9) ** 2 / 2;
   const roll = Math.random() * 100;
 
   return {
@@ -476,21 +491,23 @@ export type DlSwipeResult = {
 export function performDlSwipeCheck(
   lineWinLossArray: LineWinLossResult[],
   runLaneTarget: RunLaneTargetResult,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DlSwipeResult {
   const matchup = lineWinLossArray.find(
-    (battle) => battle.slot === runLaneTarget.selectedSlot
+    (battle) => battle.slot === runLaneTarget.selectedSlot,
   );
 
   if (!matchup) {
-    throw new Error(`No OL/DL matchup found for slot ${runLaneTarget.selectedSlot}.`);
+    throw new Error(
+      `No OL/DL matchup found for slot ${runLaneTarget.selectedSlot}.`,
+    );
   }
 
   const defensivePlayer = findPlayerByName(players, matchup.defensePlayer);
 
   const dlTackling = trait(defensivePlayer, "tackling"); // TRAIT USED: Tackling
 
-  const swipeScore = ((dlTackling / 17) ** 2) / 2;
+  const swipeScore = (dlTackling / 17) ** 2 / 2;
 
   const roll = Math.random() * 100;
 
@@ -521,14 +538,14 @@ export type FallForwardResult = {
 /** Gives a tackled runner a chance to fall forward for an extra yard. Tackle handlers use it when the runner is brought down by DL-style contact. */
 export function performFallForwardCheck(
   runnerName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): FallForwardResult {
   const runner = findPlayerByName(players, runnerName);
 
   const runnerSize = trait(runner, "size"); // TRAIT USED: Size
   const runnerStrength = trait(runner, "strength"); // TRAIT USED: Strength
 
-  const fallForwardScore = (((runnerSize + runnerStrength) / 20) ** 2);
+  const fallForwardScore = ((runnerSize + runnerStrength) / 20) ** 2;
 
   const roll = Math.random() * 100;
 
@@ -545,7 +562,6 @@ export function performFallForwardCheck(
   };
 }
 
-
 export type BruiserCheckResult = {
   runner: string;
   runnerSize: number;
@@ -558,13 +574,13 @@ export type BruiserCheckResult = {
 /** Gives a powerful runner a chance to erase a negative-yardage result before normal backfield contact is resolved. */
 export function performBruiserCheck(
   runnerName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): BruiserCheckResult {
   const runner = findPlayerByName(players, runnerName);
 
   const runnerSize = trait(runner, "size"); // TRAIT USED: Size
   const runnerStrength = trait(runner, "strength"); // TRAIT USED: Strength
-  const bruiserScore = (((runnerSize + runnerStrength) / 2) / 21) ** 2.7;
+  const bruiserScore = ((runnerSize + runnerStrength) / 2 / 21) ** 2.7;
   const roll = Math.random() * 100;
 
   return {
@@ -589,7 +605,7 @@ export type CarryDefenderResult = {
 /** Gives a wrapped runner up to two extra yards for carrying a defender. Linebacker tackle handling uses it to model power through contact. */
 export function performCarryDefenderChecks(
   runnerName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): CarryDefenderResult {
   const runner = findPlayerByName(players, runnerName);
 
@@ -614,14 +630,14 @@ export function handleRunnerTackle(
   state: RunPlayState,
   tackler: string,
   reason: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): FallForwardResult {
   const fallForwardResult = performFallForwardCheck(state.runner, players);
 
   if (fallForwardResult.succeeded) {
     state.yards += fallForwardResult.yardsAdded;
     state.log.push(
-      `${state.runner} falls forward for +${fallForwardResult.yardsAdded} yard.`
+      `${state.runner} falls forward for +${fallForwardResult.yardsAdded} yard.`,
     );
   }
 
@@ -638,14 +654,14 @@ export function handleLbWrapTackle(
   state: RunPlayState,
   tackler: string,
   reason: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): CarryDefenderResult {
   const carryDefenderResult = performCarryDefenderChecks(state.runner, players);
 
   if (carryDefenderResult.yardsAdded > 0) {
     state.yards += carryDefenderResult.yardsAdded;
     state.log.push(
-      `${state.runner} carries ${tackler} for +${carryDefenderResult.yardsAdded} extra ${carryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`
+      `${state.runner} carries ${tackler} for +${carryDefenderResult.yardsAdded} extra ${carryDefenderResult.yardsAdded === 1 ? "yard" : "yards"}.`,
     );
   }
 
@@ -662,17 +678,21 @@ export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-
 /** Rolls backfield loss yardage from the configured negative-yardage table. Falls back to the old -5 to -1 range when settings are unavailable. */
 export function getBackfieldYards(
   settings: FrontendSettings | undefined,
-  modLog?: string[]
+  modLog?: string[],
 ): number {
-  const negativeYardageSettings = settingArray<RunNegativeYardageSetting>(settings, "negativeYardage");
+  const negativeYardageSettings = settingArray<RunNegativeYardageSetting>(
+    settings,
+    "negativeYardage",
+  );
 
   if (!negativeYardageSettings.length) {
     const fallbackYards = randomInt(-5, -1);
-    modLog?.push(`Yard ${fallbackYards} Backfield loss fallback (negative yardage table missing)`);
+    modLog?.push(
+      `Yard ${fallbackYards} Backfield loss fallback (negative yardage table missing)`,
+    );
     return fallbackYards;
   }
 
@@ -684,8 +704,13 @@ export function getBackfieldYards(
     if (roll <= cumulative) {
       const minYards = Number(range.minYards) || 0;
       const maxYards = Number(range.maxYards) || minYards;
-      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
-      modLog?.push(`Yard ${yards} Backfield loss (${range.label}, roll ${roll.toFixed(2)})`);
+      const yards = randomInt(
+        Math.min(minYards, maxYards),
+        Math.max(minYards, maxYards),
+      );
+      modLog?.push(
+        `Yard ${yards} Backfield loss (${range.label}, roll ${roll.toFixed(2)})`,
+      );
       return yards;
     }
   }
@@ -693,8 +718,13 @@ export function getBackfieldYards(
   const fallback = negativeYardageSettings[negativeYardageSettings.length - 1];
   const minYards = Number(fallback.minYards) || 0;
   const maxYards = Number(fallback.maxYards) || minYards;
-  const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
-  modLog?.push(`Yard ${yards} Backfield loss (${fallback.label}, capped roll ${roll.toFixed(2)})`);
+  const yards = randomInt(
+    Math.min(minYards, maxYards),
+    Math.max(minYards, maxYards),
+  );
+  modLog?.push(
+    `Yard ${yards} Backfield loss (${fallback.label}, capped roll ${roll.toFixed(2)})`,
+  );
   return yards;
 }
 
@@ -703,31 +733,41 @@ export function getAccelToLBYards(
   runner: PlayerTrait | undefined,
   settings: FrontendSettings | undefined,
   modLog?: string[],
-  type?: string
+  type?: string,
 ) {
   const baseRoll = Math.random() * 100;
   const acceleration = trait(runner, "acceleration"); // TRAIT USED: Acceleration
   const vision = trait(runner, "vision"); // TRAIT USED: Vision
-  const accelerationMod = ((acceleration / 10) ** 2) / 12;
+  const accelerationMod = (acceleration / 10) ** 2 / 12;
   //For only the very first acceltoLB should vision be considered, otherwise:
-  const recursiveAccelerationMod = ((acceleration / 10) ** 2) / 9;
-  const visionMod = (((vision/10)**2)/12);
+  const recursiveAccelerationMod = (acceleration / 10) ** 2 / 9;
+  const visionMod = (vision / 10) ** 2 / 12;
 
   let adjustedRoll = Math.min(100, baseRoll + accelerationMod + visionMod);
-  if(type == "restart"){
+  if (type == "restart") {
     adjustedRoll = Math.min(100, baseRoll + recursiveAccelerationMod);
   }
 
   let cumulative = 0;
-  const accelToLBSettings = settingArray<RunAccelToLBSetting>(settings, "accelToLBYards");
+  const accelToLBSettings = settingArray<RunAccelToLBSetting>(
+    settings,
+    "accelToLBYards",
+  );
   const yardsForRange = (range: RunAccelToLBSetting | undefined) => {
     if (!range) return 0;
     const legacyYards = Number(range.yards);
-    const minYards = Number.isFinite(Number(range.minYards)) ? Number(range.minYards) : legacyYards;
-    const maxYards = Number.isFinite(Number(range.maxYards)) ? Number(range.maxYards) : minYards;
+    const minYards = Number.isFinite(Number(range.minYards))
+      ? Number(range.minYards)
+      : legacyYards;
+    const maxYards = Number.isFinite(Number(range.maxYards))
+      ? Number(range.maxYards)
+      : minYards;
 
     if (!Number.isFinite(minYards) || !Number.isFinite(maxYards)) return 0;
-    return randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+    return randomInt(
+      Math.min(minYards, maxYards),
+      Math.max(minYards, maxYards),
+    );
   };
 
   for (const range of accelToLBSettings) {
@@ -735,7 +775,7 @@ export function getAccelToLBYards(
     if (adjustedRoll <= cumulative) {
       const yards = yardsForRange(range);
       modLog?.push(
-        `Yard +${yards} Accel to LB (${range.label}, roll ${adjustedRoll.toFixed(2)} = ${baseRoll.toFixed(2)}${type === "restart" ? ` + ${recursiveAccelerationMod.toFixed(2)} Accel` : ` + ${accelerationMod.toFixed(2)} Accel + ${visionMod.toFixed(2)} Vision`})`
+        `Yard +${yards} Accel to LB (${range.label}, roll ${adjustedRoll.toFixed(2)} = ${baseRoll.toFixed(2)}${type === "restart" ? ` + ${recursiveAccelerationMod.toFixed(2)} Accel` : ` + ${accelerationMod.toFixed(2)} Accel + ${visionMod.toFixed(2)} Vision`})`,
       );
       return yards;
     }
@@ -745,7 +785,7 @@ export function getAccelToLBYards(
   const fallbackYards = yardsForRange(fallbackRange);
   if (fallbackYards) {
     modLog?.push(
-      `Yard +${fallbackYards} Accel to LB (${fallbackRange?.label ?? "fallback"}, capped roll ${adjustedRoll.toFixed(2)})`
+      `Yard +${fallbackYards} Accel to LB (${fallbackRange?.label ?? "fallback"}, capped roll ${adjustedRoll.toFixed(2)})`,
     );
   }
   return fallbackYards;
@@ -755,7 +795,7 @@ export function getAccelToLBYards(
 export function getSecondarySpeedYards(
   runner: PlayerTrait | undefined,
   settings: FrontendSettings | undefined,
-  modLog?: string[]
+  modLog?: string[],
 ) {
   //CHANGE: baseroll should be a decimal 0 - 100
   const baseRoll = Math.random() * 100;
@@ -765,18 +805,24 @@ export function getSecondarySpeedYards(
 
   let maxYardageMod = 0;
   let cumulative = 0;
-  const secondarySpeedSettings = settingArray<RunSecondarySpeedSetting>(settings, "secondarySpeedYards");
+  const secondarySpeedSettings = settingArray<RunSecondarySpeedSetting>(
+    settings,
+    "secondarySpeedYards",
+  );
   for (const range of secondarySpeedSettings) {
     cumulative += Number(range.percentage) || 0;
     if (adjustedRoll <= cumulative) {
-      if(range.label == 'speed_lvl2_4'){
+      if (range.label == "speed_lvl2_4") {
         maxYardageMod = Math.floor((speed / 40) ** 2); //TRAIT USED: Speed
       }
       const minYards = Number(range.minYards) || 0;
       const maxYards = Number(range.maxYards + maxYardageMod) || minYards;
-      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+      const yards = randomInt(
+        Math.min(minYards, maxYards),
+        Math.max(minYards, maxYards),
+      );
       modLog?.push(
-        `Yard +${yards} Secondary Speed (roll ${adjustedRoll.toFixed(2)} = ${baseRoll} + ${speedMod.toFixed(2)})`
+        `Yard +${yards} Secondary Speed (roll ${adjustedRoll.toFixed(2)} = ${baseRoll} + ${speedMod.toFixed(2)})`,
       );
       return yards;
     }
@@ -786,9 +832,12 @@ export function getSecondarySpeedYards(
   if (fallback) {
     const minYards = Number(fallback.minYards) || 0;
     const maxYards = Number(fallback.maxYards) || minYards;
-    const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+    const yards = randomInt(
+      Math.min(minYards, maxYards),
+      Math.max(minYards, maxYards),
+    );
     modLog?.push(
-      `Yard +${yards} Secondary Speed (capped roll ${adjustedRoll.toFixed(2)})`
+      `Yard +${yards} Secondary Speed (capped roll ${adjustedRoll.toFixed(2)})`,
     );
     return yards;
   }
@@ -801,54 +850,66 @@ function addSecondarySpeedYards(
   runState: RunPlayState,
   players: PlayerTrait[],
   settings: FrontendSettings | undefined,
-  defenseFormation: DefensiveAssignment[] = []
+  defenseFormation: DefensiveAssignment[] = [],
 ) {
   const secondarySpeedYards = getSecondarySpeedYards(
     findPlayerByName(players, runState.runner),
     settings,
-    runState.log
+    runState.log,
   );
   if (secondarySpeedYards > 0) {
     addYards(
       runState,
       secondarySpeedYards,
-      `${runState.runner} uses speed in the secondary before pursuit can close`
+      `${runState.runner} uses speed in the secondary before pursuit can close`,
     );
   }
 
-  const pursuitResult = resolveSecondaryPursuit(runState, defenseFormation, players);
+  const pursuitResult = resolveSecondaryPursuit(
+    runState,
+    defenseFormation,
+    players,
+  );
   if (pursuitResult?.escaped) {
     addSecondaryBreakawayYards(runState, players, settings);
     tackleByFastestSecondaryDefender(runState, defenseFormation, players);
   }
 }
 
-
 /** Rolls true breakaway yardage after the runner has escaped the initial secondary DB/LB chase. A separate speed check determines whether the speed modifier applies to the yardage-bucket roll. */
 export function getSecondaryBreakawayYards(
   runner: PlayerTrait | undefined,
   settings: FrontendSettings | undefined,
-  modLog?: string[]
+  modLog?: string[],
 ) {
   const speed = trait(runner, "speed"); // TRAIT USED: Speed
   const speedModifier = (speed / 18) ** 2;
   //CHANGE all rolls to be decimal 0-100
-  const modifierChance = ((speed / 15) ** 2);
+  const modifierChance = (speed / 15) ** 2;
   const modifierRoll = Math.random() * 100;
   const modifierApplied = modifierRoll <= modifierChance;
   const baseRoll = Math.random() * 100;
-  const adjustedRoll = Math.min(100, baseRoll + (modifierApplied ? speedModifier : 0));
+  const adjustedRoll = Math.min(
+    100,
+    baseRoll + (modifierApplied ? speedModifier : 0),
+  );
 
   let cumulative = 0;
-  const breakawaySettings = settingArray<RunSecondaryBreakawaySetting>(settings, "secondaryBreakawayYards");
+  const breakawaySettings = settingArray<RunSecondaryBreakawaySetting>(
+    settings,
+    "secondaryBreakawayYards",
+  );
   for (const range of breakawaySettings) {
     cumulative += Number(range.percentage) || 0;
     if (adjustedRoll <= cumulative) {
       const minYards = Number(range.minYards) || 0;
       const maxYards = Number(range.maxYards) || minYards;
-      const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+      const yards = randomInt(
+        Math.min(minYards, maxYards),
+        Math.max(minYards, maxYards),
+      );
       modLog?.push(
-        `Yard +${yards} Breakaway (roll ${adjustedRoll.toFixed(2)} = ${baseRoll}${modifierApplied ? ` + ${speedModifier.toFixed(2)} Speed` : ""}; speed bonus roll ${modifierRoll} <= ${modifierChance.toFixed(2)} ${modifierApplied ? "applied" : "failed"})`
+        `Yard +${yards} Breakaway (roll ${adjustedRoll.toFixed(2)} = ${baseRoll}${modifierApplied ? ` + ${speedModifier.toFixed(2)} Speed` : ""}; speed bonus roll ${modifierRoll} <= ${modifierChance.toFixed(2)} ${modifierApplied ? "applied" : "failed"})`,
       );
       return yards;
     }
@@ -858,15 +919,18 @@ export function getSecondaryBreakawayYards(
   if (fallback) {
     const minYards = Number(fallback.minYards) || 0;
     const maxYards = Number(fallback.maxYards) || minYards;
-    const yards = randomInt(Math.min(minYards, maxYards), Math.max(minYards, maxYards));
+    const yards = randomInt(
+      Math.min(minYards, maxYards),
+      Math.max(minYards, maxYards),
+    );
     modLog?.push(
-      `Yard +${yards} Breakaway (capped roll ${adjustedRoll.toFixed(2)}; speed bonus ${modifierApplied ? "applied" : "failed"})`
+      `Yard +${yards} Breakaway (capped roll ${adjustedRoll.toFixed(2)}; speed bonus ${modifierApplied ? "applied" : "failed"})`,
     );
     return yards;
   }
 
   modLog?.push(
-    `Breakaway yardage skipped because no Breakaway_ settings were loaded (roll ${adjustedRoll.toFixed(2)}).`
+    `Breakaway yardage skipped because no Breakaway_ settings were loaded (roll ${adjustedRoll.toFixed(2)}).`,
   );
   return 0;
 }
@@ -874,18 +938,18 @@ export function getSecondaryBreakawayYards(
 function addSecondaryBreakawayYards(
   runState: RunPlayState,
   players: PlayerTrait[],
-  settings: FrontendSettings | undefined
+  settings: FrontendSettings | undefined,
 ) {
   const breakawayYards = getSecondaryBreakawayYards(
     findPlayerByName(players, runState.runner),
     settings,
-    runState.log
+    runState.log,
   );
   if (breakawayYards > 0) {
     addYards(
       runState,
       breakawayYards,
-      `${runState.runner} breaks away after escaping the initial secondary pursuit`
+      `${runState.runner} breaks away after escaping the initial secondary pursuit`,
     );
   }
 }
@@ -893,16 +957,17 @@ function addSecondaryBreakawayYards(
 function tackleByFastestSecondaryDefender(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ) {
   if (runState.stopped) return;
 
   const fastestDefender = defenseFormation
-    .filter((assignment) =>
-      assignment.player &&
-      (assignment.position.startsWith("DB") ||
-        assignment.position.startsWith("LB") ||
-        assignment.position.startsWith("S"))
+    .filter(
+      (assignment) =>
+        assignment.player &&
+        (assignment.position.startsWith("DB") ||
+          assignment.position.startsWith("LB") ||
+          assignment.position.startsWith("S")),
     )
     .map((assignment) => ({
       assignment,
@@ -916,10 +981,10 @@ function tackleByFastestSecondaryDefender(
     runState,
     fastestDefender.assignment.player,
     "Breakaway End Fastest Secondary Defender",
-    players
+    players,
   );
   runState.log.push(
-    `${fastestDefender.assignment.player} makes the automatic tackle after the breakaway as the fastest DB/LB/S on the field.`
+    `${fastestDefender.assignment.player} makes the automatic tackle after the breakaway as the fastest DB/LB/S on the field.`,
   );
 }
 
@@ -938,16 +1003,17 @@ export type SecondaryPursuitResult = {
 export function resolveSecondaryPursuit(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): SecondaryPursuitResult | undefined {
   if (runState.stopped) return undefined;
 
   const pursuitCandidates = defenseFormation
-    .filter((assignment) =>
-      assignment.player &&
-      (assignment.position.startsWith("LB") ||
-        assignment.position.startsWith("DB") ||
-        assignment.position.startsWith("S"))
+    .filter(
+      (assignment) =>
+        assignment.player &&
+        (assignment.position.startsWith("LB") ||
+          assignment.position.startsWith("DB") ||
+          assignment.position.startsWith("S")),
     )
     .map((assignment) => {
       const player = findPlayerByName(players, assignment.player);
@@ -962,7 +1028,7 @@ export function resolveSecondaryPursuit(
 
   const totalPursuitScore = pursuitCandidates.reduce(
     (sum, candidate) => sum + candidate.pursuitScore,
-    0
+    0,
   );
 
   if (totalPursuitScore <= 0) return undefined;
@@ -975,7 +1041,10 @@ export function resolveSecondaryPursuit(
       return pursuitRoll <= runningScore;
     }) ?? pursuitCandidates[pursuitCandidates.length - 1];
 
-  const runnerSpeed = trait(findPlayerByName(players, runState.runner), "speed");
+  const runnerSpeed = trait(
+    findPlayerByName(players, runState.runner),
+    "speed",
+  );
   const chaserSpeed = selectedCandidate.speed;
   const rawSpeedCheck = 25 + runnerSpeed - chaserSpeed;
   const speedCheck = Math.max(3, Math.min(65, rawSpeedCheck));
@@ -985,17 +1054,17 @@ export function resolveSecondaryPursuit(
 
   if (escaped) {
     runState.log.push(
-      `${runState.runner} outruns ${chaser} in secondary pursuit (roll ${speedRoll} < ${speedCheck.toFixed(2)}%).`
+      `${runState.runner} outruns ${chaser} in secondary pursuit (roll ${speedRoll} < ${speedCheck.toFixed(2)}%).`,
     );
   } else {
     handleRunnerTackle(
       runState,
       chaser,
       "Secondary Pursuit Speed Check",
-      players
+      players,
     );
     runState.log.push(
-      `${chaser} catches ${runState.runner} in secondary pursuit (roll ${speedRoll} >= ${speedCheck.toFixed(2)}%).`
+      `${chaser} catches ${runState.runner} in secondary pursuit (roll ${speedRoll} >= ${speedCheck.toFixed(2)}%).`,
     );
   }
 
@@ -1025,7 +1094,7 @@ export type DlWrapResult = DefenderWrapResult;
 /** Checks whether any named defender wraps the runner cleanly based on tackling. DL and LB wrap wrappers both delegate here. */
 export function performDefenderWrapCheck(
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DefenderWrapResult {
   const defender = findPlayerByName(players, defenderName);
 
@@ -1050,11 +1119,10 @@ export function performDefenderWrapCheck(
 /** Names the generic wrap check as a defensive-line wrap for backfield readability. `runPlay` and DL pursuit call it during DL contact. */
 export function performDlWrapCheck(
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DlWrapResult {
   return performDefenderWrapCheck(defenderName, players);
 }
-
 
 type RunLaneSide = "left" | "center" | "right";
 
@@ -1081,10 +1149,12 @@ function lbPositionNumber(assignment: DefensiveAssignment): number {
 export function pickLinebackerForRunLane(
   defenseFormation: DefensiveAssignment[],
   selectedSlot: FormationSlot,
-  runnerSlot?: FormationSlot
+  runnerSlot?: FormationSlot,
 ): DefensiveAssignment | undefined {
   const linebackers = defenseFormation
-    .filter((assignment) => assignment.player && assignment.position.startsWith("LB"))
+    .filter(
+      (assignment) => assignment.player && assignment.position.startsWith("LB"),
+    )
     .sort((a, b) => lbPositionNumber(a) - lbPositionNumber(b));
 
   if (linebackers.length === 0) return undefined;
@@ -1094,28 +1164,30 @@ export function pickLinebackerForRunLane(
 
   if (side === "center") {
     return (
-      linebackers.find((assignment) => runnerSlot && assignment.align === runnerSlot) ??
-      linebackers.find((assignment) => assignmentSide(assignment) === "center") ??
+      linebackers.find(
+        (assignment) => runnerSlot && assignment.align === runnerSlot,
+      ) ??
+      linebackers.find(
+        (assignment) => assignmentSide(assignment) === "center",
+      ) ??
       linebackers[0]
     );
   }
 
   const sameSideLinebacker = linebackers.find(
-    (assignment) => assignmentSide(assignment) === side
+    (assignment) => assignmentSide(assignment) === side,
   );
 
   if (sameSideLinebacker) return sameSideLinebacker;
 
-  return side === "left"
-    ? linebackers[0]
-    : linebackers[linebackers.length - 1];
+  return side === "left" ? linebackers[0] : linebackers[linebackers.length - 1];
 }
 
 /** Finds defensive linemen adjacent to the chosen lane who can still chase. Short-acceleration pressure uses these DLs when the runner has not created enough space. */
 export function getAdjacentDefensiveLinemenForRunLane(
   lineWinLossArray: LineWinLossResult[],
   selectedSlot: FormationSlot,
-  jukedDefenders: string[] = []
+  jukedDefenders: string[] = [],
 ): DefensiveAssignment[] {
   const selectedIndex = TEOL_SLOTS.indexOf(selectedSlot);
   if (selectedIndex < 0) return [];
@@ -1130,8 +1202,8 @@ export function getAdjacentDefensiveLinemenForRunLane(
       Boolean(
         battle?.defensePlayer &&
         battle.defensePosition.startsWith("DL") &&
-        !jukedDefenderSet.has(battle.defensePlayer)
-      )
+        !jukedDefenderSet.has(battle.defensePlayer),
+      ),
     )
     .map((battle) => ({
       position: battle.defensePosition,
@@ -1143,7 +1215,7 @@ export function getAdjacentDefensiveLinemenForRunLane(
 /** Chooses among eligible defenders by defensive star power. Short-acceleration and second-level restart logic use this when several defenders can challenge. */
 export function weightedPickDefenderByDefStars(
   defenders: DefensiveAssignment[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DefensiveAssignment | undefined {
   const weightedDefenders = defenders
     .map((defender) => {
@@ -1157,7 +1229,10 @@ export function weightedPickDefenderByDefStars(
 
   if (weightedDefenders.length === 0) return defenders[0];
 
-  const totalWeight = weightedDefenders.reduce((sum, { weight }) => sum + weight, 0);
+  const totalWeight = weightedDefenders.reduce(
+    (sum, { weight }) => sum + weight,
+    0,
+  );
   const roll = Math.random() * totalWeight;
   let runningTotal = 0;
 
@@ -1177,23 +1252,26 @@ export function pickShortAccelerationDefender(
   offenseFormation: Partial<Record<FormationSlot, string>>,
   runnerName: string,
   jukedDefenders: string[],
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DefensiveAssignment | undefined {
-  const runnerSlot = (Object.entries(offenseFormation) as [FormationSlot, string | undefined][])
-    .find(([, player]) => player === runnerName)?.[0];
+  const runnerSlot = (
+    Object.entries(offenseFormation) as [FormationSlot, string | undefined][]
+  ).find(([, player]) => player === runnerName)?.[0];
   const beatenDefenderSet = new Set(jukedDefenders.filter(Boolean));
   const linebacker = pickLinebackerForRunLane(
-    defenseFormation.filter((assignment) => !beatenDefenderSet.has(assignment.player)),
+    defenseFormation.filter(
+      (assignment) => !beatenDefenderSet.has(assignment.player),
+    ),
     runLaneTarget.selectedSlot,
-    runnerSlot
+    runnerSlot,
   );
   const adjacentDefensiveLinemen = getAdjacentDefensiveLinemenForRunLane(
     lineWinLossArray,
     runLaneTarget.selectedSlot,
-    jukedDefenders
+    jukedDefenders,
   );
   const candidates = [linebacker, ...adjacentDefensiveLinemen].filter(
-    (defender): defender is DefensiveAssignment => Boolean(defender?.player)
+    (defender): defender is DefensiveAssignment => Boolean(defender?.player),
   );
 
   return weightedPickDefenderByDefStars(candidates, players);
@@ -1204,13 +1282,13 @@ function getRemainingSecondLevelDefenders(
   defenseFormation: DefensiveAssignment[],
   lineWinLossArray: LineWinLossResult[],
   beatenDefenders: Set<string>,
-  includeDefensiveLinemen: boolean
+  includeDefensiveLinemen: boolean,
 ): DefensiveAssignment[] {
   const remainingLinebackers = defenseFormation.filter(
     (assignment) =>
       assignment.player &&
       assignment.position.startsWith("LB") &&
-      !beatenDefenders.has(assignment.player)
+      !beatenDefenders.has(assignment.player),
   );
 
   const remainingDefensiveLinemen = includeDefensiveLinemen
@@ -1219,7 +1297,7 @@ function getRemainingSecondLevelDefenders(
           (battle) =>
             battle.defensePlayer &&
             battle.defensePosition.startsWith("DL") &&
-            !beatenDefenders.has(battle.defensePlayer)
+            !beatenDefenders.has(battle.defensePlayer),
         )
         .map((battle) => ({
           position: battle.defensePosition,
@@ -1268,7 +1346,7 @@ export type LbJukeResult = {
 export function performLbJukeCheck(
   runnerName: string,
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): LbJukeResult {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
@@ -1276,8 +1354,8 @@ export function performLbJukeCheck(
   const runnerJukeTrait = trait(runner, "juke"); // TRAIT USED: Juke
   const defenderTacklingTrait = trait(defender, "tackling"); // TRAIT USED: Tackling
 
-  const rbJukeScore = 15 + ((runnerJukeTrait / 8) ** 2) / 3;
-  const lbDefendScore = ((defenderTacklingTrait / 15) ** 2) / 2;
+  const rbJukeScore = 15 + (runnerJukeTrait / 8) ** 2 / 3;
+  const lbDefendScore = (defenderTacklingTrait / 15) ** 2 / 2;
   const targetToBeat = rbJukeScore - lbDefendScore;
   const roll = Math.random() * 100;
 
@@ -1294,7 +1372,6 @@ export function performLbJukeCheck(
   };
 }
 
-
 /** Runs the linebacker/second-level phase, including wraps, jukes, trucks, recursive restarts, and secondary entry. `runPlay` calls this after the runner clears or survives the defensive line. */
 export function resolveLinebackerSecondLevel(
   runState: RunPlayState,
@@ -1305,41 +1382,50 @@ export function resolveLinebackerSecondLevel(
   selectedDefender?: DefensiveAssignment,
   settings?: FrontendSettings,
   lineWinLossArray: LineWinLossResult[] = [],
-  beatenDefenders: string[] = []
+  beatenDefenders: string[] = [],
 ): LbSecondLevelResult {
-  const runnerSlot = (Object.entries(offenseFormation) as [FormationSlot, string | undefined][])
-    .find(([, player]) => player === runState.runner)?.[0];
+  const runnerSlot = (
+    Object.entries(offenseFormation) as [FormationSlot, string | undefined][]
+  ).find(([, player]) => player === runState.runner)?.[0];
 
   const beatenDefenderSet = new Set(beatenDefenders.filter(Boolean));
 
   const eligibleDefenseFormation = defenseFormation.filter(
-    (assignment) => !assignment.player || !beatenDefenderSet.has(assignment.player)
+    (assignment) =>
+      !assignment.player || !beatenDefenderSet.has(assignment.player),
   );
 
-  const linebacker = selectedDefender ?? pickLinebackerForRunLane(
-    eligibleDefenseFormation,
-    runLaneTarget.selectedSlot,
-    runnerSlot
-  );
+  const linebacker =
+    selectedDefender ??
+    pickLinebackerForRunLane(
+      eligibleDefenseFormation,
+      runLaneTarget.selectedSlot,
+      runnerSlot,
+    );
 
   if (!linebacker) {
-    runState.log.push(`${runState.runner} reaches the second level with no linebacker in position and breaks into the secondary.`);
+    runState.log.push(
+      `${runState.runner} reaches the second level with no linebacker in position and breaks into the secondary.`,
+    );
     addSecondarySpeedYards(runState, players, settings, defenseFormation);
     return { stopped: false };
   }
 
-  const restartSecondLevelCycle = (beatenDefender: string, action: "juke" | "truck") => {
+  const restartSecondLevelCycle = (
+    beatenDefender: string,
+    action: "juke" | "truck",
+  ) => {
     beatenDefenderSet.add(beatenDefender);
     const remainingBeforeAcceleration = getRemainingSecondLevelDefenders(
       defenseFormation,
       lineWinLossArray,
       beatenDefenderSet,
-      true
+      true,
     );
 
     if (remainingBeforeAcceleration.length === 0) {
       runState.log.push(
-        `${runState.runner} has no remaining linebackers or defensive linemen after the ${action} and accelerates into the secondary.`
+        `${runState.runner} has no remaining linebackers or defensive linemen after the ${action} and accelerates into the secondary.`,
       );
       addSecondarySpeedYards(runState, players, settings, defenseFormation);
       return undefined;
@@ -1348,47 +1434,48 @@ export function resolveLinebackerSecondLevel(
     const escapeAccelerationResult = performPostTruckorJukeAccelerationCheck(
       runState.runner,
       players,
-      action
+      action,
     );
 
     if (escapeAccelerationResult.acceleratedPast) {
       runState.log.push(
-        `${runState.runner} accelerates past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} <= ${escapeAccelerationResult.accelPastChance.toFixed(2)}%) and breaks into the secondary.`
+        `${runState.runner} accelerates past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} <= ${escapeAccelerationResult.accelPastChance.toFixed(2)}%) and breaks into the secondary.`,
       );
       addSecondarySpeedYards(runState, players, settings, defenseFormation);
       return undefined;
-    } 
-    
-    else{
+    } else {
       runState.log.push(
-        `${runState.runner} cannot accelerate past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} > ${escapeAccelerationResult.accelPastChance.toFixed(2)}%), so the next defender-runner interaction is reevaluated.`
+        `${runState.runner} cannot accelerate past the remaining defenders after the ${action} (roll ${escapeAccelerationResult.roll.toFixed(2)} > ${escapeAccelerationResult.accelPastChance.toFixed(2)}%), so the next defender-runner interaction is reevaluated.`,
       );
 
       const accelerationYards = getAccelToLBYards(
         findPlayerByName(players, runState.runner),
         settings,
         runState.log,
-        "restart"
+        "restart",
       );
 
       addYards(
         runState,
         accelerationYards,
-        `${runState.runner} restarts downhill after the ${action}`
+        `${runState.runner} restarts downhill after the ${action}`,
       );
 
       const remainingDefenders = getRemainingSecondLevelDefenders(
         defenseFormation,
         lineWinLossArray,
         beatenDefenderSet,
-        accelerationYards <= 3
+        accelerationYards <= 3,
       );
 
-      const nextDefender = weightedPickDefenderByDefStars(remainingDefenders, players);
+      const nextDefender = weightedPickDefenderByDefStars(
+        remainingDefenders,
+        players,
+      );
 
       if (!nextDefender) {
         runState.log.push(
-          `${runState.runner} has no remaining eligible defenders after gaining +${accelerationYards} and accelerates into the secondary.`
+          `${runState.runner} has no remaining eligible defenders after gaining +${accelerationYards} and accelerates into the secondary.`,
         );
         addSecondarySpeedYards(runState, players, settings, defenseFormation);
         return undefined;
@@ -1403,14 +1490,14 @@ export function resolveLinebackerSecondLevel(
         nextDefender,
         settings,
         lineWinLossArray,
-        Array.from(beatenDefenderSet)
+        Array.from(beatenDefenderSet),
       );
     }
-
-    
   };
 
-  runState.log.push(`${runState.runner} meets ${linebacker.player} at the second level.`);
+  runState.log.push(
+    `${runState.runner} meets ${linebacker.player} at the second level.`,
+  );
 
   const wrapResult = performDefenderWrapCheck(linebacker.player, players);
   let carryDefenderResult: CarryDefenderResult | undefined;
@@ -1420,29 +1507,43 @@ export function resolveLinebackerSecondLevel(
   let truckResult: TruckAttemptResult | undefined;
 
   if (wrapResult.wrapped) {
-    carryDefenderResult = handleLbWrapTackle(runState, linebacker.player, "LB Second-Level Wrap", players);
+    carryDefenderResult = handleLbWrapTackle(
+      runState,
+      linebacker.player,
+      "LB Second-Level Wrap",
+      players,
+    );
   } else {
-    runState.log.push(`${linebacker.player} fails to wrap ${runState.runner} at the second level.`);
+    runState.log.push(
+      `${linebacker.player} fails to wrap ${runState.runner} at the second level.`,
+    );
 
     secondChanceAttempt = chooseRunnerDefenderSecondChanceAttempt(
       runState.runner,
       linebacker.player,
-      players
+      players,
     );
 
     runState.log.push(
       `${runState.runner} chooses to ${secondChanceAttempt.attempt.toLowerCase()} ${linebacker.player} ` +
-      `(truck chance ${secondChanceAttempt.truckChance.toFixed(2)}%, size diff ${secondChanceAttempt.cappedSizeDifference}).`
+        `(truck chance ${secondChanceAttempt.truckChance.toFixed(2)}%, size diff ${secondChanceAttempt.cappedSizeDifference}).`,
     );
 
     if (secondChanceAttempt.attempt === "Juke") {
-      jukeResult = performLbJukeCheck(runState.runner, linebacker.player, players);
+      jukeResult = performLbJukeCheck(
+        runState.runner,
+        linebacker.player,
+        players,
+      );
 
       if (jukeResult.juked) {
         runState.log.push(
-          `${runState.runner} jukes ${linebacker.player} at the second level (roll ${jukeResult.roll.toFixed(2)} < ${jukeResult.targetToBeat.toFixed(2)}).`
+          `${runState.runner} jukes ${linebacker.player} at the second level (roll ${jukeResult.roll.toFixed(2)} < ${jukeResult.targetToBeat.toFixed(2)}).`,
         );
-        const recursiveResult = restartSecondLevelCycle(linebacker.player, "juke");
+        const recursiveResult = restartSecondLevelCycle(
+          linebacker.player,
+          "juke",
+        );
         if (recursiveResult) {
           return {
             ...recursiveResult,
@@ -1461,28 +1562,35 @@ export function resolveLinebackerSecondLevel(
           runState,
           linebacker.player,
           "LB Second-Level Juke Failed",
-          players
+          players,
         );
       }
     } else {
-      truckResult = performTruckAttempt(runState.runner, linebacker.player, players);
+      truckResult = performTruckAttempt(
+        runState.runner,
+        linebacker.player,
+        players,
+      );
 
       if (!truckResult.trucked) {
         runState.log.push(
-          `${runState.runner} fails to truck ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`
+          `${runState.runner} fails to truck ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} > ${truckResult.truckChance.toFixed(2)}%).`,
         );
         carryDefenderResult = handleLbWrapTackle(
           runState,
           linebacker.player,
           "LB Second-Level Truck Failed",
-          players
+          players,
         );
       } else {
         runState.log.push(
-          `${runState.runner} trucks ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to accelerate again.`
+          `${runState.runner} trucks ${linebacker.player} at the second level (roll ${truckResult.roll.toFixed(2)} <= ${truckResult.truckChance.toFixed(2)}%) and tries to accelerate again.`,
         );
 
-        const recursiveResult = restartSecondLevelCycle(linebacker.player, "truck");
+        const recursiveResult = restartSecondLevelCycle(
+          linebacker.player,
+          "truck",
+        );
         if (recursiveResult) {
           return {
             ...recursiveResult,
@@ -1525,7 +1633,7 @@ export type DlJukeResult = {
 export function performDlJukeCheck(
   runnerName: string,
   defenderName: string,
-  players: PlayerTrait[]
+  players: PlayerTrait[],
 ): DlJukeResult {
   const runner = findPlayerByName(players, runnerName);
   const defender = findPlayerByName(players, defenderName);
@@ -1533,8 +1641,8 @@ export function performDlJukeCheck(
   const runnerJuke = trait(runner, "juke"); // TRAIT USED: Juke
   const defenderTackle = trait(defender, "tackling"); // TRAIT USED: Tackling
 
-  const jukeScore = 15 + (((runnerJuke / 8) ** 2) / 3);
-  const defenderJukeStop = ((defenderTackle / 17) ** 2) / 2;
+  const jukeScore = 15 + (runnerJuke / 8) ** 2 / 3;
+  const defenderJukeStop = (defenderTackle / 17) ** 2 / 2;
 
   const finalJukeChance = jukeScore - defenderJukeStop;
 
@@ -1555,13 +1663,13 @@ export function performDlJukeCheck(
 /** Returns other penetrating defensive linemen besides the one already challenged. Backfield truck and juke wins use it to continue DL pursuit if needed. */
 export function getOtherWinningDLs(
   lineWinLossArray: LineWinLossResult[],
-  challengedDefender: string
+  challengedDefender: string,
 ): LineWinLossResult[] {
   return lineWinLossArray.filter(
     (battle) =>
       battle.winner === "DL" &&
       battle.defensePlayer &&
-      battle.defensePlayer !== challengedDefender
+      battle.defensePlayer !== challengedDefender,
   );
 }
 
@@ -1585,7 +1693,7 @@ export function resolveRemainingDlPursuit(
   runState: RunPlayState,
   remainingWinningDLs: LineWinLossResult[],
   players: PlayerTrait[],
-  accelerationCheckType: PostContactAccelerationCheckType
+  accelerationCheckType: PostContactAccelerationCheckType,
 ): DlPursuitResult {
   const steps: DlPursuitStep[] = [];
 
@@ -1595,7 +1703,7 @@ export function resolveRemainingDlPursuit(
     const accelerationCheck = performPostTruckorJukeAccelerationCheck(
       runState.runner,
       players,
-      accelerationCheckType
+      accelerationCheckType,
     );
 
     if (accelerationCheck.acceleratedPast) {
@@ -1606,7 +1714,7 @@ export function resolveRemainingDlPursuit(
       });
 
       runState.log.push(
-        `${runState.runner} accelerates past the remaining penetrating defensive linemen.`
+        `${runState.runner} accelerates past the remaining penetrating defensive linemen.`,
       );
 
       return {
@@ -1623,7 +1731,7 @@ export function resolveRemainingDlPursuit(
         runState,
         defenderName,
         "DL Pursuit Wrap",
-        players
+        players,
       );
 
       steps.push({
@@ -1634,7 +1742,7 @@ export function resolveRemainingDlPursuit(
       });
 
       runState.log.push(
-        `${defenderName} catches ${runState.runner} from pursuit after the acceleration check failed.`
+        `${defenderName} catches ${runState.runner} from pursuit after the acceleration check failed.`,
       );
 
       void fallForwardResult;
@@ -1650,7 +1758,7 @@ export function resolveRemainingDlPursuit(
     const jukeResult = performDlJukeCheck(
       runState.runner,
       defenderName,
-      players
+      players,
     );
 
     if (!jukeResult.juked) {
@@ -1658,7 +1766,7 @@ export function resolveRemainingDlPursuit(
         runState,
         defenderName,
         "DL Pursuit Juke Failed",
-        players
+        players,
       );
 
       steps.push({
@@ -1687,13 +1795,11 @@ export function resolveRemainingDlPursuit(
       outcome: "Juked",
     });
 
-    runState.log.push(
-      `${runState.runner} jukes ${defenderName} in pursuit.`
-    );
+    runState.log.push(`${runState.runner} jukes ${defenderName} in pursuit.`);
   }
 
   runState.log.push(
-    `${runState.runner} escapes all penetrating defensive linemen and heads toward the second level.`
+    `${runState.runner} escapes all penetrating defensive linemen and heads toward the second level.`,
   );
 
   return {

--- a/apps/web/src/components/league/gameplay/engine/specialTeamsEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/specialTeamsEngine.ts
@@ -5,31 +5,182 @@ import { buildResult } from "./playLogger";
 
 export function punt(game: LeagueGame, ctx: EngineContext) {
   const yards = 40;
-  const ball = Math.max(1, Math.min(99, game.Possession === "Home" ? n(game.BallOn) + yards : n(game.BallOn) - yards));
+  const ball = Math.max(
+    1,
+    Math.min(
+      99,
+      game.Possession === "Home"
+        ? n(game.BallOn) + yards
+        : n(game.BallOn) - yards,
+    ),
+  );
   const possession = switchPoss(game);
   const clock = advanceQuarter(game, randomInt(5, 8));
-  const updated = { ...game, Qtr: clock.qtr, Time: clock.time, Down: 1, Distance: 10, BallOn: ball, Previous: game.BallOn, DriveStart: ball, Possession: possession };
-  return buildResult(game, updated, "Punt", game.Possession, "", yards, "", "Punt", ctx.historyLength);
+  const updated = {
+    ...game,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: 1,
+    Distance: 10,
+    BallOn: ball,
+    Previous: game.BallOn,
+    DriveStart: ball,
+    Possession: possession,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Punt",
+    game.Possession,
+    "",
+    yards,
+    "",
+    "Punt",
+    ctx.historyLength,
+  );
 }
 export function kickFG(game: LeagueGame, ctx: EngineContext) {
-  const pendingFGTeam = (game as unknown as Record<string, unknown>).pendingFGTeam as string | undefined;
+  const pendingFGTeam = (game as unknown as Record<string, unknown>)
+    .pendingFGTeam as string | undefined;
   const isXp = Boolean(pendingFGTeam);
   const scoring = pendingFGTeam || game.Possession;
-  const inRange = isXp || (game.Possession === "Home" ? n(game.BallOn) >= 65 : n(game.BallOn) <= 35);
-  let hs = n(game.HomeScore), as = n(game.AwayScore);
-  if (inRange) { if (scoring === "Home") hs += isXp ? 1 : 3; else as += isXp ? 1 : 3; }
+  const inRange =
+    isXp ||
+    (game.Possession === "Home" ? n(game.BallOn) >= 65 : n(game.BallOn) <= 35);
+  let hs = n(game.HomeScore),
+    as = n(game.AwayScore);
+  if (inRange) {
+    if (scoring === "Home") hs += isXp ? 1 : 3;
+    else as += isXp ? 1 : 3;
+  }
   const possession = switchPoss(game);
   const clock = advanceQuarter(game, randomInt(3, 8));
   const spot = kickoffSpot(possession);
-  const updated = { ...game, HomeScore: hs, AwayScore: as, Qtr: clock.qtr, Time: clock.time, Down: 1, Distance: 10, BallOn: spot, Previous: game.BallOn, DriveStart: spot, Possession: possession, pendingFGTeam: undefined };
-  return buildResult(game, updated, "Field Goal", scoring, "", 0, "", isXp ? "Kick XP" : inRange ? "Kick FG" : "Missed FG", ctx.historyLength);
+  const updated = {
+    ...game,
+    HomeScore: hs,
+    AwayScore: as,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: 1,
+    Distance: 10,
+    BallOn: spot,
+    Previous: game.BallOn,
+    DriveStart: spot,
+    Possession: possession,
+    pendingFGTeam: undefined,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Field Goal",
+    scoring,
+    "",
+    0,
+    "",
+    isXp ? "Kick XP" : inRange ? "Kick FG" : "Missed FG",
+    ctx.historyLength,
+  );
 }
 export function goForTwo(game: LeagueGame, ctx: EngineContext) {
-  const scoring = ((game as unknown as Record<string, unknown>).pendingFGTeam as string | undefined) || game.Possession;
-  const made = randomInt(1, 100) <= 47; let hs = n(game.HomeScore), as = n(game.AwayScore); if (made) { if (scoring === "Home") hs += 2; else as += 2; }
-  const possession = switchPoss(game); const spot = kickoffSpot(possession); const updated = { ...game, HomeScore: hs, AwayScore: as, Down: 1, Distance: 10, BallOn: spot, DriveStart: spot, Possession: possession };
-  return buildResult(game, updated, "Two Point", scoring, "", made ? 2 : 0, "", made ? "2PT Successful" : "2PT Failed", ctx.historyLength);
+  const scoring =
+    ((game as unknown as Record<string, unknown>).pendingFGTeam as
+      string | undefined) || game.Possession;
+  const made = randomInt(1, 100) <= 47;
+  let hs = n(game.HomeScore),
+    as = n(game.AwayScore);
+  if (made) {
+    if (scoring === "Home") hs += 2;
+    else as += 2;
+  }
+  const possession = switchPoss(game);
+  const spot = kickoffSpot(possession);
+  const updated = {
+    ...game,
+    HomeScore: hs,
+    AwayScore: as,
+    Down: 1,
+    Distance: 10,
+    BallOn: spot,
+    DriveStart: spot,
+    Possession: possession,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Two Point",
+    scoring,
+    "",
+    made ? 2 : 0,
+    "",
+    made ? "2PT Successful" : "2PT Failed",
+    ctx.historyLength,
+  );
 }
-export function handleTimeout(game: LeagueGame, ctx: EngineContext) { const key = game.Possession === "Home" ? "HomeTimeouts" : "AwayTimeouts"; const current = Number((game as unknown as Record<string, unknown>)[key] ?? 3); const updated = { ...game, [key]: Math.max(0, current - 1) }; return buildResult(game, updated, "Timeout", game.Possession, "", 0, "", "Timeout", ctx.historyLength); }
-export function spikeBall(game: LeagueGame, ctx: EngineContext) { const clock = advanceQuarter(game, 1); const updated = { ...game, Qtr: clock.qtr, Time: clock.time, Down: Math.min(4, n(game.Down) + 1), Distance: game.Distance }; return buildResult(game, updated, "Spike", game.Possession, "", 0, "", "Incomplete", ctx.historyLength); }
-export function kneel(game: LeagueGame, ctx: EngineContext, options: PlayCallOptions = {}) { void options; const clock = advanceQuarter(game, 40); const ball = game.Possession === "Home" ? n(game.BallOn) - 1 : n(game.BallOn) + 1; const updated = { ...game, Qtr: clock.qtr, Time: clock.time, Down: Math.min(4, n(game.Down) + 1), BallOn: ball }; return buildResult(game, updated, "Kneel", game.Possession, "", -1, "", "Kneel", ctx.historyLength); }
+export function handleTimeout(game: LeagueGame, ctx: EngineContext) {
+  const key = game.Possession === "Home" ? "HomeTimeouts" : "AwayTimeouts";
+  const current = Number(
+    (game as unknown as Record<string, unknown>)[key] ?? 3,
+  );
+  const updated = { ...game, [key]: Math.max(0, current - 1) };
+  return buildResult(
+    game,
+    updated,
+    "Timeout",
+    game.Possession,
+    "",
+    0,
+    "",
+    "Timeout",
+    ctx.historyLength,
+  );
+}
+export function spikeBall(game: LeagueGame, ctx: EngineContext) {
+  const clock = advanceQuarter(game, 1);
+  const updated = {
+    ...game,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: Math.min(4, n(game.Down) + 1),
+    Distance: game.Distance,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Spike",
+    game.Possession,
+    "",
+    0,
+    "",
+    "Incomplete",
+    ctx.historyLength,
+  );
+}
+export function kneel(
+  game: LeagueGame,
+  ctx: EngineContext,
+  options: PlayCallOptions = {},
+) {
+  void options;
+  const clock = advanceQuarter(game, 40);
+  const ball =
+    game.Possession === "Home" ? n(game.BallOn) - 1 : n(game.BallOn) + 1;
+  const updated = {
+    ...game,
+    Qtr: clock.qtr,
+    Time: clock.time,
+    Down: Math.min(4, n(game.Down) + 1),
+    BallOn: ball,
+  };
+  return buildResult(
+    game,
+    updated,
+    "Kneel",
+    game.Possession,
+    "",
+    -1,
+    "",
+    "Kneel",
+    ctx.historyLength,
+  );
+}

--- a/apps/web/src/components/league/gameplay/engine/statsEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/statsEngine.ts
@@ -1,2 +1,6 @@
-export function recalculateStatsFromHistory() { return undefined; }
-export function updateStatsForPlay() { return undefined; }
+export function recalculateStatsFromHistory() {
+  return undefined;
+}
+export function updateStatsForPlay() {
+  return undefined;
+}

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -1,7 +1,26 @@
 import type { LeagueGame } from "../../types";
 
-export type PlayKind = "Run" | "Pass" | "Punt" | "Field Goal" | "Two Point" | "Timeout" | "Spike" | "Kneel";
-export type FormationSlot = "WR1" | "TEOL1" | "TEOL2" | "TEOL3" | "TEOL4" | "TEOL5" | "WR2" | "WR3" | "QB" | "RB1" | "RB2";
+export type PlayKind =
+  | "Run"
+  | "Pass"
+  | "Punt"
+  | "Field Goal"
+  | "Two Point"
+  | "Timeout"
+  | "Spike"
+  | "Kneel";
+export type FormationSlot =
+  | "WR1"
+  | "TEOL1"
+  | "TEOL2"
+  | "TEOL3"
+  | "TEOL4"
+  | "TEOL5"
+  | "WR2"
+  | "WR3"
+  | "QB"
+  | "RB1"
+  | "RB2";
 export type ClockMode = "Normal" | "Hurry Up" | "Chew Clock";
 export type DefensiveAssignment = {
   position: string;
@@ -18,12 +37,44 @@ export type PlayCallOptions = {
   defense?: DefensiveAssignment[];
 };
 export type PlayerTrait = Record<string, unknown>;
-export type RunThreshold = { label: string; minYards: number; maxYards: number; rollMin: number; rollMax: number };
-export type RunBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
-export type RunAccelToLBSetting = { label: string; percentage: number; minYards: number; maxYards: number; yards?: number };
-export type RunSecondarySpeedSetting = { label: string; percentage: number; minYards: number; maxYards: number };
-export type RunSecondaryBreakawaySetting = { label: string; percentage: number; minYards: number; maxYards: number };
-export type RunNegativeYardageSetting = { label: string; percentage: number; minYards: number; maxYards: number };
+export type RunThreshold = {
+  label: string;
+  minYards: number;
+  maxYards: number;
+  rollMin: number;
+  rollMax: number;
+};
+export type RunBreakawaySetting = {
+  label: string;
+  percentage: number;
+  minYards: number;
+  maxYards: number;
+};
+export type RunAccelToLBSetting = {
+  label: string;
+  percentage: number;
+  minYards: number;
+  maxYards: number;
+  yards?: number;
+};
+export type RunSecondarySpeedSetting = {
+  label: string;
+  percentage: number;
+  minYards: number;
+  maxYards: number;
+};
+export type RunSecondaryBreakawaySetting = {
+  label: string;
+  percentage: number;
+  minYards: number;
+  maxYards: number;
+};
+export type RunNegativeYardageSetting = {
+  label: string;
+  percentage: number;
+  minYards: number;
+  maxYards: number;
+};
 export type FrontendSettings = Record<string, unknown> & {
   thresholds?: RunThreshold[];
   breakaways?: RunBreakawaySetting[];

--- a/apps/web/src/components/league/gameplay/engine/utils.ts
+++ b/apps/web/src/components/league/gameplay/engine/utils.ts
@@ -4,48 +4,140 @@ import type { ClockMode, EngineContext, PlayerTrait } from "./types";
 
 export const n = (v: unknown) => Number(v) || 0;
 export const str = (v: unknown) => String(v ?? "");
-export function randomInt(min: number, max: number) { return Math.floor(Math.random() * (max - min + 1)) + min; }
-export function clamp(value: number, min: number, max: number) { return Math.max(min, Math.min(max, value)); }
-export function choose<T>(items: T[]) { return items[Math.max(0, randomInt(0, items.length - 1))]; }
+export function randomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+export function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+export function choose<T>(items: T[]) {
+  return items[Math.max(0, randomInt(0, items.length - 1))];
+}
 export function weightedChoose<T>(items: T[], weight: (item: T) => number) {
   const total = items.reduce((sum, item) => sum + Math.max(0, weight(item)), 0);
   if (!items.length) return undefined;
   if (total <= 0) return choose(items);
   let roll = Math.random() * total;
-  return items.find((item) => { roll -= Math.max(0, weight(item)); return roll <= 0; }) ?? items[items.length - 1];
+  return (
+    items.find((item) => {
+      roll -= Math.max(0, weight(item));
+      return roll <= 0;
+    }) ?? items[items.length - 1]
+  );
 }
-export function playerName(p: PlayerTrait | undefined, fallback = "") { return str(p?.name ?? p?.Name ?? fallback); }
-export function trait(p: PlayerTrait | undefined, key: string, fallback = 50) { return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)]) || fallback; }
-export function teamPlayers(ctx: EngineContext, team: string) { return ctx.players.filter((p) => str(p.team ?? p.Team) === team); }
-export function byName(ctx: EngineContext, name?: string) { return ctx.players.find((p) => playerName(p) === name); }
-export function byPosition(ctx: EngineContext, team: string, pos: string) { return teamPlayers(ctx, team).filter((p) => str(p.position ?? p.Pos).toUpperCase().includes(pos)); }
-export function offenseTeam(game: LeagueGame) { return game.Possession === "Home" ? game.Home : game.Away; }
-export function defenseTeam(game: LeagueGame) { return game.Possession === "Home" ? game.Away : game.Home; }
-export function switchPoss(game: LeagueGame) { return game.Possession === "Home" ? "Away" : "Home"; }
-export function direction(game: LeagueGame) { return game.Possession === "Home" ? 1 : -1; }
-export function advanceBall(game: LeagueGame, yards: number) { return clamp(n(game.BallOn) + direction(game) * yards, 0, 100); }
-export function isTouchdown(game: LeagueGame, ballOn: number) { return game.Possession === "Home" ? ballOn >= 100 : ballOn <= 0; }
-export function isSafety(game: LeagueGame, ballOn: number) { return game.Possession === "Home" ? ballOn <= 0 : ballOn >= 100; }
-export function kickoffSpot(possession: string) { return possession === "Home" ? 25 : 75; }
+export function playerName(p: PlayerTrait | undefined, fallback = "") {
+  return str(p?.name ?? p?.Name ?? fallback);
+}
+export function trait(p: PlayerTrait | undefined, key: string, fallback = 50) {
+  return (
+    Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)]) || fallback
+  );
+}
+export function teamPlayers(ctx: EngineContext, team: string) {
+  return ctx.players.filter((p) => str(p.team ?? p.Team) === team);
+}
+export function byName(ctx: EngineContext, name?: string) {
+  return ctx.players.find((p) => playerName(p) === name);
+}
+export function byPosition(ctx: EngineContext, team: string, pos: string) {
+  return teamPlayers(ctx, team).filter((p) =>
+    str(p.position ?? p.Pos)
+      .toUpperCase()
+      .includes(pos),
+  );
+}
+export function offenseTeam(game: LeagueGame) {
+  return game.Possession === "Home" ? game.Home : game.Away;
+}
+export function defenseTeam(game: LeagueGame) {
+  return game.Possession === "Home" ? game.Away : game.Home;
+}
+export function switchPoss(game: LeagueGame) {
+  return game.Possession === "Home" ? "Away" : "Home";
+}
+export function direction(game: LeagueGame) {
+  return game.Possession === "Home" ? 1 : -1;
+}
+export function advanceBall(game: LeagueGame, yards: number) {
+  return clamp(n(game.BallOn) + direction(game) * yards, 0, 100);
+}
+export function isTouchdown(game: LeagueGame, ballOn: number) {
+  return game.Possession === "Home" ? ballOn >= 100 : ballOn <= 0;
+}
+export function isSafety(game: LeagueGame, ballOn: number) {
+  return game.Possession === "Home" ? ballOn <= 0 : ballOn >= 100;
+}
+export function kickoffSpot(possession: string) {
+  return possession === "Home" ? 25 : 75;
+}
 export function advanceQuarter(game: LeagueGame, secondsUsed: number) {
   const left = Math.max(0, parseTimeToSeconds(game.Time) - secondsUsed);
   let qtr: string | number = game.Qtr;
   let time: string | number = left;
-  if (left === 0 && Number(game.Qtr) < 4) { qtr = Number(game.Qtr) + 1; time = 15 * 60; }
-  else if (left === 0 && Number(game.Qtr) >= 4) qtr = "FINAL";
+  if (left === 0 && Number(game.Qtr) < 4) {
+    qtr = Number(game.Qtr) + 1;
+    time = 15 * 60;
+  } else if (left === 0 && Number(game.Qtr) >= 4) qtr = "FINAL";
   return { qtr, time };
 }
-export function clockRunoff(mode: ClockMode = "Normal", base = randomInt(4, 12), clockStops = false) {
+export function clockRunoff(
+  mode: ClockMode = "Normal",
+  base = randomInt(4, 12),
+  clockStops = false,
+) {
   if (clockStops) return base;
   if (mode === "Hurry Up") return base + randomInt(4, 8);
   if (mode === "Chew Clock") return base + randomInt(36, 40);
   return base + randomInt(24, 38);
 }
-export function nextDownDistance(game: LeagueGame, yards: number, newBallOn = advanceBall(game, yards)) {
-  const down = n(game.Down); const distance = n(game.Distance);
-  if (isTouchdown(game, newBallOn)) return { down: 1, distance: 10, ballOn: kickoffSpot(switchPoss(game)), touchdown: true, turnover: false };
-  if (isSafety(game, newBallOn)) return { down: 1, distance: 10, ballOn: kickoffSpot(switchPoss(game)), touchdown: false, turnover: true, safety: true };
-  if (yards >= distance) return { down: 1, distance: Math.min(10, game.Possession === "Home" ? 100 - newBallOn : newBallOn), ballOn: newBallOn, touchdown: false, turnover: false };
-  if (down >= 4) return { down: 1, distance: 10, ballOn: newBallOn, touchdown: false, turnover: true };
-  return { down: down + 1, distance: distance - yards, ballOn: newBallOn, touchdown: false, turnover: false };
+export function nextDownDistance(
+  game: LeagueGame,
+  yards: number,
+  newBallOn = advanceBall(game, yards),
+) {
+  const down = n(game.Down);
+  const distance = n(game.Distance);
+  if (isTouchdown(game, newBallOn))
+    return {
+      down: 1,
+      distance: 10,
+      ballOn: kickoffSpot(switchPoss(game)),
+      touchdown: true,
+      turnover: false,
+    };
+  if (isSafety(game, newBallOn))
+    return {
+      down: 1,
+      distance: 10,
+      ballOn: kickoffSpot(switchPoss(game)),
+      touchdown: false,
+      turnover: true,
+      safety: true,
+    };
+  if (yards >= distance)
+    return {
+      down: 1,
+      distance: Math.min(
+        10,
+        game.Possession === "Home" ? 100 - newBallOn : newBallOn,
+      ),
+      ballOn: newBallOn,
+      touchdown: false,
+      turnover: false,
+    };
+  if (down >= 4)
+    return {
+      down: 1,
+      distance: 10,
+      ballOn: newBallOn,
+      touchdown: false,
+      turnover: true,
+    };
+  return {
+    down: down + 1,
+    distance: distance - yards,
+    ballOn: newBallOn,
+    touchdown: false,
+    turnover: false,
+  };
 }

--- a/apps/web/src/components/league/gameplay/gameEngine.ts
+++ b/apps/web/src/components/league/gameplay/gameEngine.ts
@@ -5,11 +5,46 @@ export type {
   EngineContext,
   FrontendSettings,
   DefensiveAssignment,
-  RunPlayState
+  RunPlayState,
 } from "./engine/types";
-export { runPlay, determineTackler, fumbleCheck, checkForFumble } from "./engine/runEngine";
-export { passPlay, determineTimeToThrow, handleSack, assignRoutes, determineSeparation, choosePassTarget, determineCompletionPct, determinePassOutcome, calcYAC } from "./engine/passEngine";
-export { punt, kickFG, goForTwo, handleTimeout, spikeBall, kneel } from "./engine/specialTeamsEngine";
-export { updateGameState, handleTouchdown, handleSafety, handleTOonDowns } from "./engine/gameStateEngine";
-export { determinePlayOutcome, logPlayToDB, buildGameData } from "./engine/playLogger";
-export { validateOffensiveFormation, saveOffensiveFormation, generateDefensiveFormation } from "./engine/formationEngine";
+export {
+  runPlay,
+  determineTackler,
+  fumbleCheck,
+  checkForFumble,
+} from "./engine/runEngine";
+export {
+  passPlay,
+  determineTimeToThrow,
+  handleSack,
+  assignRoutes,
+  determineSeparation,
+  choosePassTarget,
+  determineCompletionPct,
+  determinePassOutcome,
+  calcYAC,
+} from "./engine/passEngine";
+export {
+  punt,
+  kickFG,
+  goForTwo,
+  handleTimeout,
+  spikeBall,
+  kneel,
+} from "./engine/specialTeamsEngine";
+export {
+  updateGameState,
+  handleTouchdown,
+  handleSafety,
+  handleTOonDowns,
+} from "./engine/gameStateEngine";
+export {
+  determinePlayOutcome,
+  logPlayToDB,
+  buildGameData,
+} from "./engine/playLogger";
+export {
+  validateOffensiveFormation,
+  saveOffensiveFormation,
+  generateDefensiveFormation,
+} from "./engine/formationEngine";

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -823,9 +823,14 @@
   border-collapse: collapse;
   color: var(--text-muted);
 }
-.score-chart thead tr { border-bottom: 1px solid var(--gray-light); }
+.score-chart thead tr {
+  border-bottom: 1px solid var(--gray-light);
+}
 .score-chart th,
-.score-chart td { text-align: center; padding: 1vw; }
+.score-chart td {
+  text-align: center;
+  padding: 1vw;
+}
 .score-chart .team-cell {
   display: flex;
   align-items: center;
@@ -840,7 +845,10 @@
   height: clamp(36px, 5vw, 72px);
   object-fit: contain;
 }
-.score-chart .total-cell { font-weight: 700; color: var(--text-light); }
+.score-chart .total-cell {
+  font-weight: 700;
+  color: var(--text-light);
+}
 .leaders-card {
   max-width: 900px;
   margin: 2vw auto;
@@ -867,7 +875,10 @@
   font-weight: 700;
   color: var(--text-light);
 }
-.leader-divider { border-bottom: 1px solid var(--gray-light); margin: 1.5vw 0; }
+.leader-divider {
+  border-bottom: 1px solid var(--gray-light);
+  margin: 1.5vw 0;
+}
 .leader-row {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -876,10 +887,19 @@
   margin: 1vw 0;
 }
 .leader-left,
-.leader-right { display: flex; align-items: center; gap: 1vw; }
-.leader-right { justify-content: flex-end; text-align: right; }
+.leader-right {
+  display: flex;
+  align-items: center;
+  gap: 1vw;
+}
+.leader-right {
+  justify-content: flex-end;
+  text-align: right;
+}
 .leader-center,
-.leader-label { text-align: center; }
+.leader-label {
+  text-align: center;
+}
 .player-placeholder {
   width: clamp(56px, 10vw, 96px);
   height: clamp(56px, 10vw, 96px);
@@ -890,14 +910,27 @@
   justify-content: center;
   font-size: clamp(28px, 5vw, 48px);
 }
-.player-placeholder img { width: 100%; height: 100%; border-radius: 50%; object-fit: cover; }
+.player-placeholder img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
 .leader-value,
 .leader-name,
-.leader-label { font-weight: 700; color: var(--text-light); }
-.leader-value { font-size: clamp(28px, 6vw, 38px); }
+.leader-label {
+  font-weight: 700;
+  color: var(--text-light);
+}
+.leader-value {
+  font-size: clamp(28px, 6vw, 38px);
+}
 .leader-pos,
 .leader-statline,
-.leader-row.statlines { color: var(--text-muted); font-weight: 400; }
+.leader-row.statlines {
+  color: var(--text-muted);
+  font-weight: 400;
+}
 .boxscore-link {
   display: block;
   margin: 1vw auto 0;
@@ -1039,7 +1072,9 @@
   background: var(--accent-red);
   color: var(--gray-dark);
 }
-.stats-group { margin-bottom: clamp(24px, 5vw, 72px); }
+.stats-group {
+  margin-bottom: clamp(24px, 5vw, 72px);
+}
 .stats-title {
   font-weight: 700;
   margin: clamp(12px, 2vw, 28px) 0;
@@ -1060,20 +1095,31 @@
   border-bottom: 2px solid var(--accent-red);
   color: var(--text-light);
 }
-.stats-table tr:nth-child(even) { background: var(--gray-dark); }
-.stats-table tr:nth-child(odd) { background: var(--gray-medium); }
-.stats-table .team-row td { font-weight: 700; }
+.stats-table tr:nth-child(even) {
+  background: var(--gray-dark);
+}
+.stats-table tr:nth-child(odd) {
+  background: var(--gray-medium);
+}
+.stats-table .team-row td {
+  font-weight: 700;
+}
 .stats-placeholder {
   text-align: center;
   color: var(--text-muted);
 }
-.overview-section { display: grid; gap: clamp(18px, 4vw, 56px); }
+.overview-section {
+  display: grid;
+  gap: clamp(18px, 4vw, 56px);
+}
 .stats-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(16px, 3vw, 48px);
 }
-.team-table { min-width: 0; }
+.team-table {
+  min-width: 0;
+}
 .team-stats-card {
   margin-top: 5vw;
   padding: clamp(16px, 4vw, 48px);
@@ -1088,23 +1134,36 @@
   text-align: center;
   font-size: clamp(18px, 3vw, 30px);
 }
-.team-stats-table td:first-child { text-align: left; }
+.team-stats-table td:first-child {
+  text-align: left;
+}
 .team-stats-table .header-row td,
 .team-stats-table .header2-row td {
   font-weight: 700;
   color: var(--text-light);
 }
-.team-stats-table .stat-row td { color: var(--text-muted); }
-.team-stats-table .indent-1 td:first-child { padding-left: clamp(24px, 5vw, 64px); }
-.team-stats-table .indent-2 td:first-child { padding-left: clamp(48px, 10vw, 128px); }
+.team-stats-table .stat-row td {
+  color: var(--text-muted);
+}
+.team-stats-table .indent-1 td:first-child {
+  padding-left: clamp(24px, 5vw, 64px);
+}
+.team-stats-table .indent-2 td:first-child {
+  padding-left: clamp(48px, 10vw, 128px);
+}
 .team-stats-logo {
   width: clamp(40px, 8vw, 88px);
   height: clamp(40px, 8vw, 88px);
   object-fit: contain;
 }
 @media (max-width: 780px) {
-  .stats-row { grid-template-columns: 1fr; }
-  .boxscore-card, .team-stats-card { margin-inline: 0; }
+  .stats-row {
+    grid-template-columns: 1fr;
+  }
+  .boxscore-card,
+  .team-stats-card {
+    margin-inline: 0;
+  }
 }
 
 .play-caller {
@@ -1114,87 +1173,576 @@
   padding: clamp(12px, 2.5vw, 24px);
   background: linear-gradient(180deg, var(--gray-medium), var(--gray-dark));
 }
-.control-panel-toggle { width: 100%; padding: 12px; border: 0; border-radius: 10px; background: var(--accent-red); color: white; font-weight: 700; cursor: pointer; }
-.play-caller.collapsed { padding: 1vw; }
-.game-controls { display: flex; flex-wrap: wrap; gap: 10px; margin: 12px 0; }
-.game-controls button, .game-modal-panel button, .clock-options button { border: 0; border-radius: 10px; padding: 10px 14px; background: var(--gray-light); color: var(--text-light); cursor: pointer; }
-.game-controls.primary button { background: var(--accent-red); font-weight: 700; }
-.game-controls button:disabled { opacity: .45; cursor: not-allowed; }
-.play-call-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; color: var(--text-muted); }
-.game-modal { position: fixed; inset: 0; background: rgba(0,0,0,.78); z-index: 2000; display: flex; align-items: center; justify-content: center; padding: 20px; }
-.game-modal-panel { position: relative; width: min(960px, 96vw); max-height: 92vh; overflow: auto; padding: clamp(18px, 4vw, 34px); border-radius: 16px; background: var(--gray-medium); box-shadow: 0 20px 60px #000a; }
-.formation-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; }
-.formation-picker { display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid #ffffff22; border-radius: 12px; background: var(--gray-dark); }
-.formation-picker.required span::after { content: " *"; color: var(--accent-red); }
-.formation-picker select, .route-row select { min-height: 38px; border-radius: 8px; border: 1px solid #ffffff33; background: #111; color: white; }
-.los-preview { position: relative; display: grid; grid-template-columns: repeat(8, minmax(70px, 1fr)); gap: 10px; padding: 28px 12px; background: #1f7a3a; border-radius: 14px; }
-.los-defense, .los-backfield { grid-column: 1 / -1; text-align: center; font-weight: 700; }
-.los-line-react { grid-column: 1 / -1; height: 4px; background: #61a5ff; }
-.los-token { min-height: 78px; padding: 8px; border-radius: 999px; background: #ffffffee; color: #111; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; font-size: 12px; }
-.los-backfield { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; }
-.route-list { display: grid; gap: 10px; }
-.route-row { display: grid; grid-template-columns: 1fr 150px 120px; gap: 10px; align-items: center; padding: 10px; background: var(--gray-dark); border-radius: 10px; }
-.rusher-options { display: flex; flex-wrap: nowrap; gap: 12px; margin: 18px 0; overflow-x: auto; align-items: flex-start; }
-.rusher-option { display: flex; flex-direction: column; gap: 6px; align-items: center; min-width: 72px; padding: 6px; background: transparent; }
-.rusher-option .player-circle-static { width: 54px; height: 54px; flex: 0 0 54px; }
-.rusher-option.selected { outline: 0; }
-.rusher-option.selected .player-circle-static { box-shadow: 0 0 0 4px var(--accent-red); }
-.rusher-option span { max-width: 76px; font-size: 11px; line-height: 1.15; text-align: center; }
-.clock-options { display: grid; gap: 12px; }
-.clock-options .active { background: var(--accent-red); }
-@media (max-width: 700px) { .route-row { grid-template-columns: 1fr; } .los-preview { grid-template-columns: repeat(2, 1fr); } }
+.control-panel-toggle {
+  width: 100%;
+  padding: 12px;
+  border: 0;
+  border-radius: 10px;
+  background: var(--accent-red);
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+}
+.play-caller.collapsed {
+  padding: 1vw;
+}
+.game-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 12px 0;
+}
+.game-controls button,
+.game-modal-panel button,
+.clock-options button {
+  border: 0;
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: var(--gray-light);
+  color: var(--text-light);
+  cursor: pointer;
+}
+.game-controls.primary button {
+  background: var(--accent-red);
+  font-weight: 700;
+}
+.game-controls button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.play-call-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+  color: var(--text-muted);
+}
+.game-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.78);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.game-modal-panel {
+  position: relative;
+  width: min(960px, 96vw);
+  max-height: 92vh;
+  overflow: auto;
+  padding: clamp(18px, 4vw, 34px);
+  border-radius: 16px;
+  background: var(--gray-medium);
+  box-shadow: 0 20px 60px #000a;
+}
+.formation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 12px;
+}
+.formation-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid #ffffff22;
+  border-radius: 12px;
+  background: var(--gray-dark);
+}
+.formation-picker.required span::after {
+  content: " *";
+  color: var(--accent-red);
+}
+.formation-picker select,
+.route-row select {
+  min-height: 38px;
+  border-radius: 8px;
+  border: 1px solid #ffffff33;
+  background: #111;
+  color: white;
+}
+.los-preview {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(8, minmax(70px, 1fr));
+  gap: 10px;
+  padding: 28px 12px;
+  background: #1f7a3a;
+  border-radius: 14px;
+}
+.los-defense,
+.los-backfield {
+  grid-column: 1 / -1;
+  text-align: center;
+  font-weight: 700;
+}
+.los-line-react {
+  grid-column: 1 / -1;
+  height: 4px;
+  background: #61a5ff;
+}
+.los-token {
+  min-height: 78px;
+  padding: 8px;
+  border-radius: 999px;
+  background: #ffffffee;
+  color: #111;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 12px;
+}
+.los-backfield {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.route-list {
+  display: grid;
+  gap: 10px;
+}
+.route-row {
+  display: grid;
+  grid-template-columns: 1fr 150px 120px;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  background: var(--gray-dark);
+  border-radius: 10px;
+}
+.rusher-options {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 12px;
+  margin: 18px 0;
+  overflow-x: auto;
+  align-items: flex-start;
+}
+.rusher-option {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  min-width: 72px;
+  padding: 6px;
+  background: transparent;
+}
+.rusher-option .player-circle-static {
+  width: 54px;
+  height: 54px;
+  flex: 0 0 54px;
+}
+.rusher-option.selected {
+  outline: 0;
+}
+.rusher-option.selected .player-circle-static {
+  box-shadow: 0 0 0 4px var(--accent-red);
+}
+.rusher-option span {
+  max-width: 76px;
+  font-size: 11px;
+  line-height: 1.15;
+  text-align: center;
+}
+.clock-options {
+  display: grid;
+  gap: 12px;
+}
+.clock-options .active {
+  background: var(--accent-red);
+}
+@media (max-width: 700px) {
+  .route-row {
+    grid-template-columns: 1fr;
+  }
+  .los-preview {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
 
 /* Legacy-style play caller modals */
-.formation-full-panel { width: 100%; height: 100%; max-width: none; border-radius: 0; overflow: auto; }
-.formation-panel { background: var(--gray-light); }
-.formation-field { margin-bottom: 4vw; overflow-x: auto; min-width: 720px; }
-.formation-row { display: flex; justify-content: center; align-items: center; gap: 2vw; margin-bottom: 4vw; }
-.formation-row.top-row { justify-content: center; }
-.formation-slot { flex: 0 0 clamp(60px, 8vw, 90px); width: clamp(60px, 8vw, 90px); height: clamp(60px, 8vw, 90px); border: 2px dotted var(--text-muted); border-radius: 50%; background: var(--gray-dark); display: flex; align-items: center; justify-content: center; font-size: clamp(12px, 2vw, 18px); font-weight: 500; position: relative; color: var(--text-muted); overflow: hidden; cursor: pointer; }
-.formation-slot::before { content: attr(data-label); }
-.formation-slot.filled::before { content: ''; }
-.formation-slot.qb { border-color: #64b5f6; color: #64b5f6; }
-.formation-slot.rb { border-color: #81c784; color: #81c784; }
-.formation-slot.wr { border-color: #ffb74d; color: #ffb74d; }
-.formation-slot.teol { border-color: #ba68c8; color: #ba68c8; }
-.formation-slot.required::after { content: '*'; color: var(--accent-red); margin-left: 0.2em; font-size: 1.2em; }
-.formation-slot.filled { border-style: solid; }
-.formation-slot.filled::after { content: ''; }
-.formation-slot > div { width: 100%; height: 100%; position: relative; }
-.formation-remove { position: absolute; top: -4px; right: -4px; width: 24px; height: 24px; min-width: 24px; padding: 0; border: 2px solid #fff; border-radius: 50%; background: var(--accent-red); color: #fff; line-height: 18px; font-size: 16px; font-weight: 800; z-index: 4; cursor: pointer; }
-.bench { display: flex; flex-wrap: wrap; gap: 1.25vw; }
-.player-item { flex: 0 1 96px; max-width: 110px; border: 2px solid var(--text-muted); border-radius: 12px; background: var(--gray-dark); padding: 8px; display: flex; flex-direction: column; align-items: center; gap: 6px; font-size: 12px; font-weight: 500; color: var(--text-light); cursor: grab; text-align: center; }
-.player-item.selected { border-color: var(--accent-red); border-width: 4px; }
-.player-name { font-weight: 700; line-height: 1.2; }
-.player-item .player-circle-static { width: 64px; height: 64px; flex: 0 0 64px; }
-.player-circle-static { width: 100%; height: 100%; background: #fff; color: #000; border-radius: 50%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-.player-circle-static img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
-.routes-panel { max-height: 90vh; overflow-y: auto; max-width: 95vw; width: 95vw; }
-.routes-board { margin-bottom: 4vw; position: relative; height: 60vh; min-height: 480px; background: #2e7d32; border: 2px solid #fff; overflow: hidden; display: flex; flex-direction: column-reverse; }
-.route-zone { position: relative; flex: 1; border-top: 2px solid #fff; }
-.route-zone > span { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: clamp(42px, 10vw, 130px); color: rgba(255,255,255,0.2); text-transform: uppercase; pointer-events: none; z-index: 0; }
-.route-drop { position: absolute; inset: 0; z-index: 1; }
-.route-read-lane { position: absolute; inset-block: 0; z-index: 1; border-left: 1px dashed rgba(255,255,255,.28); }
-.route-read-lane:first-of-type { border-left: 0; }
-.route-read-label { position: absolute; top: 4px; left: 50%; transform: translateX(-50%); color: rgba(255,255,255,.65); font-size: 12px; font-weight: 700; pointer-events: none; }
-.player-circle { position: absolute; top: 50%; transform: translate(-50%, -50%); width: clamp(60px, 8vw, 90px); height: clamp(60px, 8vw, 90px); padding: 0; border: 0; background: transparent; color: #000; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: grab; box-shadow: 0 2px 4px rgba(0,0,0,0.3); touch-action: none; z-index: 2; overflow: visible; }
-.player-circle:active { cursor: grabbing; }
-.player-circle .read-badge { position: absolute; top: 0; right: 0; transform: translate(10%, -50%); background: var(--accent-red); color: #fff; border-radius: 4px; padding: 0.25rem 0.4rem; font-size: clamp(12px, 1.6vw, 20px); z-index: 3; }
-.read-summary { background: #fff; color: #000; border-radius: 6px; padding: 2vw; margin: 2vw 0; font-size: clamp(14px, 2.5vw, 24px); }
-.read-summary .summary-row { display: flex; gap: 1vw; }
-.read-summary .summary-label { width: 30%; font-weight: 600; }
-.player-detail { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #fff; color: #000; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.5); padding: 2vw; z-index: 2001; font-size: clamp(14px, 2.5vw, 24px); }
-.los-field { background: #2e7d32; padding: 2vw; position: relative; display: flex; flex-direction: column; align-items: center; gap: 1vw; min-height: 520px; }
-.los-line { position: absolute; top: 50%; left: 0; width: 100%; height: 4px; background: #1565c0; }
-.los-row { display: flex; justify-content: center; gap: 1vw; width: 100%; min-height: 80px; z-index: 1; }
-.los-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 1vw; width: 100%; z-index: 1; }
-.los-col { display: flex; flex-direction: column; align-items: center; gap: 1vw; }
-.los-player { width: clamp(52px, 7vw, 86px); height: clamp(52px, 7vw, 86px); background: transparent; border-radius: 50%; overflow: hidden; display: flex; align-items: flex-start; justify-content: center; color: #fff; }
-.los-player img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
-.los-player.empty { visibility: hidden; }
-.formation-actions { display: flex; justify-content: flex-end; gap: 2vw; }
-@media (max-width: 700px) { .formation-field { min-width: 620px; } .routes-board { min-height: 420px; } .player-item { max-width: 100%; flex-basis: 100%; } }
-.eligible-receiver-list { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin: 0 0 16px; color: var(--text-dark); font-weight: 800; }
-.eligible-receiver-chip { display: inline-flex; align-items: center; gap: 8px; border: 2px solid var(--text-muted); border-radius: 999px; background: #fff; color: #111; padding: 6px 10px; font-size: 13px; font-weight: 800; cursor: grab; }
-.eligible-receiver-chip .los-player { width: 32px; height: 32px; flex: 0 0 32px; background: #111; color: #fff; }
-.eligible-receiver-chip:active { cursor: grabbing; }
+.formation-full-panel {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  border-radius: 0;
+  overflow: auto;
+}
+.formation-panel {
+  background: var(--gray-light);
+}
+.formation-field {
+  margin-bottom: 4vw;
+  overflow-x: auto;
+  min-width: 720px;
+}
+.formation-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2vw;
+  margin-bottom: 4vw;
+}
+.formation-row.top-row {
+  justify-content: center;
+}
+.formation-slot {
+  flex: 0 0 clamp(60px, 8vw, 90px);
+  width: clamp(60px, 8vw, 90px);
+  height: clamp(60px, 8vw, 90px);
+  border: 2px dotted var(--text-muted);
+  border-radius: 50%;
+  background: var(--gray-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(12px, 2vw, 18px);
+  font-weight: 500;
+  position: relative;
+  color: var(--text-muted);
+  overflow: hidden;
+  cursor: pointer;
+}
+.formation-slot::before {
+  content: attr(data-label);
+}
+.formation-slot.filled::before {
+  content: "";
+}
+.formation-slot.qb {
+  border-color: #64b5f6;
+  color: #64b5f6;
+}
+.formation-slot.rb {
+  border-color: #81c784;
+  color: #81c784;
+}
+.formation-slot.wr {
+  border-color: #ffb74d;
+  color: #ffb74d;
+}
+.formation-slot.teol {
+  border-color: #ba68c8;
+  color: #ba68c8;
+}
+.formation-slot.required::after {
+  content: "*";
+  color: var(--accent-red);
+  margin-left: 0.2em;
+  font-size: 1.2em;
+}
+.formation-slot.filled {
+  border-style: solid;
+}
+.formation-slot.filled::after {
+  content: "";
+}
+.formation-slot > div {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+.formation-remove {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  padding: 0;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: var(--accent-red);
+  color: #fff;
+  line-height: 18px;
+  font-size: 16px;
+  font-weight: 800;
+  z-index: 4;
+  cursor: pointer;
+}
+.bench {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25vw;
+}
+.player-item {
+  flex: 0 1 96px;
+  max-width: 110px;
+  border: 2px solid var(--text-muted);
+  border-radius: 12px;
+  background: var(--gray-dark);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-light);
+  cursor: grab;
+  text-align: center;
+}
+.player-item.selected {
+  border-color: var(--accent-red);
+  border-width: 4px;
+}
+.player-name {
+  font-weight: 700;
+  line-height: 1.2;
+}
+.player-item .player-circle-static {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 64px;
+}
+.player-circle-static {
+  width: 100%;
+  height: 100%;
+  background: #fff;
+  color: #000;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.player-circle-static img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.routes-panel {
+  max-height: 90vh;
+  overflow-y: auto;
+  max-width: 95vw;
+  width: 95vw;
+}
+.routes-board {
+  margin-bottom: 4vw;
+  position: relative;
+  height: 60vh;
+  min-height: 480px;
+  background: #2e7d32;
+  border: 2px solid #fff;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column-reverse;
+}
+.route-zone {
+  position: relative;
+  flex: 1;
+  border-top: 2px solid #fff;
+}
+.route-zone > span {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(42px, 10vw, 130px);
+  color: rgba(255, 255, 255, 0.2);
+  text-transform: uppercase;
+  pointer-events: none;
+  z-index: 0;
+}
+.route-drop {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+.route-read-lane {
+  position: absolute;
+  inset-block: 0;
+  z-index: 1;
+  border-left: 1px dashed rgba(255, 255, 255, 0.28);
+}
+.route-read-lane:first-of-type {
+  border-left: 0;
+}
+.route-read-label {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 12px;
+  font-weight: 700;
+  pointer-events: none;
+}
+.player-circle {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: clamp(60px, 8vw, 90px);
+  height: clamp(60px, 8vw, 90px);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #000;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  touch-action: none;
+  z-index: 2;
+  overflow: visible;
+}
+.player-circle:active {
+  cursor: grabbing;
+}
+.player-circle .read-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(10%, -50%);
+  background: var(--accent-red);
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.25rem 0.4rem;
+  font-size: clamp(12px, 1.6vw, 20px);
+  z-index: 3;
+}
+.read-summary {
+  background: #fff;
+  color: #000;
+  border-radius: 6px;
+  padding: 2vw;
+  margin: 2vw 0;
+  font-size: clamp(14px, 2.5vw, 24px);
+}
+.read-summary .summary-row {
+  display: flex;
+  gap: 1vw;
+}
+.read-summary .summary-label {
+  width: 30%;
+  font-weight: 600;
+}
+.player-detail {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  color: #000;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  padding: 2vw;
+  z-index: 2001;
+  font-size: clamp(14px, 2.5vw, 24px);
+}
+.los-field {
+  background: #2e7d32;
+  padding: 2vw;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1vw;
+  min-height: 520px;
+}
+.los-line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #1565c0;
+}
+.los-row {
+  display: flex;
+  justify-content: center;
+  gap: 1vw;
+  width: 100%;
+  min-height: 80px;
+  z-index: 1;
+}
+.los-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 1vw;
+  width: 100%;
+  z-index: 1;
+}
+.los-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1vw;
+}
+.los-player {
+  width: clamp(52px, 7vw, 86px);
+  height: clamp(52px, 7vw, 86px);
+  background: transparent;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  color: #fff;
+}
+.los-player img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.los-player.empty {
+  visibility: hidden;
+}
+.formation-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 2vw;
+}
+@media (max-width: 700px) {
+  .formation-field {
+    min-width: 620px;
+  }
+  .routes-board {
+    min-height: 420px;
+  }
+  .player-item {
+    max-width: 100%;
+    flex-basis: 100%;
+  }
+}
+.eligible-receiver-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 16px;
+  color: var(--text-dark);
+  font-weight: 800;
+}
+.eligible-receiver-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 2px solid var(--text-muted);
+  border-radius: 999px;
+  background: #fff;
+  color: #111;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: grab;
+}
+.eligible-receiver-chip .los-player {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  background: #111;
+  color: #fff;
+}
+.eligible-receiver-chip:active {
+  cursor: grabbing;
+}

--- a/apps/web/src/components/mainMenu/MainMenuButton.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuButton.tsx
@@ -7,7 +7,11 @@ type MainMenuButtonProps = {
 
 export function MainMenuButton({ item, onSelect }: MainMenuButtonProps) {
   return (
-    <button className="menu-button" type="button" onClick={() => onSelect(item)}>
+    <button
+      className="menu-button"
+      type="button"
+      onClick={() => onSelect(item)}
+    >
       <span>{item.label}</span>
       <span className="underline" />
     </button>

--- a/apps/web/src/components/mainMenu/MainMenuScreen.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuScreen.tsx
@@ -30,7 +30,7 @@ function fadeAudio(
   audio: HTMLAudioElement,
   from: number,
   to: number,
-  durationMs: number
+  durationMs: number,
 ) {
   const start = performance.now();
   audio.volume = from;
@@ -55,7 +55,7 @@ export function MainMenuScreen({ onNavigate }: MainMenuScreenProps) {
   const tickerRef = useRef<HTMLDivElement | null>(null);
 
   const [placeholderMessage, setPlaceholderMessage] = useState<string | null>(
-    null
+    null,
   );
 
   useEffect(() => {
@@ -143,12 +143,15 @@ export function MainMenuScreen({ onNavigate }: MainMenuScreenProps) {
     }
 
     setPlaceholderMessage(
-      item.placeholderMessage ?? `${item.label} has not been migrated yet.`
+      item.placeholderMessage ?? `${item.label} has not been migrated yet.`,
     );
   };
 
   return (
-    <section className="main-menu-screen" aria-label="Animal Football Main Menu">
+    <section
+      className="main-menu-screen"
+      aria-label="Animal Football Main Menu"
+    >
       <div className="corner tl" />
       <div className="corner tr" />
       <div className="corner bl" />
@@ -160,12 +163,10 @@ export function MainMenuScreen({ onNavigate }: MainMenuScreenProps) {
         <div className="panel">
           <div className="ticker">
             <div className="track" id="tickerTrack" ref={tickerRef}>
-              WEEK 1 • 8:00 PM ET • HOME vs AWAY{" "}
-              <span className="sep">|</span>
+              WEEK 1 • 8:00 PM ET • HOME vs AWAY <span className="sep">|</span>
               POWER RANKINGS UPDATE • TOP 5: ATL, DAL, DEN, SEA, CLT{" "}
               <span className="sep">|</span>
-              WEATHER: CLEAR • 62°F • 5 MPH WNW{" "}
-              <span className="sep">|</span>
+              WEATHER: CLEAR • 62°F • 5 MPH WNW <span className="sep">|</span>
               INJURY REPORT: RB QUESTIONABLE (ANKLE){" "}
               <span className="sep">|</span>
             </div>

--- a/apps/web/src/components/players/PlayerCard.tsx
+++ b/apps/web/src/components/players/PlayerCard.tsx
@@ -1,35 +1,39 @@
 import type { Player } from "./types";
 import { Stars } from "./Stars";
 
-const FALLBACK_PLAYER_IMAGE = "https://andrew-jacobson06.github.io/public-audio/baby.png";
+const FALLBACK_PLAYER_IMAGE =
+  "https://andrew-jacobson06.github.io/public-audio/baby.png";
 
-const traitGroups: Record<string, Array<{ key: keyof Player; label: string }>> = {
+const traitGroups: Record<
+  string,
+  Array<{ key: keyof Player; label: string }>
+> = {
   "General Traits": [
     { key: "Size", label: "Size" },
     { key: "Strength", label: "Strength" },
     { key: "Stamina", label: "Stamina" },
-    { key: "Ball Security", label: "Ball Security" }
+    { key: "Ball Security", label: "Ball Security" },
   ],
   "Passing Skills": [
     { key: "Poise", label: "Poise" },
     { key: "Accuracy", label: "Accuracy" },
     { key: "Arm-Strength", label: "Arm-Strength" },
-    { key: "Read Defense", label: "Read Defense" }
+    { key: "Read Defense", label: "Read Defense" },
   ],
   "Running Skill": [
     { key: "Acceleration", label: "Acceleration" },
     { key: "Speed", label: "Speed" },
     { key: "Juke", label: "Juke" },
-    { key: "Vision", label: "Vision" }
+    { key: "Vision", label: "Vision" },
   ],
   "Receiving Skill": [
     { key: "Route Running", label: "Route Running" },
     { key: "Jump", label: "Jump" },
-    { key: "Hands", label: "Hands" }
+    { key: "Hands", label: "Hands" },
   ],
   "Off Ball Skills": [
     { key: "Run Blocking", label: "Run Blocking" },
-    { key: "Pass Protect", label: "Pass Protect" }
+    { key: "Pass Protect", label: "Pass Protect" },
   ],
   "Defensive Skills": [
     { key: "RunStop", label: "RunStop" },
@@ -38,8 +42,8 @@ const traitGroups: Record<string, Array<{ key: keyof Player; label: string }>> =
     { key: "Strip", label: "Strip" },
     { key: "Ball Hawk", label: "Ball Hawk" },
     { key: "Read QB", label: "Read QB" },
-    { key: "Coverage", label: "Coverage" }
-  ]
+    { key: "Coverage", label: "Coverage" },
+  ],
 };
 
 function getBarColor(val: number) {
@@ -60,7 +64,10 @@ function firstNonEmpty(...values: Array<string | undefined>) {
 }
 
 function getPlayerImage(player: Player) {
-  return firstNonEmpty(player["Player Image from AI"], player.Image) || FALLBACK_PLAYER_IMAGE;
+  return (
+    firstNonEmpty(player["Player Image from AI"], player.Image) ||
+    FALLBACK_PLAYER_IMAGE
+  );
 }
 
 function getJerseyImage(player: Player) {
@@ -78,7 +85,14 @@ export function PlayerCard({ player, onBack }: PlayerCardProps) {
 
   return (
     <div id="playerCardView">
-      <button id="playerCardBack" className="back-button" type="button" onClick={onBack}>← Back</button>
+      <button
+        id="playerCardBack"
+        className="back-button"
+        type="button"
+        onClick={onBack}
+      >
+        ← Back
+      </button>
       <div className="player-card-layout">
         <div id="playerImageContainer" className="player-image-container">
           <img
@@ -86,26 +100,38 @@ export function PlayerCard({ player, onBack }: PlayerCardProps) {
             src={playerImage}
             alt="Player"
             style={{
-              transform: `translate(${numberValue(player.translateX)}px, ${numberValue(player.translateY)}px) scale(${numberValue(player.scale, 1)})`
+              transform: `translate(${numberValue(player.translateX)}px, ${numberValue(player.translateY)}px) scale(${numberValue(player.scale, 1)})`,
             }}
           />
           <div id="jersey-wrapper">
-            {jerseyImage && <img id="jersey" src={jerseyImage} alt="Jersey Overlay" />}
+            {jerseyImage && (
+              <img id="jersey" src={jerseyImage} alt="Jersey Overlay" />
+            )}
           </div>
         </div>
         <div id="playerDetails" className="player-details">
-          <div><strong>{player.Name}</strong></div>
+          <div>
+            <strong>{player.Name}</strong>
+          </div>
           <div>{player.Team}</div>
-          <div>{player.Pos} / {player.DefPos}</div>
-          <div>Off: <Stars value={player["Off Stars"]} /></div>
-          <div>Def: <Stars value={player["Def Stars"]} /></div>
+          <div>
+            {player.Pos} / {player.DefPos}
+          </div>
+          <div>
+            Off: <Stars value={player["Off Stars"]} />
+          </div>
+          <div>
+            Def: <Stars value={player["Def Stars"]} />
+          </div>
         </div>
         <div id="playerTraitBars" className="player-trait-bars">
           {Object.entries(traitGroups).map(([groupName, traits]) => (
             <details className="trait-group" open key={groupName}>
               <summary>{groupName}</summary>
               {traits.map((trait) => {
-                const val = numberValue(player[trait.key] as string | number | undefined);
+                const val = numberValue(
+                  player[trait.key] as string | number | undefined,
+                );
                 return (
                   <div className="trait-bar-card" key={trait.label}>
                     <div className="trait-bar-header">
@@ -113,7 +139,10 @@ export function PlayerCard({ player, onBack }: PlayerCardProps) {
                       <span className="trait-value">{val}</span>
                     </div>
                     <div className="progress">
-                      <div className={`progress-bar ${getBarColor(val)}`} style={{ width: `${val}%` }} />
+                      <div
+                        className={`progress-bar ${getBarColor(val)}`}
+                        style={{ width: `${val}%` }}
+                      />
                     </div>
                   </div>
                 );

--- a/apps/web/src/components/players/PlayerList.tsx
+++ b/apps/web/src/components/players/PlayerList.tsx
@@ -7,10 +7,21 @@ type PlayerListProps = {
   onBack?: () => void;
 };
 
-export function PlayerList({ players, onSelectPlayer, onBack }: PlayerListProps) {
+export function PlayerList({
+  players,
+  onSelectPlayer,
+  onBack,
+}: PlayerListProps) {
   return (
     <div id="playerListView">
-      <button id="playerListBack" className="back-button" type="button" onClick={onBack}>← Back</button>
+      <button
+        id="playerListBack"
+        className="back-button"
+        type="button"
+        onClick={onBack}
+      >
+        ← Back
+      </button>
       <table id="playerTable" className="player-table">
         <thead>
           <tr>
@@ -22,11 +33,18 @@ export function PlayerList({ players, onSelectPlayer, onBack }: PlayerListProps)
         </thead>
         <tbody>
           {players.map((player, index) => (
-            <tr key={`${player.Name ?? "player"}-${index}`} onClick={() => onSelectPlayer(player)}>
+            <tr
+              key={`${player.Name ?? "player"}-${index}`}
+              onClick={() => onSelectPlayer(player)}
+            >
               <td>{player.Name}</td>
-              <td>{player.Pos}/{player.DefPos}</td>
               <td>
-                O:<Stars value={player["Off Stars"]} /> D:<Stars value={player["Def Stars"]} />
+                {player.Pos}/{player.DefPos}
+              </td>
+              <td>
+                O:
+                <Stars value={player["Off Stars"]} /> D:
+                <Stars value={player["Def Stars"]} />
               </td>
               <td>{player.Team}</td>
             </tr>

--- a/apps/web/src/components/players/PlayersScreen.tsx
+++ b/apps/web/src/components/players/PlayersScreen.tsx
@@ -30,14 +30,27 @@ export function PlayersScreen({ onBack }: PlayersScreenProps) {
   }, []);
 
   if (selectedPlayer) {
-    return <PlayerCard player={selectedPlayer} onBack={() => setSelectedPlayer(null)} />;
+    return (
+      <PlayerCard
+        player={selectedPlayer}
+        onBack={() => setSelectedPlayer(null)}
+      />
+    );
   }
 
   return (
     <>
       {isLoading && <p className="players-message">Loading players...</p>}
-      {error && <p className="players-message players-message--error">{error}</p>}
-      {!isLoading && !error && <PlayerList players={players} onSelectPlayer={setSelectedPlayer} onBack={onBack} />}
+      {error && (
+        <p className="players-message players-message--error">{error}</p>
+      )}
+      {!isLoading && !error && (
+        <PlayerList
+          players={players}
+          onSelectPlayer={setSelectedPlayer}
+          onBack={onBack}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/components/players/Stars.tsx
+++ b/apps/web/src/components/players/Stars.tsx
@@ -11,11 +11,15 @@ export function Stars({ value }: StarsProps) {
   return (
     <span className="stars" aria-label={`${numericValue} stars`}>
       {Array.from({ length: full }, (_, index) => (
-        <span className="star full" key={`full-${index}`}>★</span>
+        <span className="star full" key={`full-${index}`}>
+          ★
+        </span>
       ))}
       {half && <span className="star half">★</span>}
       {Array.from({ length: empty }, (_, index) => (
-        <span className="star empty" key={`empty-${index}`}>★</span>
+        <span className="star empty" key={`empty-${index}`}>
+          ★
+        </span>
       ))}
     </span>
   );

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
### Motivation
- The web frontend contained many long/minified lines and dense single-line expressions that made editing difficult, so files were reformatted for readability with consistent line breaks and indentation.
- Keep existing behavior while making JSX, TypeScript, and CSS easier to scan and edit for future changes.

### Description
- Ran a code formatter across `apps/web/src` to expand long imports, inline objects, JSX and helper functions; major files improved include `GameCenter.tsx`, `GameControls.tsx`, `GameField.tsx`, `GameControls.css`, and multiple gameplay engine modules under `gameplay/engine`.
- Normalized multiline import/exports, function signatures, object literals, and type declarations to use explicit line breaks and consistent indentation without changing intent.
- Cleaned up CSS formatting and multiline values in `App.css` and component CSS to improve maintainability.
- Minor whitespace and readability adjustments in player components and small helpers; no intentional logic changes were introduced.

### Testing
- Ran the formatter command `npx prettier@latest --write apps/web/src` which completed successfully.
- Ran linting with `npm run lint` (ESLint) which completed without errors.
- Built the web app with `npm run build` (TypeScript + Vite) which succeeded and produced a valid `dist`.
- Ran `git diff --check` to ensure no trailing/diff issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a584a38d9e883248c92502bdc00b56b)