### PR TITLE
Run play: select runner before executing; add Punt button

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -351,8 +351,8 @@ export function GameControls({
               {settingFormation ? "Hide Bench" : "Set Formation"}
             </button>
             <button
-              disabled={!validFormation}
-              onClick={() => onAction("Run Play", optionsWithDefense())}
+              disabled={!validFormation || runners.length === 0}
+              onClick={() => setModal("run")}
             >
               Call Run Play
             </button>
@@ -364,6 +364,9 @@ export function GameControls({
               }}
             >
               Call Pass Play
+            </button>
+            <button onClick={() => onAction("Punt", optionsWithDefense())}>
+              Call Punt Play
             </button>
           </div>
         </>
@@ -569,7 +572,9 @@ export function GameControls({
           <div className="rusher-options">
             {runners.map((r) => (
               <button
-                className={`rusher-option ${options.runner === r ? "selected" : ""}`}
+                className={`rusher-option ${
+                  (options.runner || runners[0]) === r ? "selected" : ""
+                }`}
                 onClick={() => setOpt({ runner: r })}
                 type="button"
                 key={r}
@@ -583,7 +588,10 @@ export function GameControls({
             disabled={!validFormation}
             onClick={() => {
               setModal(null);
-              onAction("Run Play", optionsWithDefense());
+              onAction("Run Play", {
+                ...optionsWithDefense(),
+                runner: options.runner || runners[0],
+              });
             }}
           >
             Execute Run


### PR DESCRIPTION
### Motivation
- Enable explicit selection of which player will carry the ball for a run play instead of immediately snapping with an implicit or absent runner.
- Restore a dedicated punt control in the play-caller UI that triggers the existing automatic punt logic.

### Description
- Change the `Call Run Play` control to open the existing run-selection modal (`setModal("run")`) and disable the button when no eligible `runners` are present.
- Add a `Call Punt Play` button that invokes the existing punt action via `onAction("Punt", optionsWithDefense())`.
- Update the run modal to highlight the selected/default runner by comparing `(options.runner || runners[0]) === r` and pass the resolved `runner` into the executed run payload (`runner: options.runner || runners[0]`).
- Minor formatting tweak to the rusher button className for readability in `apps/web/src/components/league/GameControls.tsx`.

### Testing
- Ran `npm run build` (TypeScript compile + Vite build) and it completed successfully.
- Ran `npm run lint` (ESLint) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c4e51262c83249e65695bb1ca7757)