### PR TITLE
Add field control console and player action menus

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1476,19 +1476,21 @@ export function GameCenter({
               </div>
             </div>
           </div>
-          <GameField />
+          <div className="field-console-stage">
+            <GameField />
+            <GameControls
+              game={currentGame}
+              players={players}
+              options={playOptions}
+              onOptionsChange={setPlayOptions}
+              onAction={action}
+            />
+          </div>
           {lastPlay && (
             <div className="last-play-desc">
               <strong>Last Play:</strong> {lastPlay}
             </div>
           )}
-          <GameControls
-            game={currentGame}
-            players={players}
-            options={playOptions}
-            onOptionsChange={setPlayOptions}
-            onAction={action}
-          />
           <ScoreChart game={currentGame} history={history} />
           <LeaderCard
             game={currentGame}

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -201,7 +201,7 @@ export function GameControls({
   onOptionsChange,
   onAction,
 }: Props) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
   const [modal, setModal] = useState<
     "formation" | "routes" | "run" | "clock" | null
   >(null);
@@ -288,17 +288,11 @@ export function GameControls({
         type="button"
         onClick={() => setCollapsed(!collapsed)}
       >
-        {collapsed ? "Open Play Caller" : "Collapse Play Caller"}
+        {collapsed ? "Open Controls" : "Minimize Controls"}
       </button>
       {!collapsed && (
         <>
-          <h3>{offenseTeam} Play Caller</h3>
-          <div className="game-controls">
-            <button onClick={() => setModal("formation")}>Formation</button>
-            <button onClick={() => setModal("routes")}>Routes</button>
-            <button onClick={() => setModal("run")}>Run Modal</button>
-            <button onClick={() => setModal("clock")}>Clock</button>
-          </div>
+          <h3>{offenseTeam} Control Console</h3>
           <div className="play-call-summary">
             <span>
               {validFormation ? "Formation ready" : "Set required formation"}
@@ -307,24 +301,21 @@ export function GameControls({
             <span>Clock: {options.clockMode || "Normal"}</span>
           </div>
           <div className="game-controls primary">
+            <button onClick={() => setModal("formation")}>Set Formation</button>
             <button
               disabled={!validFormation}
               onClick={() => onAction("Run Play", optionsWithDefense())}
             >
-              Run Play
+              Call Run Play
             </button>
-
             <button
-              disabled={!validFormation || !canPass}
-              onClick={() => onAction("Pass Play", options)}
+              disabled={!validFormation}
+              onClick={() => {
+                if (!canPass) setModal("routes");
+                else onAction("Pass Play", options);
+              }}
             >
-              Pass Play
-            </button>
-            <button onClick={() => onAction("Field Goal", options)}>FG</button>
-            <button onClick={() => onAction("Punt", options)}>Punt</button>
-            <button onClick={() => onAction("Two Point", options)}>2PT</button>
-            <button onClick={() => onAction("Timeout", options)}>
-              Timeout
+              Call Pass Play
             </button>
           </div>
         </>

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -518,3 +518,53 @@ textarea {
       0 0 44px rgba(248, 113, 113, 0.82);
   }
 }
+
+.token {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.token:focus-visible img {
+  outline: 3px solid #facc15;
+  outline-offset: 4px;
+}
+
+.player-action-menu {
+  position: absolute;
+  z-index: 180;
+  min-width: 178px;
+  padding: 10px;
+  border: 1px solid rgba(248, 250, 252, 0.28);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.48);
+  transform: translate(-50%, calc(-100% - 42px));
+}
+
+.player-action-menu-title {
+  margin-bottom: 8px;
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.player-action-menu button {
+  width: 100%;
+  margin-top: 6px;
+  border: 0;
+  border-radius: 10px;
+  padding: 9px 10px;
+  background: #334155;
+  color: #f8fafc;
+  font-weight: 800;
+  cursor: pointer;
+  text-align: left;
+}
+
+.player-action-menu button:hover,
+.player-action-menu button:focus-visible {
+  background: #ef4444;
+}

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import "./GameField.css";
 
@@ -214,6 +214,11 @@ export default function GameField() {
   const isRunningRef = useRef(false);
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
+  const [selectedPlayerMenu, setSelectedPlayerMenu] = useState<{
+    player: AnimationPlayer;
+    leftPct: number;
+    topPct: number;
+  } | null>(null);
 
   const showError = useCallback((message: string) => {
     if (errorBoxRef.current) {
@@ -463,6 +468,7 @@ export default function GameField() {
       stopFootballFollow();
       playersRef.current = {};
       labelsRef.current = {};
+      setSelectedPlayerMenu(null);
       footballCarrierIdRef.current = null;
       if (scoreMainRef.current)
         scoreMainRef.current.textContent =
@@ -581,6 +587,20 @@ export default function GameField() {
         label.textContent = player.name;
         el.appendChild(img);
         el.appendChild(label);
+        el.tabIndex = 0;
+        el.setAttribute("role", "button");
+        el.setAttribute("aria-label", `Open ${player.name} player actions`);
+        const openPlayerMenu = (event: MouseEvent | KeyboardEvent) => {
+          event.stopPropagation();
+          const target = event.currentTarget as HTMLDivElement;
+          const leftPct = parseFloat(target.style.left) || player.x;
+          const topPct = parseFloat(target.style.top) || yardToYPct(player.yard);
+          setSelectedPlayerMenu({ player, leftPct, topPct });
+        };
+        el.addEventListener("click", openPlayerMenu);
+        el.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") openPlayerMenu(event);
+        });
         field.appendChild(el);
         playersRef.current[player.id] = {
           ...player,
@@ -768,7 +788,12 @@ export default function GameField() {
   return (
     <div className="game-shell">
       <div className="field-viewport" id="fieldViewport" ref={fieldViewportRef}>
-        <div className="field-wrap" id="field" ref={fieldRef}>
+        <div
+          className="field-wrap"
+          id="field"
+          ref={fieldRef}
+          onClick={() => setSelectedPlayerMenu(null)}
+        >
           <div className="field-title">Dynamic Football Animation View</div>
           <div className="team-end" id="cltEnd" ref={cltEndRef}>
             WILDFIRE
@@ -789,6 +814,22 @@ export default function GameField() {
             END
           </div>
           <div className="football" id="football" ref={footballRef} />
+          {selectedPlayerMenu && (
+            <div
+              className="player-action-menu"
+              style={{
+                left: `${selectedPlayerMenu.leftPct}%`,
+                top: `${selectedPlayerMenu.topPct}%`,
+              }}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="player-action-menu-title">
+                {selectedPlayerMenu.player.name}
+              </div>
+              <button type="button">Substitute</button>
+              <button type="button">Change Position</button>
+            </div>
+          )}
         </div>
       </div>
       <div className="caption" id="caption" ref={captionRef}>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1696,3 +1696,72 @@
 .eligible-receiver-chip { display: inline-flex; align-items: center; gap: 8px; border: 2px solid var(--text-muted); border-radius: 999px; background: #fff; color: #111; padding: 6px 10px; font-size: 13px; font-weight: 800; cursor: grab; }
 .eligible-receiver-chip .control-player-bubble { width: 32px; height: 32px; flex: 0 0 32px; background: #111; color: #fff; }
 .eligible-receiver-chip:active { cursor: grabbing; }
+
+.field-console-stage {
+  position: relative;
+}
+
+.field-console-stage .play-caller {
+  position: absolute;
+  right: clamp(14px, 2.5vw, 28px);
+  top: 656px;
+  z-index: 300;
+  transform: translateY(-100%);
+  width: min(760px, calc(100% - 28px));
+  margin: 0;
+  border-color: rgba(248, 250, 252, 0.28);
+  background: rgba(15, 23, 42, 0.94);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(12px);
+}
+
+.field-console-stage .play-caller.collapsed {
+  width: auto;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
+}
+
+.field-console-stage .control-panel-toggle {
+  width: auto;
+  min-width: 150px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.42);
+}
+
+.field-console-stage .play-caller:not(.collapsed) .control-panel-toggle {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  min-width: 0;
+  padding: 8px 12px;
+}
+
+.field-console-stage .play-caller h3 {
+  margin: 0 135px 12px 0;
+}
+
+.field-console-stage .play-call-summary {
+  margin-bottom: 8px;
+}
+
+.field-console-stage .game-controls.primary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field-console-stage .game-controls.primary button {
+  min-height: 48px;
+}
+
+@media (max-width: 720px) {
+  .field-console-stage .play-caller {
+    top: 644px;
+  }
+
+  .field-console-stage .game-controls.primary {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make play controls accessible while viewing the field so an operator can manage plays without leaving the field view.  
- Reduce control surface complexity for the initial iteration by exposing only the key actions for calling plays.  
- Allow interacting directly with players on the field to support substitutions and position changes via an in-context menu.

### Description
- Move `GameControls` into a field overlay wrapper (`.field-console-stage`) in `GameCenter` so the console sits over the field and can be minimized to the bottom-right.  
- Update `GameControls` to start collapsed by default and expose three actions: `Set Formation`, `Call Run Play`, and `Call Pass Play` (with the `Call Pass Play` flow opening routes modal if routes are not set).  
- Add keyboard-focusable, clickable player tokens in `GameField` and open a contextual player action popup with `Substitute` and `Change Position` options when a token is activated.  
- Add styling for the overlay console and player action menu in `league.css` and `GameField.css`, and ensure the popup positions relative to the selected token.

### Testing
- Built the web app with `npm run build` and the production build completed successfully.  
- Ran linting with `npm run lint` and the codebase passed lint checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c3db5f1408324b72773ca22ce5a46)