### PR TITLE
Remove LOS preview controls and CSS conflicts

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -103,7 +103,7 @@ function PlayerBubble({
   const src = imgOf(player);
   return (
     <div
-      className={`${small ? "los-player" : "player-circle-static"} ${name ? "" : "empty"}`}
+      className={`${small ? "control-player-bubble" : "player-circle-static"} ${name ? "" : "empty"}`}
     >
       {name && (src ? <img src={src} alt={name} /> : <span>👤</span>)}
     </div>
@@ -203,7 +203,7 @@ export function GameControls({
 }: Props) {
   const [collapsed, setCollapsed] = useState(false);
   const [modal, setModal] = useState<
-    "formation" | "los" | "routes" | "run" | "clock" | null
+    "formation" | "routes" | "run" | "clock" | null
   >(null);
   const [selected, setSelected] = useState<string>("");
   const [detail, setDetail] = useState<string>("");
@@ -279,10 +279,6 @@ export function GameControls({
     defense,
   });
 
-  const supplementalDefenseRows = [
-    defense.filter((d) => d.position.startsWith("S")),
-    defense.filter((d) => d.position.startsWith("LB")),
-  ].filter((row) => row.length > 0);
   return (
     <div
       className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}
@@ -299,7 +295,6 @@ export function GameControls({
           <h3>{offenseTeam} Play Caller</h3>
           <div className="game-controls">
             <button onClick={() => setModal("formation")}>Formation</button>
-            <button onClick={() => setModal("los")}>View LOS</button>
             <button onClick={() => setModal("routes")}>Routes</button>
             <button onClick={() => setModal("run")}>Run Modal</button>
             <button onClick={() => setModal("clock")}>Clock</button>
@@ -492,61 +487,6 @@ export function GameControls({
             <button disabled={!validFormation} onClick={() => setModal(null)}>
               Save
             </button>
-          </div>
-        </ControlModal>
-      )}
-      {modal === "los" && (
-        <ControlModal wide onClose={() => setModal(null)}>
-          <h3>Line of Scrimmage</h3>
-          <div className="los-field">
-            <div className="los-line" />
-            {supplementalDefenseRows.map((row, index) => (
-              <div className="los-row" key={`defense-row-${index}`}>
-                {row.map((d) => (
-                  <PlayerBubble
-                    key={d.position}
-                    small
-                    name={d.player}
-                    player={byName(d.player)}
-                  />
-                ))}
-              </div>
-            ))}
-            <div className="los-grid">
-              {LINE_SLOTS.map((slot) => (
-                <div className="los-col" key={slot}>
-                  <PlayerBubble
-                    small
-                    name={defense.find((d) => d.align === slot)?.player}
-                    player={byName(
-                      defense.find((d) => d.align === slot)?.player,
-                    )}
-                  />
-                  <PlayerBubble
-                    small
-                    name={formation[slot]}
-                    player={byName(formation[slot])}
-                  />
-                </div>
-              ))}
-            </div>
-            <div className="los-row">
-              <PlayerBubble
-                small
-                name={formation.QB}
-                player={byName(formation.QB)}
-              />
-            </div>
-            <div className="los-row">
-              {(["RB1", "RB2"] as FormationSlot[]).map((s) => (
-                <PlayerBubble
-                  key={s}
-                  small
-                  name={formation[s]}
-                  player={byName(formation[s])}
-                />
-              ))}
-            </div>
           </div>
         </ControlModal>
       )}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1249,45 +1249,6 @@
   background: #111;
   color: white;
 }
-.los-preview {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(8, minmax(70px, 1fr));
-  gap: 10px;
-  padding: 28px 12px;
-  background: #1f7a3a;
-  border-radius: 14px;
-}
-.los-defense,
-.los-backfield {
-  grid-column: 1 / -1;
-  text-align: center;
-  font-weight: 700;
-}
-.los-line-react {
-  grid-column: 1 / -1;
-  height: 4px;
-  background: #61a5ff;
-}
-.los-token {
-  min-height: 78px;
-  padding: 8px;
-  border-radius: 999px;
-  background: #ffffffee;
-  color: #111;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-size: 12px;
-}
-.los-backfield {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-  flex-wrap: wrap;
-}
 .route-list {
   display: grid;
   gap: 10px;
@@ -1345,9 +1306,6 @@
 @media (max-width: 700px) {
   .route-row {
     grid-template-columns: 1fr;
-  }
-  .los-preview {
-    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -1625,65 +1583,6 @@
   z-index: 2001;
   font-size: clamp(14px, 2.5vw, 24px);
 }
-.los-field {
-  background: #2e7d32;
-  padding: 2vw;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1vw;
-  min-height: 520px;
-}
-.los-line {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 4px;
-  background: #1565c0;
-}
-.los-row {
-  display: flex;
-  justify-content: center;
-  gap: 1vw;
-  width: 100%;
-  min-height: 80px;
-  z-index: 1;
-}
-.los-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  gap: 1vw;
-  width: 100%;
-  z-index: 1;
-}
-.los-col {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1vw;
-}
-.los-player {
-  width: clamp(52px, 7vw, 86px);
-  height: clamp(52px, 7vw, 86px);
-  background: transparent;
-  border-radius: 50%;
-  overflow: hidden;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  color: #fff;
-}
-.los-player img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
-}
-.los-player.empty {
-  visibility: hidden;
-}
 .formation-actions {
   display: flex;
   justify-content: flex-end;
@@ -1723,7 +1622,27 @@
   font-weight: 800;
   cursor: grab;
 }
-.eligible-receiver-chip .los-player {
+.control-player-bubble {
+  width: clamp(52px, 7vw, 86px);
+  height: clamp(52px, 7vw, 86px);
+  background: transparent;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  color: #fff;
+}
+.control-player-bubble img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.control-player-bubble.empty {
+  visibility: hidden;
+}
+.eligible-receiver-chip .control-player-bubble {
   width: 32px;
   height: 32px;
   flex: 0 0 32px;
@@ -1772,16 +1691,9 @@
 .read-summary .summary-row { display: flex; gap: 1vw; }
 .read-summary .summary-label { width: 30%; font-weight: 600; }
 .player-detail { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #fff; color: #000; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.5); padding: 2vw; z-index: 2001; font-size: clamp(14px, 2.5vw, 24px); }
-.los-field { background: #2e7d32; padding: 2vw; position: relative; display: flex; flex-direction: column; align-items: center; gap: 1vw; min-height: 520px; }
-
-.los-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 1vw; width: 100%; z-index: 1; }
-.los-col { display: flex; flex-direction: column; align-items: center; gap: 1vw; }
-.los-player { width: clamp(52px, 7vw, 86px); height: clamp(52px, 7vw, 86px); background: transparent; border-radius: 50%; overflow: hidden; display: flex; align-items: flex-start; justify-content: center; color: #fff; }
-.los-player img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
-.los-player.empty { visibility: hidden; }
 .formation-actions { display: flex; justify-content: flex-end; gap: 2vw; }
 @media (max-width: 700px) { .formation-field { min-width: 620px; } .routes-board { min-height: 420px; } .player-item { max-width: 100%; flex-basis: 100%; } }
 .eligible-receiver-list { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin: 0 0 16px; color: var(--text-dark); font-weight: 800; }
 .eligible-receiver-chip { display: inline-flex; align-items: center; gap: 8px; border: 2px solid var(--text-muted); border-radius: 999px; background: #fff; color: #111; padding: 6px 10px; font-size: 13px; font-weight: 800; cursor: grab; }
-.eligible-receiver-chip .los-player { width: 32px; height: 32px; flex: 0 0 32px; background: #111; color: #fff; }
+.eligible-receiver-chip .control-player-bubble { width: 32px; height: 32px; flex: 0 0 32px; background: #111; color: #fff; }
 .eligible-receiver-chip:active { cursor: grabbing; }


### PR DESCRIPTION
### Motivation
- The play-caller LOS preview UI and `league.css` contained styles that conflicted with the canonical LOS styles in `GameField.css`, causing visual overlap and unintended styling.
- The LOS preview modal in the play-caller is redundant and unreachable in the new UI flow, so removing it simplifies maintenance and prevents regressions.

### Description
- Removed the `View LOS` control and the LOS modal rendering path from `apps/web/src/components/league/GameControls.tsx` and removed `"los"` from the modal state union so the LOS modal can no longer be opened via the play caller.
- Dropped the `supplementalDefenseRows` helper usage which was only needed by the removed LOS modal in `GameControls.tsx`.
- Renamed the small player bubble class from `los-player` to `control-player-bubble` in `PlayerBubble` (in `GameControls.tsx`) to avoid namespace collision with field LOS styles and updated dependent markup.
- Deleted legacy `los-*` preview/modal CSS rules from `apps/web/src/components/league/league.css` and added a scoped `.control-player-bubble` block so receiver chips keep the intended small-bubble styling without using the `los-` namespace, leaving `apps/web/src/components/league/GameField.css` as the source of truth for LOS visuals.

### Testing
- Built the web app with `npm run build` in `apps/web`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c2de2d0408324bf1b59feb3325391)