### PR TITLE
Clear formation on possession change and enable bench swap/remove interactions

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { LeagueGame, GameTab } from "./types";
 import "./GameCenter.css";
 import {
@@ -30,7 +30,7 @@ import {
   spikeBall,
 } from "./gameplay/gameEngine";
 import { animatePlay } from "./gameplay/engine/animationAdapter";
-import type { FrontendSettings, PlayCallOptions } from "./gameplay/gameEngine";
+import type { FormationSlot, FrontendSettings, PlayCallOptions } from "./gameplay/gameEngine";
 
 type Play = Record<string, unknown>;
 type LineStatMatchup = {
@@ -1288,6 +1288,7 @@ export function GameCenter({
   const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
   const [settingFormation, setSettingFormation] = useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
+  const previousPossessionRef = useRef(currentGame.Possession);
   const ctx = useMemo(
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
@@ -1325,6 +1326,22 @@ export function GameCenter({
       active = false;
     };
   }, [game]);
+
+  useEffect(() => {
+    if (previousPossessionRef.current === currentGame.Possession) return;
+    previousPossessionRef.current = currentGame.Possession;
+    // A new possession means the old offense has left the field, so discard the saved offensive setup, routes, reads, runner, and generated defensive mirror before the next team starts choosing personnel.
+    setPlayOptions((options) => ({
+      ...options,
+      formation: {},
+      routes: {},
+      reads: {},
+      runner: undefined,
+      defense: [],
+    }));
+    setSettingFormation(false);
+    setSelectedFormationPlayer("");
+  }, [currentGame.Possession]);
   const persist = async (result: ReturnType<typeof runPlay>) => {
     const previousGame = currentGame;
     const previousBallOn = currentGame.BallOn;
@@ -1509,15 +1526,34 @@ export function GameCenter({
                 selectedFormationPlayer={selectedFormationPlayer}
                 onFormationSlotClick={(slot) => {
                   const selectedPlayer = selectedFormationPlayer;
-                  if (!selectedPlayer || playOptions.formation?.[slot]) return;
+                  if (!selectedPlayer) return;
+
+                  const currentFormation = playOptions.formation ?? {};
                   const nextFormation = Object.fromEntries(
-                    Object.entries(playOptions.formation ?? {}).filter(
-                      ([, player]) => player !== selectedPlayer,
+                    Object.entries(currentFormation).filter(
+                      ([formationSlot, player]) =>
+                        formationSlot !== slot && player !== selectedPlayer,
                     ),
-                  );
+                  ) as Partial<Record<FormationSlot, string>>;
+
+                  // Selecting an empty bench slot is a remove action: clicking a filled field spot sends that player to the bench without putting anyone back on the field.
+                  if (selectedPlayer === "__EMPTY_BENCH_SLOT__") {
+                    setPlayOptions({
+                      ...playOptions,
+                      formation: nextFormation,
+                      routes: {},
+                      reads: {},
+                    });
+                    setSelectedFormationPlayer("");
+                    return;
+                  }
+
+                  // Otherwise the selected bench player takes the clicked spot. If the spot was occupied, its previous player naturally returns to the bench because they are omitted from the next formation map.
                   setPlayOptions({
                     ...playOptions,
                     formation: { ...nextFormation, [slot]: selectedPlayer },
+                    routes: {},
+                    reads: {},
                   });
                   setSelectedFormationPlayer("");
                 }}

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -13,6 +13,7 @@ const OL_SLOTS: FormationSlot[] = ["LT", "LG", "C", "RG", "RT"];
 const REQUIRED = new Set<FormationSlot>(["QB", "LG", "C", "RG"]);
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
+const EMPTY_BENCH_SLOT = "__EMPTY_BENCH_SLOT__";
 
 type Player = Record<string, unknown>;
 type Props = {
@@ -133,6 +134,7 @@ function buildDefense(
   players: Player[],
   formation: Partial<Record<FormationSlot, string>>,
 ): DefensiveAssignment[] {
+  // The defense belongs to the team without possession; deriving it here keeps the UI preview and play-call payload in sync with the scoreboard.
   const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
   const defenders = players.filter((p) => teamOf(p) === defenseTeam);
   const by = (d: string) =>
@@ -147,6 +149,7 @@ function buildDefense(
     lbs = by("LB"),
     safeties = by("S");
   const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
+  // Saved receiver slots drive coverage first, then saved offensive-line slots drive front-seven alignment.
   const wrs = WR_SLOTS.filter((s) => formation[s]);
   const ol = OL_SLOTS.filter((s) => formation[s]);
   const out: DefensiveAssignment[] = [];
@@ -164,6 +167,7 @@ function buildDefense(
       align: slot,
     }),
   );
+  // Any remaining defenders key on backfield/QB slots before the safety fallback so the final formation has support against runs and passes.
   let remaining = Math.max(0, 7 - out.length);
   (["QB", "RB1", "RB2"] as FormationSlot[])
     .slice(0, remaining)
@@ -222,9 +226,10 @@ export function GameControls({
   const bench = roster.filter(
     (p) => !Object.values(formation).includes(nameOf(p)),
   );
-  const selectedBenchPlayer = bench.some((player) => nameOf(player) === selected)
-    ? selected
-    : "";
+  const selectedBenchPlayer =
+    selected === EMPTY_BENCH_SLOT || bench.some((player) => nameOf(player) === selected)
+      ? selected
+      : "";
 
   useEffect(() => {
     onSelectedFormationPlayerChange?.(
@@ -245,17 +250,20 @@ export function GameControls({
     setOpt({ routes: nextRoutes, reads: nextReads });
   };
 
+  // Every offensive formation edit is held in `options.formation`; from that saved setup we deterministically generate the defensive alignment preview.
   const defense = useMemo(
     () => buildDefense(game, players, options.formation ?? {}),
     [game, players, options.formation],
   );
 
+  // Snapping a play should carry both the user-saved offense and the generated defense into the engine so the final resolver sees the same field shown in the UI.
   const optionsWithDefense = (): PlayCallOptions => ({
     ...options,
     defense,
   });
 
   const saveFormation = () => {
+    // Saving closes the bench but keeps `options.formation` plus the generated defensive mirror available for the next play call.
     onOptionsChange(optionsWithDefense());
     setSettingFormation(false);
     setSelected("");
@@ -308,9 +316,19 @@ export function GameControls({
         <div className="field-formation-bench" aria-label="Offensive bench">
           <div className="field-formation-bench-header">
             <h4>Bench</h4>
-            <span>Pick a player, then pick an open field slot.</span>
+            <span>Pick a player to place/swap, or pick Empty to remove a fielded player.</span>
           </div>
           <div className="bench bench-ten-wide">
+            <button
+              type="button"
+              onClick={() =>
+                setSelected(selectedBenchPlayer === EMPTY_BENCH_SLOT ? "" : EMPTY_BENCH_SLOT)
+              }
+              className={`player-item ${selectedBenchPlayer === EMPTY_BENCH_SLOT ? "selected" : ""}`}
+            >
+              <PlayerBubble />
+              <span className="player-name">Empty bench slot</span>
+            </button>
             {bench.map((p) => (
               <button
                 type="button"

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -867,12 +867,11 @@ export default function GameField({
               const playerName = formation[slot];
               const player = findFormationPlayer(playerName);
               const playerImage = imgOf(player);
-              const isOpen = !playerName;
               return (
                 <button
                   key={slot}
                   type="button"
-                  className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer && isOpen ? "targetable" : ""}`}
+                  className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer ? "targetable" : ""}`}
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
                     top: `${yardToYPct(55 + lineup.yardOffsetFromLos)}%`,
@@ -886,7 +885,7 @@ export default function GameField({
                   }
                   onClick={(event) => {
                     event.stopPropagation();
-                    if (isOpen) onFormationSlotClick?.(slot);
+                    onFormationSlotClick?.(slot);
                   }}
                 >
                   {playerName ? (

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -17,6 +17,7 @@ export function validateOffensiveFormation(
 export function saveOffensiveFormation(
   formation: Partial<Record<FormationSlot, string>>,
 ): FormationEntry[] {
+  // This is the first durable handoff point: collapse the UI's slot->player map into portable entries that later play resolution can pass to defensive setup.
   return Object.entries(formation)
     .filter(([, player]) => Boolean(player))
     .map(([position, player]) => ({ position, player: String(player) }));
@@ -26,6 +27,7 @@ export function generateDefensiveFormation(
   ctx: EngineContext,
   offense: FormationEntry[] = [],
 ): FormationEntry[] {
+  // Defensive formation starts after the offense is saved because defenders align to known offensive threats rather than guessing at empty slots.
   const defenders = teamPlayers(ctx, defenseTeam(game));
   const group = (defPos: string) =>
     defenders
@@ -42,6 +44,7 @@ export function generateDefensiveFormation(
     return player;
   };
   const out: FormationEntry[] = [];
+  // Wide receivers create the first defensive obligations: the best available DBs travel to those exact receiver slots.
   offense
     .filter((s) => s.position.startsWith("WR"))
     .forEach((slot, i) => {
@@ -53,6 +56,7 @@ export function generateDefensiveFormation(
           align: slot.position,
         });
     });
+  // Offensive linemen define the box, so each occupied line slot receives a DL/LB matchup aligned over that saved offensive position.
   offense
     .filter((s) => OL_SLOTS.has(String(s.position)))
     .forEach((slot, i) => {
@@ -64,6 +68,7 @@ export function generateDefensiveFormation(
           align: slot.position,
         });
     });
+  // After man/box assignments, leftover linebackers and a safety fill the second level/deep help so the final defense is complete enough for run and pass engines.
   [take(lbs), take(lbs), take(safeties)]
     .filter(Boolean)
     .forEach((p, i) =>


### PR DESCRIPTION
### Motivation
- Ensure saved offensive setup does not persist across possession changes so the incoming offense always starts with a clean slate. 
- Allow intuitive bench interactions: swap a bench player into an occupied field slot, and allow an explicit Empty choice to remove a fielded player without filling the slot. 
- Make the flow from saving an offensive formation to generating the defensive mirror easier to follow by adding explanatory comments. 

### Description
- Clear saved formation, routes, reads, runner, generated defense, and active selection when possession changes by observing `currentGame.Possession` and resetting `playOptions` and selection state (`apps/web/src/components/league/GameCenter.tsx`).
- Make all formation slots targetable while in formation mode and allow clicking occupied slots to perform swaps or removals (`apps/web/src/components/league/GameField.tsx` and `apps/web/src/components/league/GameCenter.tsx`).
- Support an explicit "Empty bench slot" selector that, when chosen and a field slot is clicked, removes the player from the field without placing anyone in that slot (`apps/web/src/components/league/GameControls.tsx`), using a sentinel `__EMPTY_BENCH_SLOT__` value and clearing `routes`/`reads` on personnel edits.
- Clear route/read assignments after any personnel swap or removal and ensure the UI-generated defensive preview is recomputed from the saved offense and propagated into the play payload (`apps/web/src/components/league/GameControls.tsx`).
- Add developer-facing comments in `saveOffensiveFormation` and `generateDefensiveFormation` to explain the handoff and why the defense is generated from the saved offensive slots (`apps/web/src/components/league/gameplay/engine/formationEngine.ts`).

### Testing
- Ran `npm -s --prefix apps/web run build` and the project built successfully. 
- Ran `npm -s --prefix apps/web run lint` and linting succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c45890ca48324b4d36e089c7f23e2)