### PR TITLE
Update main menu navigation

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -26,41 +26,6 @@ body {
   min-height: 100vh;
 }
 
-.backend-status {
-  display: none;
-  position: fixed;
-  right: 1vw;
-  top: 1vw;
-  z-index: 120;
-  max-width: 38vw;
-  padding: 0.65vw 1vw;
-  background: rgba(30, 30, 30, 0.92);
-  border: 1px solid #27ae60;
-  color: var(--text-light);
-  font-size: clamp(10px, 1.2vw, 14px);
-}
-
-.backend-status--error {
-  border-color: #e74c3c;
-}
-
-.migration-nav {
-  display: none;
-  position: fixed;
-  top: calc(1vw + 44px);
-  left: 1vw;
-  z-index: 110;
-}
-
-.migration-nav__button {
-  background: var(--accent-red);
-  color: var(--text-light);
-  border: none;
-  padding: 0.7vw 1.4vw;
-  cursor: pointer;
-  font-family: inherit;
-}
-
 .back-button {
   position: fixed;
   top: 1vw;
@@ -75,6 +40,10 @@ body {
 
 #playerListView {
   padding: 2vw;
+}
+
+.league-app__back {
+  top: 1.25rem;
 }
 
 .player-table {
@@ -254,27 +223,6 @@ body {
 
 .players-message--error {
   color: #fecaca;
-}
-
-.migration-nav {
-  display: flex;
-  gap: 0.4rem;
-}
-
-.migration-nav__button--active {
-  background: var(--accent-red-dark);
-  box-shadow: 0 0 12px rgba(255, 59, 59, 0.45);
-}
-
-.debug-status-screen {
-  min-height: 100vh;
-  padding: 8rem 2rem 2rem;
-  box-sizing: border-box;
-}
-
-.debug-status-screen__back {
-  position: static;
-  margin-top: 1rem;
 }
 
 .main-menu-screen {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,48 +1,16 @@
 import { useState } from "react";
-import { BackendStatus } from "./components/BackendStatus";
 import { MainMenuScreen } from "./components/mainMenu/MainMenuScreen";
 import { PlayersScreen } from "./components/players/PlayersScreen";
 import { LeagueAppScreen } from "./components/league/LeagueAppScreen";
 import "./App.css";
 
-export type Screen = "mainMenu" | "players" | "league" | "debug";
+export type Screen = "mainMenu" | "players" | "league";
 
 function App() {
   const [screen, setScreen] = useState<Screen>("mainMenu");
 
   return (
     <main className="app">
-      <BackendStatus />
-      <nav className="migration-nav" aria-label="Migration screens">
-        <button
-          className={`migration-nav__button ${screen === "mainMenu" ? "migration-nav__button--active" : ""}`}
-          type="button"
-          onClick={() => setScreen("mainMenu")}
-        >
-          Main Menu
-        </button>
-        <button
-          className={`migration-nav__button ${screen === "players" ? "migration-nav__button--active" : ""}`}
-          type="button"
-          onClick={() => setScreen("players")}
-        >
-          Players
-        </button>
-        <button
-          className={`migration-nav__button ${screen === "league" ? "migration-nav__button--active" : ""}`}
-          type="button"
-          onClick={() => setScreen("league")}
-        >
-          League App
-        </button>
-        <button
-          className={`migration-nav__button ${screen === "debug" ? "migration-nav__button--active" : ""}`}
-          type="button"
-          onClick={() => setScreen("debug")}
-        >
-          Backend Status
-        </button>
-      </nav>
       {screen === "mainMenu" && (
         <MainMenuScreen
           onNavigate={(nextScreen) => nextScreen && setScreen(nextScreen)}
@@ -51,22 +19,8 @@ function App() {
       {screen === "players" && (
         <PlayersScreen onBack={() => setScreen("mainMenu")} />
       )}
-      {screen === "league" && <LeagueAppScreen />}
-      {screen === "debug" && (
-        <section className="debug-status-screen">
-          <h1>Backend / Debug Status</h1>
-          <p>
-            The backend connection indicator remains visible in the top-right
-            corner.
-          </p>
-          <button
-            className="back-button debug-status-screen__back"
-            type="button"
-            onClick={() => setScreen("mainMenu")}
-          >
-            ← Back
-          </button>
-        </section>
+      {screen === "league" && (
+        <LeagueAppScreen onBack={() => setScreen("mainMenu")} />
       )}
     </main>
   );

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -10,7 +10,11 @@ import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
 import "./league.css";
-export function LeagueAppScreen() {
+type LeagueAppScreenProps = {
+  onBack?: () => void;
+};
+
+export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [activeTab, setActiveTab] = useState<LeagueTab>("scores");
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
@@ -121,6 +125,15 @@ export function LeagueAppScreen() {
       )}
       {!loadingGame && (
         <>
+          {onBack && (
+            <button
+              className="back-button league-app__back"
+              type="button"
+              onClick={onBack}
+            >
+              ← Back
+            </button>
+          )}
           <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
           <div id="tabContents">
             {activeTab === "news" && (

--- a/apps/web/src/components/mainMenu/MainMenuScreen.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuScreen.tsx
@@ -10,11 +10,7 @@ const MENU_SONG_URL =
 
 const menuItems: MainMenuItem[] = [
   { label: "View Players", screen: "players" },
-  {
-    label: "Existing League",
-    placeholderMessage:
-      "Existing League has not been migrated yet. TODO: connect this button when the Games/League screen is ported.",
-  },
+  { label: "Existing League", screen: "league" },
   {
     label: "New League",
     placeholderMessage:


### PR DESCRIPTION
### Motivation
- Remove the temporary top migration navigation and backend/debug status cluttering the app shell to make the main menu the primary navigation entry point.
- Wire migrated screens into the main menu so users can open the league and players flows from the in-app menu rather than hidden top buttons.

### Description
- Removed the `BackendStatus` import and the top `migration-nav` block from `apps/web/src/App.tsx` and trimmed the `Screen` type to remove `debug`.
- Updated `apps/web/src/components/mainMenu/MainMenuScreen.tsx` so the `Existing League` menu item now navigates to the `league` screen and `View Players` remains mapped to `players`.
- Modified `apps/web/src/components/league/LeagueAppScreen.tsx` to accept an optional `onBack` prop and render a back button when provided, allowing return to the main menu.
- Cleaned up obsolete CSS rules for `.backend-status`, `.migration-nav`, and debug-screen in `apps/web/src/App.css` and added positioning for `.league-app__back`.

### Testing
- Ran `npm run build` in `apps/web` and the production build completed successfully.
- Ran `npm run lint` in `apps/web` and ESLint reported no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c368617c4832481e902c5eed11129)