### PR TITLE
Remove empty bench slot; enable field-player removal and adjust formation layering

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1529,10 +1529,15 @@ export function GameCenter({
                 players={players}
                 selectedFormationPlayer={selectedFormationPlayer}
                 onFormationSlotClick={(slot) => {
-                  const selectedPlayer = selectedFormationPlayer;
-                  if (!selectedPlayer) return;
-
                   const currentFormation = playOptions.formation ?? {};
+                  const selectedPlayer = selectedFormationPlayer;
+                  const slotPlayer = currentFormation[slot];
+
+                  if (!selectedPlayer) {
+                    if (slotPlayer) setSelectedFormationPlayer(slotPlayer);
+                    return;
+                  }
+
                   const nextFormation = Object.fromEntries(
                     Object.entries(currentFormation).filter(
                       ([formationSlot, player]) =>
@@ -1540,19 +1545,7 @@ export function GameCenter({
                     ),
                   ) as Partial<Record<FormationSlot, string>>;
 
-                  // Selecting an empty bench slot is a remove action: clicking a filled field spot sends that player to the bench without putting anyone back on the field.
-                  if (selectedPlayer === "__EMPTY_BENCH_SLOT__") {
-                    setPlayOptions({
-                      ...playOptions,
-                      formation: nextFormation,
-                      routes: {},
-                      reads: {},
-                    });
-                    setSelectedFormationPlayer("");
-                    return;
-                  }
-
-                  // Otherwise the selected bench player takes the clicked spot. If the spot was occupied, its previous player naturally returns to the bench because they are omitted from the next formation map.
+                  // The selected player takes the clicked spot. If the spot was occupied, its previous player naturally returns to the bench because they are omitted from the next formation map.
                   setPlayOptions({
                     ...playOptions,
                     formation: { ...nextFormation, [slot]: selectedPlayer },
@@ -1571,6 +1564,7 @@ export function GameCenter({
               onAction={action}
               onFormationModeChange={setSettingFormation}
               onSelectedFormationPlayerChange={setSelectedFormationPlayer}
+              selectedFormationPlayer={selectedFormationPlayer}
             />
           </div>
           {lastPlay && (

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -13,7 +13,6 @@ const OL_SLOTS: FormationSlot[] = ["LT", "LG", "C", "RG", "RT"];
 const REQUIRED = new Set<FormationSlot>(["QB", "LG", "C", "RG"]);
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
-const EMPTY_BENCH_SLOT = "__EMPTY_BENCH_SLOT__";
 
 type Player = Record<string, unknown>;
 type Props = {
@@ -24,6 +23,7 @@ type Props = {
   onAction: (label: string, options?: PlayCallOptions) => void;
   onFormationModeChange?: (active: boolean) => void;
   onSelectedFormationPlayerChange?: (player: string) => void;
+  selectedFormationPlayer?: string;
 };
 
 function nameOf(p: Player) {
@@ -192,6 +192,7 @@ export function GameControls({
   onAction,
   onFormationModeChange,
   onSelectedFormationPlayerChange,
+  selectedFormationPlayer = "",
 }: Props) {
   const [collapsed, setCollapsed] = useState(true);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
@@ -226,10 +227,13 @@ export function GameControls({
   const bench = roster.filter(
     (p) => !Object.values(formation).includes(nameOf(p)),
   );
-  const selectedBenchPlayer =
-    selected === EMPTY_BENCH_SLOT || bench.some((player) => nameOf(player) === selected)
-      ? selected
-      : "";
+  const fieldedNames = Object.values(formation).filter((name): name is string => Boolean(name));
+  const selectedBenchPlayer = bench.some((player) => nameOf(player) === selected)
+    ? selected
+    : "";
+  const selectedFieldPlayer = fieldedNames.includes(selectedFormationPlayer)
+    ? selectedFormationPlayer
+    : "";
 
   useEffect(() => {
     onSelectedFormationPlayerChange?.(
@@ -316,19 +320,41 @@ export function GameControls({
         <div className="field-formation-bench" aria-label="Offensive bench">
           <div className="field-formation-bench-header">
             <h4>Bench</h4>
-            <span>Pick a player to place/swap, or pick Empty to remove a fielded player.</span>
+            <span>Pick a bench player to place/swap. Select a fielded player, then click open bench space to remove them.</span>
           </div>
-          <div className="bench bench-ten-wide">
-            <button
-              type="button"
-              onClick={() =>
-                setSelected(selectedBenchPlayer === EMPTY_BENCH_SLOT ? "" : EMPTY_BENCH_SLOT)
-              }
-              className={`player-item ${selectedBenchPlayer === EMPTY_BENCH_SLOT ? "selected" : ""}`}
-            >
-              <PlayerBubble />
-              <span className="player-name">Empty bench slot</span>
-            </button>
+          <div
+            className={`bench bench-ten-wide ${selectedFieldPlayer ? "remove-target" : ""}`}
+            onClick={(event) => {
+              if (event.currentTarget !== event.target || !selectedFieldPlayer) return;
+
+              const nextFormation = Object.fromEntries(
+                Object.entries(formation).filter(([, player]) => player !== selectedFieldPlayer),
+              ) as Partial<Record<FormationSlot, string>>;
+
+              setOpt({ formation: nextFormation, routes: {}, reads: {} });
+              setSelected("");
+              onSelectedFormationPlayerChange?.("");
+            }}
+            role={selectedFieldPlayer ? "button" : undefined}
+            tabIndex={selectedFieldPlayer ? 0 : undefined}
+            aria-label={
+              selectedFieldPlayer
+                ? `Remove ${selectedFieldPlayer} from the field`
+                : "Offensive bench players"
+            }
+            onKeyDown={(event) => {
+              if (!selectedFieldPlayer || (event.key !== "Enter" && event.key !== " ")) return;
+              event.preventDefault();
+
+              const nextFormation = Object.fromEntries(
+                Object.entries(formation).filter(([, player]) => player !== selectedFieldPlayer),
+              ) as Partial<Record<FormationSlot, string>>;
+
+              setOpt({ formation: nextFormation, routes: {}, reads: {} });
+              setSelected("");
+              onSelectedFormationPlayerChange?.("");
+            }}
+          >
             {bench.map((p) => (
               <button
                 type="button"

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -581,7 +581,7 @@ textarea {
 
 .field-formation-slot {
   position: absolute;
-  z-index: 145;
+  z-index: 170;
   width: 58px;
   height: 58px;
   padding: 0;
@@ -609,6 +609,12 @@ textarea {
   border-style: solid;
   box-shadow:
     0 0 0 4px rgba(250, 204, 21, 0.42),
+    0 8px 18px rgba(0, 0, 0, 0.45);
+}
+
+.field-formation-slot.selected {
+  box-shadow:
+    0 0 0 5px rgba(34, 197, 94, 0.55),
     0 8px 18px rgba(0, 0, 0, 0.45);
 }
 
@@ -651,7 +657,10 @@ textarea {
 }
 
 .field-formation-slot.defense {
+  z-index: 135;
   border-color: #ef4444;
   color: #fecaca;
   background: rgba(127, 29, 29, 0.86);
+  opacity: 0.38;
+  pointer-events: none;
 }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -963,7 +963,7 @@ export default function GameField({
                 <button
                   key={slot}
                   type="button"
-                  className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer ? "targetable" : ""}`}
+                  className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer ? "targetable" : ""} ${playerName && selectedFormationPlayer === playerName ? "selected" : ""}`}
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
                     top: `${yardToYPct(55 + lineup.yardOffsetFromLos)}%`,

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1797,6 +1797,12 @@
   overflow-y: auto;
 }
 
+.bench-ten-wide.remove-target {
+  cursor: copy;
+  outline: 2px dashed rgba(34, 197, 94, 0.65);
+  outline-offset: 4px;
+}
+
 .bench-ten-wide .player-item {
   width: 100%;
   max-width: none;


### PR DESCRIPTION
### Motivation
- Simplify the formation bench UX by removing a dedicated "Empty bench slot" target and instead letting the user remove a selected fielded player by clicking the bench area. 
- Improve visual clarity during formation setup by bringing offensive slots to the front and visually de-emphasizing the auto-generated defensive preview so the user can focus on offense placement.

### Description
- Removed the clickable `EMPTY_BENCH_SLOT` option and updated the bench copy to instruct users to "Select a fielded player, then click open bench space to remove them" in `GameControls.tsx`.
- Added bench-area click and keyboard handling to remove the currently selected fielded player and update `options.formation` accordingly in `GameControls.tsx` (supports click and Enter/Space activation).
- Changed field-slot click behavior in `GameCenter.tsx` so clicking an occupied slot with no bench selection now selects that fielded player, and clicking a slot while a bench/selected player exists places/swaps that player into the slot.
- Added a `selected` visual state on field slots in `GameField.tsx` and CSS to highlight the selected fielded player, raised offensive slot `z-index`, faded/disabled defensive preview slots during setup, and added a `remove-target` bench style in `league.css`.

### Testing
- Ran `npm run build` for the web app and the build completed successfully.
- Ran `npm run lint` and ESLint reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c48238ce8832490090f1b51175fce)