### PR TITLE
Enable field player substitutions and position swaps

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1637,13 +1637,19 @@ export function GameCenter({
                     return;
                   }
 
+                  const selectedPlayerEntry = Object.entries(
+                    currentFormation,
+                  ).find(([, player]) => player === selectedPlayer);
+                  const selectedPlayerSlot = selectedPlayerEntry?.[0] as
+                    | FormationSlot
+                    | undefined;
                   const nextFormation = Object.fromEntries(
                     Object.entries(currentFormation).filter(
                       ([formationSlot, player]) =>
                         formationSlot !== slot && player !== selectedPlayer,
                     ),
                   ) as Partial<Record<FormationSlot, string>>;
-                  const wouldAddPlayer = !slotPlayer;
+                  const wouldAddPlayer = !slotPlayer && !selectedPlayerSlot;
                   const currentPlayerCount =
                     Object.values(currentFormation).filter(Boolean).length;
 
@@ -1653,7 +1659,10 @@ export function GameCenter({
                   )
                     return;
 
-                  // The selected player takes the clicked spot. If the spot was occupied, its previous player naturally returns to the bench because they are omitted from the next formation map.
+                  if (selectedPlayerSlot && slotPlayer) {
+                    nextFormation[selectedPlayerSlot] = slotPlayer;
+                  }
+
                   setPlayOptions({
                     ...playOptions,
                     formation: { ...nextFormation, [slot]: selectedPlayer },
@@ -1661,6 +1670,15 @@ export function GameCenter({
                     reads: {},
                   });
                   setSelectedFormationPlayer("");
+                  setSettingFormation(false);
+                }}
+                onPlayerSubstitute={(playerName) => {
+                  setSelectedFormationPlayer(playerName);
+                  setSettingFormation(true);
+                }}
+                onPlayerChangePosition={(playerName) => {
+                  setSelectedFormationPlayer(playerName);
+                  setSettingFormation(true);
                 }}
               />
             </div>
@@ -1673,6 +1691,7 @@ export function GameCenter({
               onFormationModeChange={setSettingFormation}
               onSelectedFormationPlayerChange={setSelectedFormationPlayer}
               selectedFormationPlayer={selectedFormationPlayer}
+              requestedFormationMode={settingFormation}
             />
           </div>
           {lastPlay && (

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -25,6 +25,7 @@ type Props = {
   onFormationModeChange?: (active: boolean) => void;
   onSelectedFormationPlayerChange?: (player: string) => void;
   selectedFormationPlayer?: string;
+  requestedFormationMode?: boolean;
 };
 
 /**
@@ -236,6 +237,7 @@ export function GameControls({
   onFormationModeChange,
   onSelectedFormationPlayerChange,
   selectedFormationPlayer = "",
+  requestedFormationMode,
 }: Props) {
   const [collapsed, setCollapsed] = useState(true);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
@@ -245,9 +247,11 @@ export function GameControls({
 
   const offenseTeam = game.Possession === "Home" ? game.Home : game.Away;
 
-  useEffect(() => {
-    onFormationModeChange?.(settingFormation);
-  }, [onFormationModeChange, settingFormation]);
+  const activeFormationMode = requestedFormationMode ?? settingFormation;
+  const setFormationMode = (active: boolean) => {
+    setSettingFormation(active);
+    onFormationModeChange?.(active);
+  };
 
   const roster = useMemo(
     () => players.filter((p) => teamOf(p) === offenseTeam),
@@ -286,10 +290,13 @@ export function GameControls({
     : "";
 
   useEffect(() => {
-    onSelectedFormationPlayerChange?.(
-      settingFormation ? selectedBenchPlayer : "",
-    );
-  }, [onSelectedFormationPlayerChange, selectedBenchPlayer, settingFormation]);
+    if (!activeFormationMode) {
+      onSelectedFormationPlayerChange?.("");
+      return;
+    }
+    if (selectedBenchPlayer)
+      onSelectedFormationPlayerChange?.(selectedBenchPlayer);
+  }, [activeFormationMode, onSelectedFormationPlayerChange, selectedBenchPlayer]);
   const setRouteAndRead = (
     player: string,
     route: string,
@@ -319,7 +326,7 @@ export function GameControls({
   const saveFormation = () => {
     // Saving closes the bench but keeps `options.formation` plus the generated defensive mirror available for the next play call.
     onOptionsChange(optionsWithDefense());
-    setSettingFormation(false);
+    setFormationMode(false);
     setSelected("");
   };
 
@@ -350,8 +357,8 @@ export function GameControls({
             <span>Clock: {options.clockMode || "Normal"}</span>
           </div>
           <div className="game-controls primary">
-            <button onClick={() => setSettingFormation((active) => !active)}>
-              {settingFormation ? "Hide Bench" : "Set Formation"}
+            <button onClick={() => setFormationMode(!activeFormationMode)}>
+              {activeFormationMode ? "Hide Bench" : "Set Formation"}
             </button>
             <button
               disabled={!validFormation || runners.length === 0}
@@ -374,7 +381,7 @@ export function GameControls({
           </div>
         </>
       )}
-      {settingFormation && (
+      {activeFormationMode && (
         <div className="field-formation-bench" aria-label="Offensive bench">
           <div className="field-formation-bench-header">
             <h4>Bench</h4>
@@ -428,11 +435,33 @@ export function GameControls({
             {bench.map((p) => (
               <button
                 type="button"
-                onClick={() =>
+                onClick={() => {
+                  const benchPlayerName = nameOf(p);
+                  if (selectedFieldPlayer) {
+                    const replaceSlot = Object.entries(formation).find(
+                      ([, player]) => player === selectedFieldPlayer,
+                    )?.[0] as FormationSlot | undefined;
+                    if (replaceSlot) {
+                      setOpt({
+                        formation: {
+                          ...formation,
+                          [replaceSlot]: benchPlayerName,
+                        },
+                        routes: {},
+                        reads: {},
+                      });
+                      setSelected("");
+                      onSelectedFormationPlayerChange?.("");
+                      setFormationMode(false);
+                      return;
+                    }
+                  }
                   setSelected(
-                    selectedBenchPlayer === nameOf(p) ? "" : nameOf(p),
-                  )
-                }
+                    selectedBenchPlayer === benchPlayerName
+                      ? ""
+                      : benchPlayerName,
+                  );
+                }}
                 className={`player-item ${selectedBenchPlayer === nameOf(p) ? "selected" : ""}`}
                 key={nameOf(p)}
               >
@@ -447,7 +476,7 @@ export function GameControls({
             <button
               type="button"
               onClick={() => {
-                setSettingFormation(false);
+                setFormationMode(false);
                 setSelected("");
               }}
             >

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -324,6 +324,8 @@ export default function GameField({
   players = [],
   selectedFormationPlayer = "",
   onFormationSlotClick,
+  onPlayerSubstitute,
+  onPlayerChangePosition,
   homeLogo,
   homeTeam,
   awayTeam,
@@ -334,6 +336,8 @@ export default function GameField({
   players?: FormationPlayer[];
   selectedFormationPlayer?: string;
   onFormationSlotClick?: (slot: FormationSlot) => void;
+  onPlayerSubstitute?: (playerName: string) => void;
+  onPlayerChangePosition?: (playerName: string) => void;
   homeLogo?: string;
   homeTeam?: string;
   awayTeam?: string;
@@ -1096,6 +1100,36 @@ export default function GameField({
               );
             })}
 
+          {formationMode &&
+            defense.map((assignment) => {
+              const lineup = assignment.align
+                ? FORMATION_SLOT_LINEUP[assignment.align as FormationSlot]
+                : defensiveLineupForPosition(assignment.position);
+              if (!lineup) return null;
+              const player = findFormationPlayer(assignment.player);
+              const playerImage = imgOf(player);
+              return (
+                <div
+                  key={`${assignment.position}-${assignment.player}`}
+                  className="field-formation-slot defense"
+                  style={{
+                    left: `${LANES[lineup.lane] ?? 50}%`,
+                    top: `${yardToYPct(55 + lineup.yardOffsetFromLos)}%`,
+                  }}
+                  aria-hidden="true"
+                >
+                  {playerImage ? (
+                    <img src={playerImage} alt="" />
+                  ) : (
+                    <span className="field-formation-avatar">👤</span>
+                  )}
+                  <span className="field-formation-name">
+                    {assignment.player}
+                  </span>
+                </div>
+              );
+            })}
+
           {selectedPlayerMenu && (
             <div
               className="player-action-menu"
@@ -1108,8 +1142,24 @@ export default function GameField({
               <div className="player-action-menu-title">
                 {selectedPlayerMenu.player.name}
               </div>
-              <button type="button">Substitute</button>
-              <button type="button">Change Position</button>
+              <button
+                type="button"
+                onClick={() => {
+                  onPlayerSubstitute?.(selectedPlayerMenu.player.name);
+                  setSelectedPlayerMenu(null);
+                }}
+              >
+                Substitute
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onPlayerChangePosition?.(selectedPlayerMenu.player.name);
+                  setSelectedPlayerMenu(null);
+                }}
+              >
+                Change Position
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Allow users to Substitute or Change Position by clicking a player on the field and complete the requested swap via the bench or formation UI. 
- When editing positions the defense should fade and defensive markers be shown so offensive formation slots remain targetable. 
- Swapping should support exchanging a clicked player with an already-filled offensive slot and then return the view to the animation state.

### Description
- Wired the field player action menu to new callbacks by adding `onPlayerSubstitute` and `onPlayerChangePosition` props to `GameField` and invoking them from the menu buttons to open formation editing with the clicked player selected (`apps/web/src/components/league/GameField.tsx`).
- Rendered faded defensive alignment markers while `formationMode` is active so the defense visually de-emphasizes while offensive slots remain targetable (`GameField.tsx`).
- Made `GameCenter` set the clicked player as the selected formation player and added logic to `onFormationSlotClick` to perform position swaps that move the displaced player back into the clicked player’s original slot, clear selection, and exit formation mode (`apps/web/src/components/league/GameCenter.tsx`).
- Extended `GameControls` with a `requestedFormationMode` prop and introduced an `activeFormationMode`/`setFormationMode` flow to synchronize formation mode between the field and bench UIs; clicking a bench player while a fielded player is selected now replaces that fielded player and automatically closes formation mode (`apps/web/src/components/league/GameControls.tsx`).

### Testing
- Ran linting with `npm --prefix apps/web run lint` and the lint check passed. 
- Built the web app with `npm --prefix apps/web run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d11334218832497e27e59f258b076)