### PR TITLE
Limit formations to eight players per side

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -36,6 +36,8 @@ import type {
   PlayCallOptions,
 } from "./gameplay/gameEngine";
 
+const EXPECTED_PLAYERS_PER_SIDE = 8;
+
 type Play = Record<string, unknown>;
 type LineStatMatchup = {
   offensePlayer?: string;
@@ -1544,6 +1546,15 @@ export function GameCenter({
                         formationSlot !== slot && player !== selectedPlayer,
                     ),
                   ) as Partial<Record<FormationSlot, string>>;
+                  const wouldAddPlayer = !slotPlayer;
+                  const currentPlayerCount =
+                    Object.values(currentFormation).filter(Boolean).length;
+
+                  if (
+                    wouldAddPlayer &&
+                    currentPlayerCount >= EXPECTED_PLAYERS_PER_SIDE
+                  )
+                    return;
 
                   // The selected player takes the clicked spot. If the spot was occupied, its previous player naturally returns to the bench because they are omitted from the next formation map.
                   setPlayOptions({

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -11,6 +11,7 @@ const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
 const RB_SLOTS: FormationSlot[] = ["RB1", "RB2"];
 const OL_SLOTS: FormationSlot[] = ["LT", "LG", "C", "RG", "RT"];
 const REQUIRED = new Set<FormationSlot>(["QB", "LG", "C", "RG"]);
+const EXPECTED_PLAYERS_PER_SIDE = 8;
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
 
@@ -167,21 +168,24 @@ function buildDefense(
       align: slot,
     }),
   );
-  // Any remaining defenders key on backfield/QB slots before the safety fallback so the final formation has support against runs and passes.
-  let remaining = Math.max(0, 7 - out.length);
-  (["QB", "RB1", "RB2"] as FormationSlot[])
-    .slice(0, remaining)
-    .forEach((slot, i) => {
-      const p = take([lbs, dls, dbs]);
-      if (p)
-        out.push({ position: `LB${i + 1}`, player: nameOf(p), align: slot });
-    });
-  remaining = Math.max(0, 7 - out.length);
-  if (remaining) {
+  // Any remaining defenders key on backfield/QB slots before the safety fallback
+  // so the final formation always matches the eight-player offense.
+  (["QB", "RB1", "RB2"] as FormationSlot[]).forEach((slot) => {
+    if (out.length >= EXPECTED_PLAYERS_PER_SIDE) return;
+    const p = take([lbs, dls, dbs]);
+    if (p)
+      out.push({
+        position: `LB${out.length + 1}`,
+        player: nameOf(p),
+        align: slot,
+      });
+  });
+  while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
     const p = take([safeties, lbs, dbs, dls]);
-    if (p) out.push({ position: "S", player: nameOf(p) });
+    if (!p) break;
+    out.push({ position: `S${out.length + 1}`, player: nameOf(p) });
   }
-  return out;
+  return out.slice(0, EXPECTED_PLAYERS_PER_SIDE);
 }
 
 export function GameControls({
@@ -218,7 +222,10 @@ export function GameControls({
   const runners = (["QB", ...RB_SLOTS, ...WR_SLOTS] as FormationSlot[])
     .map((s) => formation[s])
     .filter((r): r is string => Boolean(r));
-  const validFormation = [...REQUIRED].every((slot) => formation[slot]);
+  const formationPlayerCount = Object.values(formation).filter(Boolean).length;
+  const validFormation =
+    formationPlayerCount === EXPECTED_PLAYERS_PER_SIDE &&
+    [...REQUIRED].every((slot) => formation[slot]);
   const canPass = receivers.some(
     (r) => routes[r.player] && routes[r.player] !== "No Route",
   );
@@ -289,7 +296,12 @@ export function GameControls({
           <h3>{offenseTeam} Control Console</h3>
           <div className="play-call-summary">
             <span>
-              {validFormation ? "Formation ready" : "Set required formation"}
+              {validFormation
+                ? "Formation ready"
+                : `Set ${EXPECTED_PLAYERS_PER_SIDE}-player formation`}
+            </span>
+            <span>
+              Players: {formationPlayerCount}/{EXPECTED_PLAYERS_PER_SIDE}
             </span>
             <span>Runner: {options.runner || "Auto"}</span>
             <span>Clock: {options.clockMode || "Normal"}</span>

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -9,10 +9,14 @@ export type FormationEntry = {
 };
 const REQUIRED: FormationSlot[] = ["QB", "LG", "C", "RG"];
 const OL_SLOTS = new Set<string>(["LT", "LG", "C", "RG", "RT"]);
+const EXPECTED_PLAYERS_PER_SIDE = 8;
 export function validateOffensiveFormation(
   formation: Partial<Record<FormationSlot, string>>,
 ) {
-  return REQUIRED.every((slot) => Boolean(formation[slot]));
+  return (
+    Object.values(formation).filter(Boolean).length === EXPECTED_PLAYERS_PER_SIDE &&
+    REQUIRED.every((slot) => Boolean(formation[slot]))
+  );
 }
 export function saveOffensiveFormation(
   formation: Partial<Record<FormationSlot, string>>,
@@ -69,14 +73,15 @@ export function generateDefensiveFormation(
         });
     });
   // After man/box assignments, leftover linebackers and a safety fill the second level/deep help so the final defense is complete enough for run and pass engines.
-  [take(lbs), take(lbs), take(safeties)]
-    .filter(Boolean)
-    .forEach((p, i) =>
-      out.push({
-        position: i === 2 ? "S1" : `LB${i + 1}`,
-        player: playerName(p),
-        align: i === 2 ? "deep" : "box",
-      }),
-    );
-  return out;
+  while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
+    const p = take(lbs) ?? take(safeties) ?? take(dbs) ?? take(dls);
+    if (!p) break;
+    const defPos = str(p.defPos ?? p.DefPos ?? "LB").toUpperCase();
+    out.push({
+      position: `${defPos}${out.length + 1}`,
+      player: playerName(p),
+      align: defPos === "S" || defPos === "DB" ? "deep" : "box",
+    });
+  }
+  return out.slice(0, EXPECTED_PLAYERS_PER_SIDE);
 }


### PR DESCRIPTION
### Motivation
- Standardize the game to use 8 players per side and ensure UI/engine logic enforces that count for offense and defense. 
- Prevent users from placing more than 8 offensive players in the formation UI so the defensive mirror can reliably match the offense. 

### Description
- Introduced `EXPECTED_PLAYERS_PER_SIDE = 8` and updated validation so offensive formations must contain exactly 8 players and the required slots (`QB`, `LG`, `C`, `RG`) are present (`apps/web/src/components/league/gameplay/engine/formationEngine.ts`).
- Prevented the formation UI from adding a ninth player by blocking adding actions when the current formation already has 8 players (`apps/web/src/components/league/GameCenter.tsx`).
- Updated defensive generation to always fill/cap the defensive formation to 8 players (fills remaining LB/S/DB/DL slots and slices to 8) so the defense mirrors the offense count (`apps/web/src/components/league/GameControls.tsx` and `apps/web/src/components/league/gameplay/engine/formationEngine.ts`).
- Tweaked the controls UI to show current placed players as `Players: X/8` and changed the formation-ready text to reference the 8-player requirement (`apps/web/src/components/league/GameControls.tsx`).

### Testing
- Built the web app with `npm --prefix apps/web run build` and the build completed successfully. 
- Ran the linter with `npm --prefix apps/web run lint` and it completed with no errors reported. 
- Started the dev server (`npm --prefix apps/web run dev`) to smoke-check runtime behavior (server started).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c496c9d508324bbd0e5be581b5246)