### PR TITLE
Rebuild defense on formation saves; only auto-close formation on substitute/change

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -18,6 +18,7 @@ import {
 import { GameScoreboard } from "./GameScoreboard";
 import GameField from "./GameField";
 import { GameControls } from "./GameControls";
+import { buildDefense } from "./formationDefense";
 import { GameLog } from "./GameLog";
 import {
   goForTwo,
@@ -1387,6 +1388,8 @@ export function GameCenter({
   const [isSavingPlay, setIsSavingPlay] = useState(false);
   const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
   const [settingFormation, setSettingFormation] = useState(false);
+  const [autoCloseFormationOnSave, setAutoCloseFormationOnSave] =
+    useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
   const previousPossessionRef = useRef(currentGame.Possession);
   const ctx = useMemo(
@@ -1663,21 +1666,31 @@ export function GameCenter({
                     nextFormation[selectedPlayerSlot] = slotPlayer;
                   }
 
+                  const savedFormation = {
+                    ...nextFormation,
+                    [slot]: selectedPlayer,
+                  };
                   setPlayOptions({
                     ...playOptions,
-                    formation: { ...nextFormation, [slot]: selectedPlayer },
+                    formation: savedFormation,
                     routes: {},
                     reads: {},
+                    defense: buildDefense(currentGame, players, savedFormation),
                   });
                   setSelectedFormationPlayer("");
-                  setSettingFormation(false);
+                  if (autoCloseFormationOnSave) {
+                    setSettingFormation(false);
+                    setAutoCloseFormationOnSave(false);
+                  }
                 }}
                 onPlayerSubstitute={(playerName) => {
                   setSelectedFormationPlayer(playerName);
+                  setAutoCloseFormationOnSave(true);
                   setSettingFormation(true);
                 }}
                 onPlayerChangePosition={(playerName) => {
                   setSelectedFormationPlayer(playerName);
+                  setAutoCloseFormationOnSave(true);
                   setSettingFormation(true);
                 }}
               />
@@ -1688,7 +1701,10 @@ export function GameCenter({
               options={playOptions}
               onOptionsChange={setPlayOptions}
               onAction={action}
-              onFormationModeChange={setSettingFormation}
+              onFormationModeChange={(active) => {
+                setAutoCloseFormationOnSave(false);
+                setSettingFormation(active);
+              }}
               onSelectedFormationPlayerChange={setSelectedFormationPlayer}
               selectedFormationPlayer={selectedFormationPlayer}
               requestedFormationMode={settingFormation}

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -3,8 +3,8 @@ import type { LeagueGame } from "./types";
 import type {
   PlayCallOptions,
   FormationSlot,
-  DefensiveAssignment,
 } from "./gameplay/gameEngine";
+import { buildDefense } from "./formationDefense";
 
 const str = (v: unknown) => String(v ?? "");
 const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
@@ -157,89 +157,6 @@ function normalizeReads(
 }
 
 /**
- * Creates an eight-player defensive preview from the offense formation. It
- * picks the non-possessing team, ranks defenders by defensive stars inside each
- * position group, aligns coverage to receivers, aligns linemen to blockers, and
- * fills any remaining spots with linebackers/safeties.
- */
-function buildDefense(
-  game: LeagueGame,
-  players: Player[],
-  formation: Partial<Record<FormationSlot, string>>,
-): DefensiveAssignment[] {
-  // The defense belongs to the team without possession; deriving it here keeps the UI preview and play-call payload in sync with the scoreboard.
-  const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
-  const defenders = players.filter((p) => teamOf(p) === defenseTeam);
-  const by = (d: string, sortBy = "defStars") =>
-    defenders
-      .filter(
-        (p) =>
-          str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d,
-      )
-      .sort((a, b) => trait(b, sortBy) - trait(a, sortBy));
-  const dbs = by("DB", "coverage"),
-    dls = by("DL", "size"),
-    lbs = by("LB"),
-    safeties = by("S");
-  const protectedLb = lbs[0];
-  const reserveProtectedLb = (p: Player) => p !== protectedLb;
-  const lbCoverageFallbacks = lbs.filter(reserveProtectedLb);
-  const lbLineFallbacks = [...lbCoverageFallbacks].reverse();
-  const selectedDefenders = new Set<Player>();
-  const take = (arrs: Player[][]) => {
-    for (const arr of arrs) {
-      while (arr.length) {
-        const player = arr.shift();
-        if (player && !selectedDefenders.has(player)) {
-          selectedDefenders.add(player);
-          return player;
-        }
-      }
-    }
-    return undefined;
-  };
-  const byName = (playerName?: string) => players.find((p) => nameOf(p) === playerName);
-  // Saved receivers and linemen are ranked by offensive stars so the best coverage DBs and biggest DLs match the best WRs/OLs.
-  const byOffStars = (a: FormationSlot, b: FormationSlot) =>
-    trait(byName(formation[b]), "offStars") - trait(byName(formation[a]), "offStars");
-  const wrs = WR_SLOTS.filter((s) => formation[s]).sort(byOffStars);
-  const ol = OL_SLOTS.filter((s) => formation[s]).sort(byOffStars);
-  const out: DefensiveAssignment[] = [];
-  wrs.forEach((slot, i) =>
-    out.push({
-      position: `DB${i + 1}`,
-      player: nameOf(take([dbs, lbCoverageFallbacks]) ?? {}),
-      align: slot,
-    }),
-  );
-  ol.forEach((slot, i) =>
-    out.push({
-      position: `DL${i + 1}`,
-      player: nameOf(take([dls, lbLineFallbacks, lbs]) ?? {}),
-      align: slot,
-    }),
-  );
-  // Any remaining defenders key on backfield/QB slots before the safety fallback
-  // so the final formation always matches the eight-player offense.
-  (["QB", "RB1", "RB2"] as FormationSlot[]).forEach((slot) => {
-    if (out.length >= EXPECTED_PLAYERS_PER_SIDE) return;
-    const p = take([lbs, dls, dbs]);
-    if (p)
-      out.push({
-        position: `LB${out.length + 1}`,
-        player: nameOf(p),
-        align: slot,
-      });
-  });
-  while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
-    const p = take([safeties, lbs, dbs, dls]);
-    if (!p) break;
-    out.push({ position: `S${out.length + 1}`, player: nameOf(p) });
-  }
-  return out.slice(0, EXPECTED_PLAYERS_PER_SIDE);
-}
-
-/**
  * Play-calling panel for the team in possession. It manages formation editing,
  * route/read assignment, runner and clock options, generated defensive preview,
  * and the final play-call payload sent back to GameCenter.
@@ -288,8 +205,13 @@ export function GameControls({
   const canPass = receivers.some(
     (r) => routes[r.player] && routes[r.player] !== "No Route",
   );
-  const setOpt = (patch: Partial<PlayCallOptions>) =>
-    onOptionsChange({ ...options, ...patch });
+  const setOpt = (patch: Partial<PlayCallOptions>) => {
+    const nextOptions = { ...options, ...patch };
+    onOptionsChange({
+      ...nextOptions,
+      defense: buildDefense(game, players, nextOptions.formation ?? {}),
+    });
+  };
   const bench = roster.filter(
     (p) => !Object.values(formation).includes(nameOf(p)),
   );
@@ -468,7 +390,6 @@ export function GameControls({
                       });
                       setSelected("");
                       onSelectedFormationPlayerChange?.("");
-                      setFormationMode(false);
                       return;
                     }
                   }

--- a/apps/web/src/components/league/formationDefense.ts
+++ b/apps/web/src/components/league/formationDefense.ts
@@ -1,0 +1,104 @@
+import type { LeagueGame } from "./types";
+import type { DefensiveAssignment, FormationSlot } from "./gameplay/gameEngine";
+
+const str = (v: unknown) => String(v ?? "");
+const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
+const OL_SLOTS: FormationSlot[] = ["LT", "LG", "C", "RG", "RT"];
+const EXPECTED_PLAYERS_PER_SIDE = 8;
+
+type Player = Record<string, unknown>;
+
+function nameOf(p: Player) {
+  return str(p.name ?? p.Name);
+}
+function teamOf(p: Player) {
+  return str(p.team ?? p.Team);
+}
+function trait(p: Player | undefined, key: string) {
+  return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0);
+}
+
+/**
+ * Creates an eight-player defensive preview from the offense formation. It
+ * picks the non-possessing team, ranks defenders by defensive stars inside each
+ * position group, aligns coverage to receivers, aligns linemen to blockers, and
+ * fills any remaining spots with linebackers/safeties.
+ */
+export function buildDefense(
+  game: LeagueGame,
+  players: Player[],
+  formation: Partial<Record<FormationSlot, string>>,
+): DefensiveAssignment[] {
+  // The defense belongs to the team without possession; deriving it here keeps the UI preview and play-call payload in sync with the scoreboard.
+  const defenseTeam = game.Possession === "Home" ? game.Away : game.Home;
+  const defenders = players.filter((p) => teamOf(p) === defenseTeam);
+  const by = (d: string, sortBy = "defStars") =>
+    defenders
+      .filter(
+        (p) =>
+          str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d,
+      )
+      .sort((a, b) => trait(b, sortBy) - trait(a, sortBy));
+  const dbs = by("DB", "coverage"),
+    dls = by("DL", "size"),
+    lbs = by("LB"),
+    safeties = by("S");
+  const protectedLb = lbs[0];
+  const reserveProtectedLb = (p: Player) => p !== protectedLb;
+  const lbCoverageFallbacks = lbs.filter(reserveProtectedLb);
+  const lbLineFallbacks = [...lbCoverageFallbacks].reverse();
+  const selectedDefenders = new Set<Player>();
+  const take = (arrs: Player[][]) => {
+    for (const arr of arrs) {
+      while (arr.length) {
+        const player = arr.shift();
+        if (player && !selectedDefenders.has(player)) {
+          selectedDefenders.add(player);
+          return player;
+        }
+      }
+    }
+    return undefined;
+  };
+  const byName = (playerName?: string) =>
+    players.find((p) => nameOf(p) === playerName);
+  // Saved receivers and linemen are ranked by offensive stars so the best coverage DBs and biggest DLs match the best WRs/OLs.
+  const byOffStars = (a: FormationSlot, b: FormationSlot) =>
+    trait(byName(formation[b]), "offStars") -
+    trait(byName(formation[a]), "offStars");
+  const wrs = WR_SLOTS.filter((s) => formation[s]).sort(byOffStars);
+  const ol = OL_SLOTS.filter((s) => formation[s]).sort(byOffStars);
+  const out: DefensiveAssignment[] = [];
+  wrs.forEach((slot, i) =>
+    out.push({
+      position: `DB${i + 1}`,
+      player: nameOf(take([dbs, lbCoverageFallbacks]) ?? {}),
+      align: slot,
+    }),
+  );
+  ol.forEach((slot, i) =>
+    out.push({
+      position: `DL${i + 1}`,
+      player: nameOf(take([dls, lbLineFallbacks, lbs]) ?? {}),
+      align: slot,
+    }),
+  );
+  // Any remaining defenders key on backfield/QB slots before the safety fallback
+  // so the final formation always matches the eight-player offense.
+  (["QB", "RB1", "RB2"] as FormationSlot[]).forEach((slot) => {
+    if (out.length >= EXPECTED_PLAYERS_PER_SIDE) return;
+    const p = take([lbs, dls, dbs]);
+    if (p)
+      out.push({
+        position: `LB${out.length + 1}`,
+        player: nameOf(p),
+        align: slot,
+      });
+  });
+  while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
+    const p = take([safeties, lbs, dbs, dls]);
+    if (!p) break;
+    out.push({ position: `S${out.length + 1}`, player: nameOf(p) });
+  }
+  return out.slice(0, EXPECTED_PLAYERS_PER_SIDE);
+}


### PR DESCRIPTION
### Motivation
- Prevent the full "Set Formation" panel from auto-closing every time a player is added from the bench so users can continue editing the formation. 
- Ensure the defensive mirror is consistently rebuilt whenever the offensive formation is saved from any UI path. 
- Limit the auto-close behavior to explicit Substitute or Change Position actions only.

### Description
- Extracted defensive-preview logic into a shared helper `buildDefense` in `apps/web/src/components/league/formationDefense.ts` and removed the duplicate implementation. 
- Updated `GameControls` to recompute `defense` whenever `playOptions` are changed by centralizing option updates in `setOpt` and calling `buildDefense`. 
- Stopped auto-closing the full Set Formation bench flow after bench replacements by removing the forced `setFormationMode(false)` in `GameControls`. 
- Added an `autoCloseFormationOnSave` flag in `GameCenter` so Substitute and Change Position set the flag and only those saves auto-close the formation, and ensured `defense` is rebuilt on these saved formation updates. 

### Testing
- Ran `npm run lint` (web) and there were no remaining lint errors. 
- Ran `npm run build` (web) and the site built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d131b10a0832499cd54d9087475ab)