### PR TITLE
Rank defensive assignments by offensive stars

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -181,9 +181,12 @@ function buildDefense(
     lbs = by("LB"),
     safeties = by("S");
   const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
-  // Saved receiver slots drive coverage first, then saved offensive-line slots drive front-seven alignment.
-  const wrs = WR_SLOTS.filter((s) => formation[s]);
-  const ol = OL_SLOTS.filter((s) => formation[s]);
+  const byName = (playerName?: string) => players.find((p) => nameOf(p) === playerName);
+  // Saved receivers and linemen are ranked by offensive stars so the best DBs/DLs match the best WRs/OLs.
+  const byOffStars = (a: FormationSlot, b: FormationSlot) =>
+    trait(byName(formation[b]), "offStars") - trait(byName(formation[a]), "offStars");
+  const wrs = WR_SLOTS.filter((s) => formation[s]).sort(byOffStars);
+  const ol = OL_SLOTS.filter((s) => formation[s]).sort(byOffStars);
   const out: DefensiveAssignment[] = [];
   wrs.forEach((slot, i) =>
     out.push({

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -1,6 +1,6 @@
 import type { LeagueGame } from "../../types";
 import type { EngineContext, FormationSlot, PlayerTrait } from "./types";
-import { defenseTeam, playerName, str, teamPlayers, trait } from "./utils";
+import { byName, defenseTeam, playerName, str, teamPlayers, trait } from "./utils";
 
 export type FormationEntry = {
   position: FormationSlot | string;
@@ -48,9 +48,14 @@ export function generateDefensiveFormation(
     return player;
   };
   const out: FormationEntry[] = [];
-  // Wide receivers create the first defensive obligations: the best available DBs travel to those exact receiver slots.
+  const offenseByPlayerStars = (a: FormationEntry, b: FormationEntry) =>
+    trait(byName(ctx, b.player), "offStars", 0) -
+    trait(byName(ctx, a.player), "offStars", 0);
+
+  // Wide receivers create the first defensive obligations: the best available DBs travel to the highest-star receivers first.
   offense
     .filter((s) => s.position.startsWith("WR"))
+    .sort(offenseByPlayerStars)
     .forEach((slot, i) => {
       const p = take(dbs);
       if (p)
@@ -60,11 +65,12 @@ export function generateDefensiveFormation(
           align: slot.position,
         });
     });
-  // Offensive linemen define the box, so each occupied line slot receives a DL/LB matchup aligned over that saved offensive position.
+  // Offensive linemen define the box, so the best available DLs/LBs align to the highest-star blockers first.
   offense
     .filter((s) => OL_SLOTS.has(String(s.position)))
+    .sort(offenseByPlayerStars)
     .forEach((slot, i) => {
-      const p = take(i % 2 ? lbs : dls) ?? take(dls) ?? take(lbs);
+      const p = take(dls) ?? take(lbs);
       if (p)
         out.push({
           position: `${str(p.defPos ?? "DL")}${i + 1}`,


### PR DESCRIPTION
### Motivation
- Defensive matchups should target the highest-threat offensive players instead of depending on input order so the top DBs/DLs face the best WRs/OLs. 
- Keep the UI defensive preview and the gameplay formation generation consistent so what the user sees matches play resolution.

### Description
- Update preview in `apps/web/src/components/league/GameControls.tsx` to compute `byOffStars` and sort saved WR and OL slots by the assigned player’s `offStars` before assigning DB/DL slots. 
- Update engine in `apps/web/src/components/league/gameplay/engine/formationEngine.ts` to import `byName`, add `offenseByPlayerStars`, and sort offense `WR` and `OL` entries by `offStars` so the highest-star receivers and blockers get matched first. 
- Adjusted defensive selection ordering to prefer `DL` then `LB` for OL matchups and preserved the existing fill loop that caps the defense at `EXPECTED_PLAYERS_PER_SIDE`.

### Testing
- Ran `npm --prefix apps/web run build` which completed successfully. 
- Ran `npm --prefix apps/web run lint` which completed successfully. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it returned cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c500fac2c83249fb219475a04ea30)