### PR TITLE
Move formation selection onto game field

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1286,6 +1286,8 @@ export function GameCenter({
   ]);
   const [isSavingPlay, setIsSavingPlay] = useState(false);
   const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
+  const [settingFormation, setSettingFormation] = useState(false);
+  const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
   const ctx = useMemo(
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
@@ -1499,7 +1501,26 @@ export function GameCenter({
               className="game-field-panel"
               hidden={isGameFieldCollapsed}
             >
-              <GameField />
+              <GameField
+                formationMode={settingFormation}
+                formation={playOptions.formation}
+                players={players}
+                selectedFormationPlayer={selectedFormationPlayer}
+                onFormationSlotClick={(slot) => {
+                  const selectedPlayer = selectedFormationPlayer;
+                  if (!selectedPlayer || playOptions.formation?.[slot]) return;
+                  const nextFormation = Object.fromEntries(
+                    Object.entries(playOptions.formation ?? {}).filter(
+                      ([, player]) => player !== selectedPlayer,
+                    ),
+                  );
+                  setPlayOptions({
+                    ...playOptions,
+                    formation: { ...nextFormation, [slot]: selectedPlayer },
+                  });
+                  setSelectedFormationPlayer("");
+                }}
+              />
             </div>
             <GameControls
               game={currentGame}
@@ -1507,6 +1528,8 @@ export function GameCenter({
               options={playOptions}
               onOptionsChange={setPlayOptions}
               onAction={action}
+              onFormationModeChange={setSettingFormation}
+              onSelectedFormationPlayerChange={setSelectedFormationPlayer}
             />
           </div>
           {lastPlay && (

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { LeagueGame } from "./types";
 import type {
   PlayCallOptions,
@@ -7,16 +7,6 @@ import type {
 } from "./gameplay/gameEngine";
 
 const str = (v: unknown) => String(v ?? "");
-const LINE_SLOTS: FormationSlot[] = [
-  "WR1",
-  "TEOL1",
-  "TEOL2",
-  "TEOL3",
-  "TEOL4",
-  "TEOL5",
-  "WR2",
-  "WR3",
-];
 const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3"];
 const RB_SLOTS: FormationSlot[] = ["RB1", "RB2"];
 const TEOL_SLOTS: FormationSlot[] = [
@@ -37,6 +27,8 @@ type Props = {
   options: PlayCallOptions;
   onOptionsChange: (next: PlayCallOptions) => void;
   onAction: (label: string, options?: PlayCallOptions) => void;
+  onFormationModeChange?: (active: boolean) => void;
+  onSelectedFormationPlayerChange?: (player: string) => void;
 };
 
 function nameOf(p: Player) {
@@ -200,15 +192,21 @@ export function GameControls({
   options,
   onOptionsChange,
   onAction,
+  onFormationModeChange,
+  onSelectedFormationPlayerChange,
 }: Props) {
   const [collapsed, setCollapsed] = useState(true);
-  const [modal, setModal] = useState<
-    "formation" | "routes" | "run" | "clock" | null
-  >(null);
+  const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
+  const [settingFormation, setSettingFormation] = useState(false);
   const [selected, setSelected] = useState<string>("");
   const [detail, setDetail] = useState<string>("");
 
   const offenseTeam = game.Possession === "Home" ? game.Home : game.Away;
+
+  useEffect(() => {
+    onFormationModeChange?.(settingFormation);
+  }, [onFormationModeChange, settingFormation]);
+
   const roster = useMemo(
     () => players.filter((p) => teamOf(p) === offenseTeam),
     [players, offenseTeam],
@@ -227,34 +225,18 @@ export function GameControls({
   );
   const setOpt = (patch: Partial<PlayCallOptions>) =>
     onOptionsChange({ ...options, ...patch });
-  const putPlayer = (slot: FormationSlot, player: string) => {
-    const next = Object.fromEntries(
-      Object.entries(formation).filter(([, v]) => v !== player),
-    ) as Partial<Record<FormationSlot, string>>;
-    if (player) next[slot] = player;
-    setOpt({ formation: next });
-    setSelected("");
-  };
-  const removePlayer = (slot: FormationSlot) => {
-    const player = formation[slot];
-    const nextFormation = { ...formation };
-    delete nextFormation[slot];
-    const nextRoutes = { ...routes };
-    const nextReads = { ...reads };
-    if (player) {
-      delete nextRoutes[player];
-      delete nextReads[player];
-    }
-    setOpt({
-      formation: nextFormation,
-      routes: nextRoutes,
-      reads: nextReads,
-      runner: options.runner === player ? undefined : options.runner,
-    });
-  };
   const bench = roster.filter(
     (p) => !Object.values(formation).includes(nameOf(p)),
   );
+  const selectedBenchPlayer = bench.some((player) => nameOf(player) === selected)
+    ? selected
+    : "";
+
+  useEffect(() => {
+    onSelectedFormationPlayerChange?.(
+      settingFormation ? selectedBenchPlayer : "",
+    );
+  }, [onSelectedFormationPlayerChange, selectedBenchPlayer, settingFormation]);
   const setRouteAndRead = (
     player: string,
     route: string,
@@ -301,7 +283,9 @@ export function GameControls({
             <span>Clock: {options.clockMode || "Normal"}</span>
           </div>
           <div className="game-controls primary">
-            <button onClick={() => setModal("formation")}>Set Formation</button>
+            <button onClick={() => setSettingFormation((active) => !active)}>
+              {settingFormation ? "Hide Bench" : "Set Formation"}
+            </button>
             <button
               disabled={!validFormation}
               onClick={() => onAction("Run Play", optionsWithDefense())}
@@ -320,166 +304,30 @@ export function GameControls({
           </div>
         </>
       )}
-      {modal === "formation" && (
-        <ControlModal full onClose={() => setModal(null)}>
-          <h3>Offensive Formation</h3>
-          <div className="formation-field">
-            <div className="formation-row top-row">
-              {LINE_SLOTS.map((slot) => (
-                <div
-                  key={slot}
-                  className={`formation-slot ${slot.startsWith("WR") ? "wr" : "teol"} ${REQUIRED.has(slot) ? "required" : ""} ${formation[slot] ? "filled" : ""}`}
-                  data-label={slot}
-                  onDragOver={(e) => e.preventDefault()}
-                  onDrop={(e) =>
-                    putPlayer(slot, e.dataTransfer.getData("text/plain"))
-                  }
-                  onClick={() => selected && putPlayer(slot, selected)}
-                >
-                  {formation[slot] && (
-                    <div
-                      draggable
-                      onDragStart={(e) =>
-                        e.dataTransfer.setData(
-                          "text/plain",
-                          formation[slot] || "",
-                        )
-                      }
-                    >
-                      <button
-                        type="button"
-                        className="formation-remove"
-                        aria-label={`Remove ${formation[slot]} from ${slot}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          removePlayer(slot);
-                        }}
-                      >
-                        ×
-                      </button>
-                      <PlayerBubble
-                        name={formation[slot]}
-                        player={byName(formation[slot])}
-                      />
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-            <div className="formation-row middle-row">
-              <div
-                className={`formation-slot qb required ${formation.QB ? "filled" : ""}`}
-                data-label="QB"
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={(e) =>
-                  putPlayer("QB", e.dataTransfer.getData("text/plain"))
-                }
-                onClick={() => selected && putPlayer("QB", selected)}
-              >
-                {formation.QB && (
-                  <div
-                    draggable
-                    onDragStart={(e) =>
-                      e.dataTransfer.setData("text/plain", formation.QB || "")
-                    }
-                  >
-                    <button
-                      type="button"
-                      className="formation-remove"
-                      aria-label={`Remove ${formation.QB} from QB`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        removePlayer("QB");
-                      }}
-                    >
-                      ×
-                    </button>
-                    <PlayerBubble
-                      name={formation.QB}
-                      player={byName(formation.QB)}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="formation-row bottom-row">
-              {(["RB1", "RB2"] as FormationSlot[]).map((slot) => (
-                <div
-                  key={slot}
-                  className={`formation-slot rb ${formation[slot] ? "filled" : ""}`}
-                  data-label={slot}
-                  onDragOver={(e) => e.preventDefault()}
-                  onDrop={(e) =>
-                    putPlayer(slot, e.dataTransfer.getData("text/plain"))
-                  }
-                  onClick={() => selected && putPlayer(slot, selected)}
-                >
-                  {formation[slot] && (
-                    <div
-                      draggable
-                      onDragStart={(e) =>
-                        e.dataTransfer.setData(
-                          "text/plain",
-                          formation[slot] || "",
-                        )
-                      }
-                    >
-                      <button
-                        type="button"
-                        className="formation-remove"
-                        aria-label={`Remove ${formation[slot]} from ${slot}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          removePlayer(slot);
-                        }}
-                      >
-                        ×
-                      </button>
-                      <PlayerBubble
-                        name={formation[slot]}
-                        player={byName(formation[slot])}
-                      />
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className="bench-wrapper">
+      {settingFormation && (
+        <div className="field-formation-bench" aria-label="Offensive bench">
+          <div className="field-formation-bench-header">
             <h4>Bench</h4>
-            <div className="bench">
-              {bench.map((p) => (
-                <button
-                  type="button"
-                  draggable
-                  onDragStart={(e) =>
-                    e.dataTransfer.setData("text/plain", nameOf(p))
-                  }
-                  onClick={() =>
-                    setSelected(selected === nameOf(p) ? "" : nameOf(p))
-                  }
-                  className={`player-item ${selected === nameOf(p) ? "selected" : ""}`}
-                  key={nameOf(p)}
-                >
-                  <PlayerBubble name={nameOf(p)} player={p} />
-                  <span className="player-name">
-                    {nameOf(p)} - {posOf(p)}
-                  </span>
-                </button>
-              ))}
-            </div>
+            <span>Pick a player, then pick an open field slot.</span>
           </div>
-          <div className="formation-actions">
-            <button
-              onClick={() => setOpt({ formation: {}, routes: {}, reads: {} })}
-            >
-              Clear
-            </button>
-            <button disabled={!validFormation} onClick={() => setModal(null)}>
-              Save
-            </button>
+          <div className="bench bench-ten-wide">
+            {bench.map((p) => (
+              <button
+                type="button"
+                onClick={() =>
+                  setSelected(selectedBenchPlayer === nameOf(p) ? "" : nameOf(p))
+                }
+                className={`player-item ${selectedBenchPlayer === nameOf(p) ? "selected" : ""}`}
+                key={nameOf(p)}
+              >
+                <PlayerBubble name={nameOf(p)} player={p} />
+                <span className="player-name">
+                  {nameOf(p)} - {posOf(p)}
+                </span>
+              </button>
+            ))}
           </div>
-        </ControlModal>
+        </div>
       )}
       {modal === "routes" && (
         <ControlModal wide onClose={() => setModal(null)}>

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -578,3 +578,74 @@ textarea {
 .player-action-menu button:focus-visible {
   background: #ef4444;
 }
+
+.field-formation-slot {
+  position: absolute;
+  z-index: 145;
+  width: 58px;
+  height: 58px;
+  padding: 0;
+  border: 2px dashed rgba(248, 250, 252, 0.92);
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
+  font-size: 12px;
+  font-weight: 1000;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+}
+
+.field-formation-slot.required::after {
+  content: "*";
+  position: absolute;
+  top: -8px;
+  right: -2px;
+  color: #f87171;
+  font-size: 18px;
+}
+
+.field-formation-slot.targetable {
+  border-style: solid;
+  box-shadow:
+    0 0 0 4px rgba(250, 204, 21, 0.42),
+    0 8px 18px rgba(0, 0, 0, 0.45);
+}
+
+.field-formation-slot.filled {
+  border-style: solid;
+  background: transparent;
+}
+
+.field-formation-slot img,
+.field-formation-avatar {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 3px solid #f8fafc;
+  border-radius: 50%;
+  background: #fff;
+  object-fit: cover;
+}
+
+.field-formation-slot.qb { border-color: #64b5f6; color: #64b5f6; }
+.field-formation-slot.rb { border-color: #81c784; color: #81c784; }
+.field-formation-slot.wr { border-color: #ffb74d; color: #ffb74d; }
+.field-formation-slot.teol { border-color: #ba68c8; color: #ba68c8; }
+
+.field-formation-name {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  margin-top: 3px;
+  padding: 2px 5px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  font-size: 10px;
+  font-weight: 900;
+  white-space: nowrap;
+}

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormationSlot } from "./gameplay/gameEngine";
 
 import "./GameField.css";
+
+type FormationPlayer = Record<string, unknown>;
+type FormationSlotSetup = { lane: string; yardOffsetFromLos: number };
 
 type PlayerAssignment = {
   type?: string;
@@ -157,6 +161,42 @@ const DEFAULT_LINEUPS_BY_POSITION: Record<
   TE1: { lane: "RT", yardOffsetFromLos: -1 },
   TE2: { lane: "LT", yardOffsetFromLos: -1 },
 };
+const FORMATION_SLOT_LINEUP: Record<FormationSlot, FormationSlotSetup> = {
+  WR1: DEFAULT_LINEUPS_BY_POSITION.WR1,
+  WR2: DEFAULT_LINEUPS_BY_POSITION.WR2,
+  WR3: DEFAULT_LINEUPS_BY_POSITION.WR3,
+  RB1: DEFAULT_LINEUPS_BY_POSITION.RB1,
+  RB2: DEFAULT_LINEUPS_BY_POSITION.RB2,
+  QB: DEFAULT_LINEUPS_BY_POSITION.QB,
+  TEOL1: DEFAULT_LINEUPS_BY_POSITION.LT,
+  TEOL2: DEFAULT_LINEUPS_BY_POSITION.LG,
+  TEOL3: DEFAULT_LINEUPS_BY_POSITION.C,
+  TEOL4: DEFAULT_LINEUPS_BY_POSITION.RG,
+  TEOL5: DEFAULT_LINEUPS_BY_POSITION.RT,
+};
+const FORMATION_SLOTS: FormationSlot[] = [
+  "WR1",
+  "TEOL1",
+  "TEOL2",
+  "TEOL3",
+  "TEOL4",
+  "TEOL5",
+  "WR2",
+  "WR3",
+  "QB",
+  "RB1",
+  "RB2",
+];
+const REQUIRED_FORMATION_SLOTS = new Set<FormationSlot>([
+  "QB",
+  "TEOL2",
+  "TEOL3",
+  "TEOL4",
+]);
+const nameOf = (p?: FormationPlayer) => String(p?.name ?? p?.Name ?? "");
+const imgOf = (p?: FormationPlayer) =>
+  String(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo ?? "");
+
 const OFFENSIVE_DEFAULT_LANES: Record<string, string> = Object.fromEntries(
   Object.entries(DEFAULT_LINEUPS_BY_POSITION).map(([position, setup]) => [
     position,
@@ -194,7 +234,19 @@ const resolveMoveX = (move?: PlayerMoveStep) =>
 const yardToYPct = (yard: number) =>
   91.8 - (Math.max(0, Math.min(100, yard)) / 100) * (91.8 - 8.2);
 
-export default function GameField() {
+export default function GameField({
+  formationMode = false,
+  formation = {},
+  players = [],
+  selectedFormationPlayer = "",
+  onFormationSlotClick,
+}: {
+  formationMode?: boolean;
+  formation?: Partial<Record<FormationSlot, string>>;
+  players?: FormationPlayer[];
+  selectedFormationPlayer?: string;
+  onFormationSlotClick?: (slot: FormationSlot) => void;
+}) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<HTMLDivElement>(null);
   const footballRef = useRef<HTMLDivElement>(null);
@@ -216,6 +268,8 @@ export default function GameField() {
     leftPct: number;
     topPct: number;
   } | null>(null);
+  const findFormationPlayer = (playerName?: string) =>
+    players.find((player) => nameOf(player) === playerName);
 
   const showError = useCallback((message: string) => {
     if (errorBoxRef.current) {
@@ -803,6 +857,49 @@ export default function GameField() {
             END
           </div>
           <div className="football" id="football" ref={footballRef} />
+          {formationMode &&
+            FORMATION_SLOTS.map((slot) => {
+              const lineup = FORMATION_SLOT_LINEUP[slot];
+              const playerName = formation[slot];
+              const player = findFormationPlayer(playerName);
+              const playerImage = imgOf(player);
+              const isOpen = !playerName;
+              return (
+                <button
+                  key={slot}
+                  type="button"
+                  className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer && isOpen ? "targetable" : ""}`}
+                  style={{
+                    left: `${LANES[lineup.lane] ?? 50}%`,
+                    top: `${yardToYPct(55 + lineup.yardOffsetFromLos)}%`,
+                  }}
+                  aria-label={
+                    playerName
+                      ? `${slot}: ${playerName}`
+                      : selectedFormationPlayer
+                        ? `Place ${selectedFormationPlayer} at ${slot}`
+                        : `${slot} open`
+                  }
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    if (isOpen) onFormationSlotClick?.(slot);
+                  }}
+                >
+                  {playerName ? (
+                    playerImage ? (
+                      <img src={playerImage} alt={playerName} />
+                    ) : (
+                      <span className="field-formation-avatar">👤</span>
+                    )
+                  ) : (
+                    <span className="field-formation-label">{slot}</span>
+                  )}
+                  {playerName && (
+                    <span className="field-formation-name">{playerName}</span>
+                  )}
+                </button>
+              );
+            })}
           {selectedPlayerMenu && (
             <div
               className="player-action-menu"

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1763,3 +1763,46 @@
     grid-template-columns: 1fr;
   }
 }
+
+.field-formation-bench {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  z-index: 360;
+  width: min(980px, calc(100% - 32px));
+  transform: translateX(-50%);
+  padding: 12px;
+  border: 1px solid rgba(248, 250, 252, 0.3);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+}
+
+.field-formation-bench-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+  color: #f8fafc;
+}
+
+.field-formation-bench-header h4 { margin: 0; }
+.field-formation-bench-header span { color: #cbd5e1; font-size: 12px; }
+
+.bench-ten-wide {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: 8px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.bench-ten-wide .player-item {
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .bench-ten-wide { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}


### PR DESCRIPTION
### Motivation
- Replace the modal-based formation editor with an inline, field-centric workflow so users can pick a bench player and place them directly onto open formation slots on the field, limited to offensive players in a 10-wide bench as requested.

### Description
- Add a bench toggle and ten-column bench UI in `GameControls` that exposes offensive bench players and lets the user select one for placement (`settingFormation`, bench grid, selection wiring).
- Wire shared formation selection state through `GameCenter` so the GameField receives `formationMode`, `formation`, `players`, `selectedFormationPlayer`, and an `onFormationSlotClick` handler to place the selected bench player into an open slot.
- Extend `GameField` to accept the new props and render field overlay formation slots using the default lineup lane positions and positional labels for empty slots, and show player avatars/names for filled slots; clicking an open slot assigns the selected bench player via the supplied handler.
- Add CSS for `.field-formation-slot`, `.field-formation-bench`, and a `.bench-ten-wide` layout and adjust related control logic to keep previous play-call behavior intact.

### Testing
- Ran `npm run lint` and fixed issues reported by ESLint; final lint run completed successfully.
- Ran `npm run build` and the TypeScript build + `vite build` completed successfully producing a production bundle.
- Started the dev server with `npm run dev` (Vite) which reported the local and network URLs, indicating the app runs in dev mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c415f55408324a3c75612a7ae0ed2)