### PR TITLE
Adjust defensive assignment priorities

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -170,20 +170,36 @@ function buildDefense(
   // The defense belongs to the team without possession; deriving it here keeps the UI preview and play-call payload in sync with the scoreboard.
   const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
   const defenders = players.filter((p) => teamOf(p) === defenseTeam);
-  const by = (d: string) =>
+  const by = (d: string, sortBy = "defStars") =>
     defenders
       .filter(
         (p) =>
           str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d,
       )
-      .sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
-  const dbs = by("DB"),
-    dls = by("DL"),
+      .sort((a, b) => trait(b, sortBy) - trait(a, sortBy));
+  const dbs = by("DB", "coverage"),
+    dls = by("DL", "size"),
     lbs = by("LB"),
     safeties = by("S");
-  const take = (arrs: Player[][]) => arrs.find((a) => a.length)?.shift();
+  const protectedLb = lbs[0];
+  const reserveProtectedLb = (p: Player) => p !== protectedLb;
+  const lbCoverageFallbacks = lbs.filter(reserveProtectedLb);
+  const lbLineFallbacks = [...lbCoverageFallbacks].reverse();
+  const selectedDefenders = new Set<Player>();
+  const take = (arrs: Player[][]) => {
+    for (const arr of arrs) {
+      while (arr.length) {
+        const player = arr.shift();
+        if (player && !selectedDefenders.has(player)) {
+          selectedDefenders.add(player);
+          return player;
+        }
+      }
+    }
+    return undefined;
+  };
   const byName = (playerName?: string) => players.find((p) => nameOf(p) === playerName);
-  // Saved receivers and linemen are ranked by offensive stars so the best DBs/DLs match the best WRs/OLs.
+  // Saved receivers and linemen are ranked by offensive stars so the best coverage DBs and biggest DLs match the best WRs/OLs.
   const byOffStars = (a: FormationSlot, b: FormationSlot) =>
     trait(byName(formation[b]), "offStars") - trait(byName(formation[a]), "offStars");
   const wrs = WR_SLOTS.filter((s) => formation[s]).sort(byOffStars);
@@ -192,14 +208,14 @@ function buildDefense(
   wrs.forEach((slot, i) =>
     out.push({
       position: `DB${i + 1}`,
-      player: nameOf(take([dbs, lbs]) ?? {}),
+      player: nameOf(take([dbs, lbCoverageFallbacks]) ?? {}),
       align: slot,
     }),
   );
   ol.forEach((slot, i) =>
     out.push({
       position: `DL${i + 1}`,
-      player: nameOf(take([dls, lbs]) ?? {}),
+      player: nameOf(take([dls, lbLineFallbacks, lbs]) ?? {}),
       align: slot,
     }),
   );


### PR DESCRIPTION
### Motivation
- Ensure defensive backs (DBs) are chosen by coverage and defensive linemen (DLs) by size so matchups better reflect receiver and offensive-line traits. 
- Keep the single highest-star linebacker (LB) available for LB roles unless line depth forces that player into a DL slot. 
- Prevent the same player from being assigned to multiple defensive slots.

### Description
- Updated `buildDefense` in `apps/web/src/components/league/GameControls.tsx` to allow sorting by an arbitrary trait and to sort DBs by `coverage` and DLs by `size` instead of `defStars`.
- Added logic to mark the top LB (`protectedLb`) and exclude them from DB fallback pools, creating `lbCoverageFallbacks` and `lbLineFallbacks` to control LB fallbacks for DB/DL assignments.
- Introduced a `selectedDefenders` set and replaced the simple `take` helper with a deduplicating `take` that skips already-chosen players across assignment pools.
- Adjusted DB and DL assignment calls to use the new fallback lists so DBs prefer `coverage` DBs and DLs prefer biggest DLs, with LBs used only when needed.

### Testing
- Ran `npm run lint` in `apps/web` with no lint errors (passed). 
- Ran the web build (`npm run build`) which completed successfully (TypeScript compile + Vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d126a765483248e92b4713da042bc)