### PR TITLE
Make game field collapsible in GameCenter

### DIFF
--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -1,0 +1,41 @@
+.game-field-panel {
+  margin: clamp(16px, 3vw, 28px) 0;
+}
+
+.game-field-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 16px;
+  padding: 12px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.game-field-toggle:hover,
+.game-field-toggle:focus-visible {
+  border-color: rgba(248, 250, 252, 0.45);
+  background: rgba(30, 41, 59, 0.96);
+}
+
+.game-field-toggle:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.85);
+  outline-offset: 2px;
+}
+
+.game-field-toggle-status {
+  color: #cbd5e1;
+  font-size: 0.85em;
+}
+
+.game-field-content {
+  margin-top: 12px;
+}

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1285,6 +1285,7 @@ export function GameCenter({
     "Loading game state, play history, players, and frontend settings...",
   ]);
   const [isSavingPlay, setIsSavingPlay] = useState(false);
+  const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
   const ctx = useMemo(
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
@@ -1476,7 +1477,25 @@ export function GameCenter({
               </div>
             </div>
           </div>
-          <GameField />
+          <section className="game-field-panel" aria-label="Game field">
+            <button
+              className="game-field-toggle"
+              type="button"
+              aria-expanded={!isGameFieldCollapsed}
+              aria-controls="game-field-content"
+              onClick={() => setIsGameFieldCollapsed((collapsed) => !collapsed)}
+            >
+              <span>Game Field</span>
+              <span className="game-field-toggle-status">
+                {isGameFieldCollapsed ? "Show" : "Hide"}
+              </span>
+            </button>
+            {!isGameFieldCollapsed && (
+              <div id="game-field-content" className="game-field-content">
+                <GameField />
+              </div>
+            )}
+          </section>
           {lastPlay && (
             <div className="last-play-desc">
               <strong>Last Play:</strong> {lastPlay}


### PR DESCRIPTION
### Motivation
- Allow the game field to be collapsed from the GameCenter UI to free up space and avoid rendering the animation when not needed.

### Description
- Add `isGameFieldCollapsed` state to `GameCenter.tsx` and toggle it with `setIsGameFieldCollapsed`.
- Wrap `GameField` in a new `<section className="game-field-panel">` and expose an accessible toggle button with `aria-expanded` and `aria-controls` that shows `Show`/`Hide` status text.
- Add `apps/web/src/components/league/GameCenter.css` with styles for `.game-field-panel`, `.game-field-toggle`, `.game-field-toggle-status`, and `.game-field-content`.
- Render `GameField` only when expanded to avoid unnecessary DOM/animation work.

### Testing
- Ran `npm --prefix apps/web run lint` which completed successfully.
- Ran `npm --prefix apps/web run build` which produced a successful production build.
- Attempted Playwright screenshot via `npx --yes playwright install chromium` and `npx --yes playwright screenshot`, but the browser download failed with a CDN `403 Domain forbidden` so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c3e1881c883248a84150767a51e2c)