### PR TITLE
Make game field collapsible in GameCenter

### DIFF
--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -1,0 +1,67 @@
+.game-field-toggle {
+  position: absolute;
+  top: clamp(12px, 2vw, 20px);
+  right: clamp(12px, 2vw, 20px);
+  z-index: 350;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(248, 250, 252, 0.28);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.86);
+  color: #f8fafc;
+  padding: 10px 14px;
+  font-size: clamp(13px, 2vw, 16px);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.34);
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+}
+
+.game-field-toggle:hover,
+.game-field-toggle:focus-visible {
+  border-color: var(--accent-red);
+  color: #fff;
+  outline: none;
+}
+
+.game-field-toggle-icon {
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.game-field-panel[hidden] {
+  display: none;
+}
+
+.field-console-stage.field-collapsed {
+  padding-top: 68px;
+}
+
+.field-console-stage.field-collapsed .game-field-toggle {
+  left: clamp(12px, 2vw, 20px);
+  right: auto;
+}
+
+.field-console-stage.field-collapsed .play-caller {
+  position: relative;
+  top: auto;
+  right: auto;
+  transform: none;
+  width: min(760px, calc(100% - 28px));
+  margin: 0 auto;
+}
+
+@media (max-width: 720px) {
+  .game-field-toggle {
+    left: clamp(10px, 3vw, 16px);
+    right: clamp(10px, 3vw, 16px);
+    justify-content: center;
+  }
+
+  .field-console-stage.field-collapsed .game-field-toggle {
+    right: clamp(10px, 3vw, 16px);
+  }
+}

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1285,6 +1285,7 @@ export function GameCenter({
     "Loading game state, play history, players, and frontend settings...",
   ]);
   const [isSavingPlay, setIsSavingPlay] = useState(false);
+  const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
   const ctx = useMemo(
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
@@ -1476,8 +1477,30 @@ export function GameCenter({
               </div>
             </div>
           </div>
-          <div className="field-console-stage">
-            <GameField />
+          <div
+            className={`field-console-stage ${isGameFieldCollapsed ? "field-collapsed" : ""}`}
+          >
+            <button
+              className="game-field-toggle"
+              type="button"
+              aria-expanded={!isGameFieldCollapsed}
+              aria-controls="game-field-panel"
+              onClick={() => setIsGameFieldCollapsed((collapsed) => !collapsed)}
+            >
+              <span>
+                {isGameFieldCollapsed ? "Show Gamefield" : "Hide Gamefield"}
+              </span>
+              <span className="game-field-toggle-icon" aria-hidden="true">
+                {isGameFieldCollapsed ? "▾" : "▴"}
+              </span>
+            </button>
+            <div
+              id="game-field-panel"
+              className="game-field-panel"
+              hidden={isGameFieldCollapsed}
+            >
+              <GameField />
+            </div>
             <GameControls
               game={currentGame}
               players={players}


### PR DESCRIPTION
### Motivation
- Provide a way to hide the visual game field to save vertical space while keeping the play controls available. 
- Improve usability on smaller screens and allow users to focus on controls/logs without the field rendering.

### Description
- Added a boolean state `isGameFieldCollapsed` to `GameCenter` in `apps/web/src/components/league/GameCenter.tsx` to track collapse state. 
- Inserted an accessible toggle button (with `aria-expanded` and `aria-controls`) that shows or hides the field and updates the `#game-field-panel` container. 
- Wrapped `<GameField />` in a `div` with `id="game-field-panel"` and use `hidden={isGameFieldCollapsed}` to hide the panel when collapsed. 
- Added new styles in `apps/web/src/components/league/GameCenter.css` for `.game-field-toggle`, `.game-field-panel[hidden]`, `.field-console-stage.field-collapsed`, and responsive behavior to adjust layout when collapsed.

### Testing
- Ran the production build with `npm --prefix apps/web run build`, which completed successfully. 
- Ran linting with `npm --prefix apps/web run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c3f652fec8324ae4a6ad0753181cd)