### PR TITLE
Add WR4/OL formation slots, Save/Exit formation UI, and render generated defense

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1502,8 +1502,9 @@ export function GameCenter({
               hidden={isGameFieldCollapsed}
             >
               <GameField
-                formationMode={settingFormation}
+                formationMode={settingFormation || Boolean(playOptions.defense?.length)}
                 formation={playOptions.formation}
+                defense={playOptions.defense}
                 players={players}
                 selectedFormationPlayer={selectedFormationPlayer}
                 onFormationSlotClick={(slot) => {

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -7,16 +7,10 @@ import type {
 } from "./gameplay/gameEngine";
 
 const str = (v: unknown) => String(v ?? "");
-const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3"];
+const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
 const RB_SLOTS: FormationSlot[] = ["RB1", "RB2"];
-const TEOL_SLOTS: FormationSlot[] = [
-  "TEOL1",
-  "TEOL2",
-  "TEOL3",
-  "TEOL4",
-  "TEOL5",
-];
-const REQUIRED = new Set<FormationSlot>(["QB", "TEOL2", "TEOL3", "TEOL4"]);
+const OL_SLOTS: FormationSlot[] = ["LT", "LG", "C", "RG", "RT"];
+const REQUIRED = new Set<FormationSlot>(["QB", "LG", "C", "RG"]);
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
 
@@ -71,12 +65,12 @@ function ControlModal({
   );
 }
 function eligibleReceivers(formation: Partial<Record<FormationSlot, string>>) {
-  const occupiedTeols = TEOL_SLOTS.filter((slot) => formation[slot]);
-  const exposedTeols =
-    occupiedTeols.length > 1
-      ? [occupiedTeols[0], occupiedTeols[occupiedTeols.length - 1]]
-      : occupiedTeols;
-  const eligibleSlots = [...WR_SLOTS, ...RB_SLOTS, ...exposedTeols];
+  const occupiedLinemen = OL_SLOTS.filter((slot) => formation[slot]);
+  const exposedLinemen =
+    occupiedLinemen.length > 1
+      ? [occupiedLinemen[0], occupiedLinemen[occupiedLinemen.length - 1]]
+      : occupiedLinemen;
+  const eligibleSlots = [...WR_SLOTS, ...RB_SLOTS, ...exposedLinemen];
   return eligibleSlots
     .map((slot) => ({ slot, player: formation[slot] }))
     .filter((x): x is { slot: FormationSlot; player: string } =>
@@ -154,7 +148,7 @@ function buildDefense(
     safeties = by("S");
   const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
   const wrs = WR_SLOTS.filter((s) => formation[s]);
-  const ol = TEOL_SLOTS.filter((s) => formation[s]);
+  const ol = OL_SLOTS.filter((s) => formation[s]);
   const out: DefensiveAssignment[] = [];
   wrs.forEach((slot, i) =>
     out.push({
@@ -261,6 +255,12 @@ export function GameControls({
     defense,
   });
 
+  const saveFormation = () => {
+    onOptionsChange(optionsWithDefense());
+    setSettingFormation(false);
+    setSelected("");
+  };
+
   return (
     <div
       className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}
@@ -296,7 +296,7 @@ export function GameControls({
               disabled={!validFormation}
               onClick={() => {
                 if (!canPass) setModal("routes");
-                else onAction("Pass Play", options);
+                else onAction("Pass Play", optionsWithDefense());
               }}
             >
               Call Pass Play
@@ -326,6 +326,20 @@ export function GameControls({
                 </span>
               </button>
             ))}
+          </div>
+          <div className="formation-actions">
+            <button
+              type="button"
+              onClick={() => {
+                setSettingFormation(false);
+                setSelected("");
+              }}
+            >
+              Exit
+            </button>
+            <button type="button" onClick={saveFormation}>
+              Save Formation
+            </button>
           </div>
         </div>
       )}

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -649,3 +649,9 @@ textarea {
   font-weight: 900;
   white-space: nowrap;
 }
+
+.field-formation-slot.defense {
+  border-color: #ef4444;
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.86);
+}

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { FormationSlot } from "./gameplay/gameEngine";
+import type { DefensiveAssignment, FormationSlot } from "./gameplay/gameEngine";
 
 import "./GameField.css";
 
@@ -168,30 +168,32 @@ const FORMATION_SLOT_LINEUP: Record<FormationSlot, FormationSlotSetup> = {
   RB1: DEFAULT_LINEUPS_BY_POSITION.RB1,
   RB2: DEFAULT_LINEUPS_BY_POSITION.RB2,
   QB: DEFAULT_LINEUPS_BY_POSITION.QB,
-  TEOL1: DEFAULT_LINEUPS_BY_POSITION.LT,
-  TEOL2: DEFAULT_LINEUPS_BY_POSITION.LG,
-  TEOL3: DEFAULT_LINEUPS_BY_POSITION.C,
-  TEOL4: DEFAULT_LINEUPS_BY_POSITION.RG,
-  TEOL5: DEFAULT_LINEUPS_BY_POSITION.RT,
+  LT: DEFAULT_LINEUPS_BY_POSITION.LT,
+  LG: DEFAULT_LINEUPS_BY_POSITION.LG,
+  C: DEFAULT_LINEUPS_BY_POSITION.C,
+  RG: DEFAULT_LINEUPS_BY_POSITION.RG,
+  RT: DEFAULT_LINEUPS_BY_POSITION.RT,
+  WR4: DEFAULT_LINEUPS_BY_POSITION.WR4,
 };
 const FORMATION_SLOTS: FormationSlot[] = [
   "WR1",
-  "TEOL1",
-  "TEOL2",
-  "TEOL3",
-  "TEOL4",
-  "TEOL5",
+  "LT",
+  "LG",
+  "C",
+  "RG",
+  "RT",
   "WR2",
   "WR3",
+  "WR4",
   "QB",
   "RB1",
   "RB2",
 ];
 const REQUIRED_FORMATION_SLOTS = new Set<FormationSlot>([
   "QB",
-  "TEOL2",
-  "TEOL3",
-  "TEOL4",
+  "LG",
+  "C",
+  "RG",
 ]);
 const nameOf = (p?: FormationPlayer) => String(p?.name ?? p?.Name ?? "");
 const imgOf = (p?: FormationPlayer) =>
@@ -237,12 +239,14 @@ const yardToYPct = (yard: number) =>
 export default function GameField({
   formationMode = false,
   formation = {},
+  defense = [],
   players = [],
   selectedFormationPlayer = "",
   onFormationSlotClick,
 }: {
   formationMode?: boolean;
   formation?: Partial<Record<FormationSlot, string>>;
+  defense?: DefensiveAssignment[];
   players?: FormationPlayer[];
   selectedFormationPlayer?: string;
   onFormationSlotClick?: (slot: FormationSlot) => void;
@@ -898,6 +902,36 @@ export default function GameField({
                     <span className="field-formation-name">{playerName}</span>
                   )}
                 </button>
+              );
+            })}
+
+          {formationMode &&
+            defense.map((assignment) => {
+              const lineup = assignment.align
+                ? FORMATION_SLOT_LINEUP[assignment.align]
+                : DEFAULT_LINEUPS_BY_POSITION[assignment.position] ??
+                  DEFAULT_LINEUPS_BY_POSITION.LB3;
+              const player = findFormationPlayer(assignment.player);
+              const playerImage = imgOf(player);
+              return (
+                <div
+                  key={`${assignment.position}-${assignment.player}`}
+                  className="field-formation-slot defense filled"
+                  style={{
+                    left: `${LANES[lineup.lane] ?? 50}%`,
+                    top: `${yardToYPct(55 + Math.abs(lineup.yardOffsetFromLos || 1.5))}%`,
+                  }}
+                  aria-label={`${assignment.position}: ${assignment.player}`}
+                >
+                  {playerImage ? (
+                    <img src={playerImage} alt={assignment.player} />
+                  ) : (
+                    <span className="field-formation-avatar">🛡️</span>
+                  )}
+                  <span className="field-formation-name">
+                    {assignment.player}
+                  </span>
+                </div>
               );
             })}
           {selectedPlayerMenu && (

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -7,7 +7,8 @@ export type FormationEntry = {
   player: string;
   align?: string;
 };
-const REQUIRED: FormationSlot[] = ["QB", "TEOL2", "TEOL3", "TEOL4"];
+const REQUIRED: FormationSlot[] = ["QB", "LG", "C", "RG"];
+const OL_SLOTS = new Set<string>(["LT", "LG", "C", "RG", "RT"]);
 export function validateOffensiveFormation(
   formation: Partial<Record<FormationSlot, string>>,
 ) {
@@ -53,7 +54,7 @@ export function generateDefensiveFormation(
         });
     });
   offense
-    .filter((s) => s.position.startsWith("TEOL"))
+    .filter((s) => OL_SLOTS.has(String(s.position)))
     .forEach((slot, i) => {
       const p = take(i % 2 ? lbs : dls) ?? take(dls) ?? take(lbs);
       if (p)

--- a/apps/web/src/components/league/gameplay/engine/passEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/passEngine.ts
@@ -35,11 +35,11 @@ export function determineTimeToThrow(
   const protectors = [
     formation.RB1,
     formation.RB2,
-    formation.TEOL1,
-    formation.TEOL2,
-    formation.TEOL3,
-    formation.TEOL4,
-    formation.TEOL5,
+    formation.LT,
+    formation.LG,
+    formation.C,
+    formation.RG,
+    formation.RT,
   ]
     .map((name) => byName(ctx, name))
     .filter(Boolean);

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -10,14 +10,14 @@ import type {
   RunPlayState,
 } from "./types";
 
-const TEOL_SLOTS: FormationSlot[] = [
-  "TEOL1",
-  "TEOL2",
-  "TEOL3",
-  "TEOL4",
-  "TEOL5",
+const OL_SLOTS: FormationSlot[] = [
+  "LT",
+  "LG",
+  "C",
+  "RG",
+  "RT",
 ];
-const CENTER_SLOT: FormationSlot = "TEOL3";
+const CENTER_SLOT: FormationSlot = "C";
 
 /** Reads an optional frontend setting array and returns an empty list when the setting is absent. Run-yardage helpers use this to stay safe when tuning data is not loaded. */
 function settingArray<T>(
@@ -44,7 +44,7 @@ export function buildOlDlMatchups(
   offense: Partial<Record<FormationSlot, string>>,
   defense: DefensiveAssignment[],
 ): OlDlMatchup[] {
-  return TEOL_SLOTS.map((slot) => {
+  return OL_SLOTS.map((slot) => {
     const defender = defense.find(
       (d) => d.align === slot && d.position.startsWith("DL"),
     );
@@ -1128,8 +1128,8 @@ type RunLaneSide = "left" | "center" | "right";
 
 /** Converts a trench slot into left, center, or right. Linebacker targeting uses it to match pursuit to the run lane. */
 function laneSide(slot: FormationSlot): RunLaneSide {
-  const slotIndex = TEOL_SLOTS.indexOf(slot);
-  const centerIndex = TEOL_SLOTS.indexOf(CENTER_SLOT);
+  const slotIndex = OL_SLOTS.indexOf(slot);
+  const centerIndex = OL_SLOTS.indexOf(CENTER_SLOT);
 
   if (slotIndex < 0 || slotIndex === centerIndex) return "center";
   return slotIndex < centerIndex ? "left" : "right";
@@ -1189,13 +1189,13 @@ export function getAdjacentDefensiveLinemenForRunLane(
   selectedSlot: FormationSlot,
   jukedDefenders: string[] = [],
 ): DefensiveAssignment[] {
-  const selectedIndex = TEOL_SLOTS.indexOf(selectedSlot);
+  const selectedIndex = OL_SLOTS.indexOf(selectedSlot);
   if (selectedIndex < 0) return [];
 
   const jukedDefenderSet = new Set(jukedDefenders.filter(Boolean));
 
   return [selectedIndex - 1, selectedIndex + 1]
-    .map((index) => TEOL_SLOTS[index])
+    .map((index) => OL_SLOTS[index])
     .filter((slot): slot is FormationSlot => Boolean(slot))
     .map((slot) => lineWinLossArray.find((battle) => battle.slot === slot))
     .filter((battle): battle is LineWinLossResult =>

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -11,13 +11,14 @@ export type PlayKind =
   | "Kneel";
 export type FormationSlot =
   | "WR1"
-  | "TEOL1"
-  | "TEOL2"
-  | "TEOL3"
-  | "TEOL4"
-  | "TEOL5"
+  | "LT"
+  | "LG"
+  | "C"
+  | "RG"
+  | "RT"
   | "WR2"
   | "WR3"
+  | "WR4"
   | "QB"
   | "RB1"
   | "RB2";


### PR DESCRIPTION
### Motivation
- Provide full offensive slot coverage and let users exit or save formation setup at any time so the modal doesn't persist. 
- Ensure saved formations include an auto-generated defensive alignment and that saved defenders are visible on the field. 

### Description
- Add explicit offensive-line slots and `WR4` to the shared `FormationSlot` type and replace TEOL-style slots with `LT`, `LG`, `C`, `RG`, `RT` across UI and engine code (`types.ts`, `GameField.tsx`, `GameControls.tsx`, `runEngineHelper.ts`, `passEngine.ts`, `formationEngine.ts`).
- Add `Exit` and `Save Formation` buttons to the formation bench (`GameControls.tsx`) and implement `saveFormation` to persist the generated defense into `PlayCallOptions` (`options.defense`) and close formation mode. 
- Auto-include generated defensive assignments when calling plays via `optionsWithDefense()` and pass saved `defense` into `GameField` so the defense is rendered on the field (`GameCenter.tsx` and `GameField.tsx`).
- Render saved defensive markers on the field with a new `.field-formation-slot.defense` style in `GameField.css`, and update formation layout constants and helpers (lane mapping, `FORMATION_SLOT_LINEUP`, `FORMATION_SLOTS`, `REQUIRED` slots, and OL-specific helpers) so engines and UI align with the new slots. 

### Testing
- Ran `npm run lint` in `apps/web` and it completed successfully. 
- Built the web app with `npm run build` in `apps/web` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c44354de083248ffab006961fc579)