### PR TITLE
Allow DBs as backup defensive linemen

### DIFF
--- a/apps/web/src/components/league/formationDefense.ts
+++ b/apps/web/src/components/league/formationDefense.ts
@@ -47,7 +47,9 @@ export function buildDefense(
   const reserveProtectedLb = (p: Player) => p !== protectedLb;
   const lbCoverageFallbacks = lbs.filter(reserveProtectedLb);
   const lbLineFallbacks = [...lbCoverageFallbacks].reverse();
+  const dbLineFallbacks = [...dbs].reverse();
   const selectedDefenders = new Set<Player>();
+  const linebackerRoleDefenders = new Set<Player>();
   const take = (arrs: Player[][]) => {
     for (const arr of arrs) {
       while (arr.length) {
@@ -59,6 +61,25 @@ export function buildDefense(
       }
     }
     return undefined;
+  };
+  const takeLineDefender = () => {
+    const player = take([dls, lbLineFallbacks]);
+    if (player) return player;
+    const db = dbLineFallbacks.find((candidate) => !selectedDefenders.has(candidate));
+    if (
+      db &&
+      trait(db, "size") < 50 &&
+      protectedLb &&
+      !selectedDefenders.has(protectedLb) &&
+      trait(protectedLb, "size") >= 50
+    ) {
+      selectedDefenders.add(protectedLb);
+      linebackerRoleDefenders.add(db);
+      return protectedLb;
+    }
+    const dbFallback = take([dbLineFallbacks]);
+    if (dbFallback) return dbFallback;
+    return take([lbs]);
   };
   const byName = (playerName?: string) =>
     players.find((p) => nameOf(p) === playerName);
@@ -79,7 +100,7 @@ export function buildDefense(
   ol.forEach((slot, i) =>
     out.push({
       position: `DL${i + 1}`,
-      player: nameOf(take([dls, lbLineFallbacks, lbs]) ?? {}),
+      player: nameOf(takeLineDefender() ?? {}),
       align: slot,
     }),
   );
@@ -98,7 +119,10 @@ export function buildDefense(
   while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
     const p = take([safeties, lbs, dbs, dls]);
     if (!p) break;
-    out.push({ position: `S${out.length + 1}`, player: nameOf(p) });
+    out.push({
+      position: linebackerRoleDefenders.has(p) ? `LB${out.length + 1}` : `S${out.length + 1}`,
+      player: nameOf(p),
+    });
   }
   return out.slice(0, EXPECTED_PLAYERS_PER_SIDE);
 }

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -41,11 +41,33 @@ export function generateDefensiveFormation(
     dls = group("DL"),
     lbs = group("LB"),
     safeties = group("S");
+  const protectedLb = lbs[0];
+  const lbCoverageFallbacks = lbs.filter((p) => p !== protectedLb);
+  const lbLineFallbacks = [...lbCoverageFallbacks].reverse();
+  const dbLineFallbacks = [...dbs].reverse();
   const used = new Set<PlayerTrait>();
+  const linebackerRolePlayers = new Set<PlayerTrait>();
   const take = (pool: PlayerTrait[]) => {
     const player = pool.find((p) => !used.has(p));
     if (player) used.add(player);
     return player;
+  };
+  const takeLineDefender = () => {
+    const player = take(dls) ?? take(lbLineFallbacks);
+    if (player) return player;
+    const db = dbLineFallbacks.find((candidate) => !used.has(candidate));
+    if (
+      db &&
+      trait(db, "size") < 50 &&
+      protectedLb &&
+      !used.has(protectedLb) &&
+      trait(protectedLb, "size") >= 50
+    ) {
+      used.add(protectedLb);
+      linebackerRolePlayers.add(db);
+      return protectedLb;
+    }
+    return take(dbLineFallbacks) ?? take(lbs);
   };
   const out: FormationEntry[] = [];
   const offenseByPlayerStars = (a: FormationEntry, b: FormationEntry) =>
@@ -70,10 +92,10 @@ export function generateDefensiveFormation(
     .filter((s) => OL_SLOTS.has(String(s.position)))
     .sort(offenseByPlayerStars)
     .forEach((slot, i) => {
-      const p = take(dls) ?? take(lbs);
+      const p = takeLineDefender();
       if (p)
         out.push({
-          position: `${str(p.defPos ?? "DL")}${i + 1}`,
+          position: `DL${i + 1}`,
           player: playerName(p),
           align: slot.position,
         });
@@ -82,7 +104,9 @@ export function generateDefensiveFormation(
   while (out.length < EXPECTED_PLAYERS_PER_SIDE) {
     const p = take(lbs) ?? take(safeties) ?? take(dbs) ?? take(dls);
     if (!p) break;
-    const defPos = str(p.defPos ?? p.DefPos ?? "LB").toUpperCase();
+    const defPos = linebackerRolePlayers.has(p)
+      ? "LB"
+      : str(p.defPos ?? p.DefPos ?? "LB").toUpperCase();
     out.push({
       position: `${defPos}${out.length + 1}`,
       player: playerName(p),


### PR DESCRIPTION
### Motivation
- Align the defensive preview and in-engine formation generation so defensive backs (DBs) can backfill defensive line (DL) slots when DLs and non-reserved linebackers (LBs) are exhausted. 
- Preserve a single reserved LB for the line when the next candidate DB is undersized so the reserved LB fills the line and the small DB is used as an LB instead. 
- Keep DL-aligned outputs labeled as `DL` slots while recording DBs that are later converted to LB roles.

### Description
- Updated the UI preview builder in `apps/web/src/components/league/formationDefense.ts` to introduce `dbLineFallbacks`, `takeLineDefender()` and `linebackerRoleDefenders` to allow DBs to be used as backup DLs and to mark skipped undersized DBs for later LB assignment. 
- Applied the same logic to the gameplay formation generator in `apps/web/src/components/league/gameplay/engine/formationEngine.ts` with `dbLineFallbacks`, `takeLineDefender()` and `linebackerRolePlayers` to keep runtime play resolution consistent with the preview. 
- Implemented the reserved-LB swap rule where if a candidate DB has `size < 50` and the reserved LB has `size >= 50` and is unused, the reserved LB is placed on the line and the undersized DB is tracked to be assigned as an `LB` slot later; DL-aligned slots remain labeled as `DL${i+1}`.

### Testing
- Ran `npm run lint` in `apps/web` and it completed successfully. 
- Ran `npm run build` in `apps/web` (which runs `tsc -b && vite build`) and the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d17b58b3083248b58cd5ea8c06d7a)