### PR TITLE
Fix first down marker and away-team direction

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1627,6 +1627,8 @@ export function GameCenter({
                 defense={playOptions.defense}
                 players={players}
                 ballOn={currentGame.BallOn}
+                distance={currentGame.Distance}
+                possession={currentGame.Possession}
                 selectedFormationPlayer={selectedFormationPlayer}
                 homeLogo={currentGame.HomeLogo}
                 homeTeam={currentGame.Home}

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -262,6 +262,11 @@ const yardToYPct = (yard: number) =>
   91.8 - (Math.max(0, Math.min(100, yard)) / 100) * (91.8 - 8.2);
 const normalizeYard = (yard: string | number) =>
   Number.isFinite(Number(yard)) ? Number(yard) : 55;
+const normalizeDistance = (distance: string | number) =>
+  Number.isFinite(Number(distance)) ? Number(distance) : 10;
+const clampYard = (yard: number) => Math.max(0, Math.min(100, yard));
+const possessionDirection = (possession?: string) =>
+  String(possession ?? "Home").toLowerCase() === "away" ? -1 : 1;
 
 /**
  * Converts a team name into a CSS-safe side class. Known home/away names map to
@@ -329,6 +334,8 @@ export default function GameField({
   onPlayerSubstitute,
   onPlayerChangePosition,
   ballOn = 55,
+  distance = 10,
+  possession = "Home",
   homeLogo,
   homeTeam,
   awayTeam,
@@ -342,6 +349,8 @@ export default function GameField({
   onPlayerSubstitute?: (playerName: string) => void;
   onPlayerChangePosition?: (playerName: string) => void;
   ballOn?: string | number;
+  distance?: string | number;
+  possession?: string;
   homeLogo?: string;
   homeTeam?: string;
   awayTeam?: string;
@@ -374,6 +383,11 @@ export default function GameField({
   );
 
   const formationLosYard = normalizeYard(ballOn);
+  const offenseDirection = possessionDirection(possession);
+  const formationDistance = Math.max(0, normalizeDistance(distance));
+  const formationFirstDownYard = clampYard(
+    formationLosYard + offenseDirection * formationDistance,
+  );
 
   const buildFormationSetupPlan = useCallback((): AnimationPlan => {
     const losYard = formationLosYard;
@@ -421,6 +435,7 @@ export default function GameField({
       meta: {
         playId: "FORMATION_SETUP",
         playType: "Setup",
+        direction: offenseDirection === 1 ? "upfield" : "downfield",
         startYard: losYard,
         endYard: losYard,
         yardsGained: 0,
@@ -440,7 +455,7 @@ export default function GameField({
         {
           id: "firstDown",
           label: "1ST",
-          yard: losYard + 10,
+          yard: formationFirstDownYard,
           type: "firstDown",
         },
       ],
@@ -452,8 +467,10 @@ export default function GameField({
     defense,
     findFormationPlayer,
     formation,
+    formationFirstDownYard,
     formationLosYard,
     homeTeam,
+    offenseDirection,
   ]);
 
   const showError = useCallback((message: string) => {
@@ -763,7 +780,9 @@ export default function GameField({
             ...player,
             yard:
               player.yard ??
-              (lineup ? losYard + lineup.yardOffsetFromLos : losYard),
+              (lineup
+                ? losYard + offenseDirection * lineup.yardOffsetFromLos
+                : losYard),
           },
           plan.players,
         );
@@ -800,7 +819,8 @@ export default function GameField({
           ...player,
           lane,
           x: lane ? (LANES[lane] ?? target.x) : target.x,
-          yard: losYard + (player.assignment.cushionYards ?? 1.9),
+          yard:
+            losYard + offenseDirection * (player.assignment.cushionYards ?? 1.9),
         };
       });
       plan.players.forEach((rawPlayer) => {
@@ -867,6 +887,7 @@ export default function GameField({
     },
     [
       normalizePlayerLane,
+      offenseDirection,
       scrollViewportToFootball,
       startFootballCarrierFollow,
       stopFootballFollow,
@@ -1089,7 +1110,7 @@ export default function GameField({
                   className={`field-formation-slot ${slot.startsWith("WR") ? "wr" : slot.startsWith("RB") ? "rb" : slot === "QB" ? "qb" : "teol"} ${REQUIRED_FORMATION_SLOTS.has(slot) ? "required" : ""} ${playerName ? "filled" : "open"} ${selectedFormationPlayer ? "targetable" : ""} ${playerName && selectedFormationPlayer === playerName ? "selected" : ""}`}
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
-                    top: `${yardToYPct(formationLosYard + lineup.yardOffsetFromLos)}%`,
+                    top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
                   }}
                   aria-label={
                     playerName
@@ -1133,7 +1154,7 @@ export default function GameField({
                   className="field-formation-slot defense"
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
-                    top: `${yardToYPct(formationLosYard + lineup.yardOffsetFromLos)}%`,
+                    top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
                   }}
                   aria-hidden="true"
                 >


### PR DESCRIPTION
### Motivation
- The first-down marker was always placed 10 yards from the LOS and did not respect goal-to-go or the current `Distance` value.
- The field/formation preview and animation always assumed offense moved “up” the screen, making the away offense render incorrectly when they had possession.
- The UI needs to render formation player depths and first-down line according to the current possession and yards-to-go.

### Description
- Pass `distance` and `possession` from the game state into `GameField` by adding props in `GameCenter` (`distance={currentGame.Distance}` and `possession={currentGame.Possession}`).
- Add helpers in `GameField`: `normalizeDistance`, `clampYard`, and `possessionDirection` and compute `formationFirstDownYard = clampYard(formationLosYard + offenseDirection * formationDistance)` to place the first-down marker at `LOS + direction * Distance` (clamped to the goal line).
- Replace the hardcoded `los + 10` first-down yard with the computed `formationFirstDownYard` and set `meta.direction` accordingly in the formation setup plan.
- Flip formation/player default depths and coverage cushion offsets by multiplying lineup offsets and cushion yards by `offenseDirection`, so the away offense renders and animates downscreen when `Possession` is `Away`.
- Update `GameField` types/signature to accept `distance` and `possession` and include the new values in relevant callbacks/dependencies.

### Testing
- Ran `npm --prefix apps/web run lint` and resolved a related hook dependency warning; lint completed with no errors.
- Built the web client with `npm --prefix apps/web run build` and the build finished successfully.
- Ran `git diff --check` to confirm no whitespace or diff errors and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d19518e2083248757a80ca8d4e266)