### PR TITLE
Gate play calls during save/reset and animate field setup transitions

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1386,12 +1386,14 @@ export function GameCenter({
     "Loading game state, play history, players, and frontend settings...",
   ]);
   const [isSavingPlay, setIsSavingPlay] = useState(false);
+  const [isResettingPlay, setIsResettingPlay] = useState(false);
   const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
   const [settingFormation, setSettingFormation] = useState(false);
   const [autoCloseFormationOnSave, setAutoCloseFormationOnSave] =
     useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
   const previousPossessionRef = useRef(currentGame.Possession);
+  const playInFlightRef = useRef(false);
   const ctx = useMemo(
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
@@ -1446,6 +1448,8 @@ export function GameCenter({
     setSelectedFormationPlayer("");
   }, [currentGame.Possession]);
   const persist = async (result: ReturnType<typeof runPlay>) => {
+    if (playInFlightRef.current) return;
+    playInFlightRef.current = true;
     const previousGame = currentGame;
     const previousBallOn = currentGame.BallOn;
     setIsSavingPlay(true);
@@ -1476,15 +1480,17 @@ export function GameCenter({
         game: gamePayload,
       });
       if (result.play.playtype === "Run") {
-        void animatePlay("Run", null, {
-          ...result.game,
-          Previous: previousBallOn,
-        }).catch((error: unknown) => {
+        try {
+          await animatePlay("Run", null, {
+            ...result.game,
+            Previous: previousBallOn,
+          });
+        } catch (error: unknown) {
           setLog((l) => [
             `Play animation skipped: ${error instanceof Error ? error.message : String(error)}`,
             ...l,
           ]);
-        });
+        }
       }
     } catch (error) {
       setCurrentGame(previousGame);
@@ -1495,10 +1501,11 @@ export function GameCenter({
       ]);
     } finally {
       setIsSavingPlay(false);
+      playInFlightRef.current = false;
     }
   };
   const action = (label: string, options: PlayCallOptions = playOptions) => {
-    if (isSavingPlay) {
+    if (isSavingPlay || isResettingPlay || playInFlightRef.current) {
       setLog((l) => [
         "Play save in progress; wait for it to finish before snapping again.",
         ...l,
@@ -1696,6 +1703,7 @@ export function GameCenter({
                   setAutoCloseFormationOnSave(true);
                   setSettingFormation(true);
                 }}
+                onSetupTransitionChange={setIsResettingPlay}
               />
             </div>
             <GameControls
@@ -1711,6 +1719,7 @@ export function GameCenter({
               onSelectedFormationPlayerChange={setSelectedFormationPlayer}
               selectedFormationPlayer={selectedFormationPlayer}
               requestedFormationMode={settingFormation}
+              disabled={isSavingPlay || isResettingPlay}
             />
           </div>
           {lastPlay && (

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -26,6 +26,7 @@ type Props = {
   onSelectedFormationPlayerChange?: (player: string) => void;
   selectedFormationPlayer?: string;
   requestedFormationMode?: boolean;
+  disabled?: boolean;
 };
 
 /**
@@ -171,6 +172,7 @@ export function GameControls({
   onSelectedFormationPlayerChange,
   selectedFormationPlayer = "",
   requestedFormationMode,
+  disabled = false,
 }: Props) {
   const [collapsed, setCollapsed] = useState(true);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
@@ -295,17 +297,17 @@ export function GameControls({
             <span>Clock: {options.clockMode || "Normal"}</span>
           </div>
           <div className="game-controls primary">
-            <button onClick={() => setFormationMode(!activeFormationMode)}>
+            <button disabled={disabled} onClick={() => setFormationMode(!activeFormationMode)}>
               {activeFormationMode ? "Hide Bench" : "Set Formation"}
             </button>
             <button
-              disabled={!validFormation || runners.length === 0}
+              disabled={disabled || !validFormation || runners.length === 0}
               onClick={() => setModal("run")}
             >
               Call Run Play
             </button>
             <button
-              disabled={!validFormation}
+              disabled={disabled || !validFormation}
               onClick={() => {
                 if (!canPass) setModal("routes");
                 else onAction("Pass Play", optionsWithDefense());
@@ -313,7 +315,7 @@ export function GameControls({
             >
               Call Pass Play
             </button>
-            <button onClick={() => onAction("Punt", optionsWithDefense())}>
+            <button disabled={disabled} onClick={() => onAction("Punt", optionsWithDefense())}>
               Call Punt Play
             </button>
           </div>
@@ -554,7 +556,7 @@ export function GameControls({
             ))}
           </div>
           <button
-            disabled={!validFormation}
+            disabled={disabled || !validFormation}
             onClick={() => {
               setModal(null);
               onAction("Run Play", {
@@ -582,10 +584,10 @@ export function GameControls({
                 {c}
               </button>
             ))}
-            <button onClick={() => onAction("Spike", options)}>
+            <button disabled={disabled} onClick={() => onAction("Spike", options)}>
               Spike Ball
             </button>
-            <button onClick={() => onAction("Kneel", options)}>Kneel</button>
+            <button disabled={disabled} onClick={() => onAction("Kneel", options)}>Kneel</button>
           </div>
         </ControlModal>
       )}

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -339,6 +339,7 @@ export default function GameField({
   homeLogo,
   homeTeam,
   awayTeam,
+  onSetupTransitionChange,
 }: {
   formationMode?: boolean;
   formation?: Partial<Record<FormationSlot, string>>;
@@ -354,6 +355,7 @@ export default function GameField({
   homeLogo?: string;
   homeTeam?: string;
   awayTeam?: string;
+  onSetupTransitionChange?: (active: boolean) => void;
 }) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<HTMLDivElement>(null);
@@ -369,6 +371,7 @@ export default function GameField({
   const labelsRef = useRef<Record<string, HTMLDivElement>>({});
   const footballCarrierIdRef = useRef<string | null>(null);
   const isRunningRef = useRef(false);
+  const isSetupTransitionRef = useRef(false);
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
   const [selectedPlayerMenu, setSelectedPlayerMenu] = useState<{
@@ -1048,12 +1051,100 @@ export default function GameField({
   useEffect(() => {
     if (formationMode) return;
     if (!Object.values(formation).some(Boolean)) return;
-    resetAnimationScene(buildFormationSetupPlan());
+    const nextPlan = buildFormationSetupPlan();
+    const currentPlan = currentPlanRef.current;
+    if (!currentPlan || !Object.keys(playersRef.current).length) {
+      resetAnimationScene(nextPlan);
+      return;
+    }
+
+    const currentLos = currentPlan.lines.find((line) => line.id === "los")?.yard;
+    const nextLos = nextPlan.lines.find((line) => line.id === "los")?.yard;
+    const currentFirstDown = currentPlan.lines.find(
+      (line) => line.id === "firstDown",
+    )?.yard;
+    const nextFirstDown = nextPlan.lines.find(
+      (line) => line.id === "firstDown",
+    )?.yard;
+    if (currentLos === nextLos && currentFirstDown === nextFirstDown) {
+      resetAnimationScene(nextPlan);
+      return;
+    }
+
+    let cancelled = false;
+    const runSetupTransition = async () => {
+      isSetupTransitionRef.current = true;
+      onSetupTransitionChange?.(true);
+      try {
+        currentPlanRef.current = nextPlan;
+        updateLinePositions();
+        await wait(350);
+        if (cancelled) return;
+        activePhaseDurationMsRef.current = 700;
+        const moves = nextPlan.players.flatMap((targetPlayer) => {
+          if (!playersRef.current[targetPlayer.id]) return [];
+          const lineup =
+            targetPlayer.unit === "defense"
+              ? defensiveLineupForPosition(
+                  targetPlayer.role || targetPlayer.position,
+                )
+              : targetPlayer.role
+                ? DEFAULT_LINEUPS_BY_POSITION[targetPlayer.role]
+                : targetPlayer.position
+                  ? DEFAULT_LINEUPS_BY_POSITION[targetPlayer.position]
+                  : undefined;
+          const normalized = normalizePlayerLane(
+            {
+              ...targetPlayer,
+              yard:
+                targetPlayer.yard ??
+                (lineup && nextLos !== undefined
+                  ? nextLos + offenseDirection * lineup.yardOffsetFromLos
+                  : nextLos),
+            },
+            nextPlan.players,
+          );
+          return [
+            applyPlayerMove({
+              playerId: targetPlayer.id,
+              lane: normalized.lane,
+              x: normalized.x,
+              yard: normalized.yard,
+              durationMs: 700,
+            }),
+          ];
+        });
+        await Promise.all(moves);
+        if (!cancelled) {
+          syncFootballToCarrierDom();
+          scrollViewportToFootball();
+        }
+      } finally {
+        if (!cancelled) {
+          activePhaseDurationMsRef.current = DEFAULT_PHASE_DURATION_MS;
+          isSetupTransitionRef.current = false;
+          onSetupTransitionChange?.(false);
+        }
+      }
+    };
+    void runSetupTransition();
+    return () => {
+      cancelled = true;
+      isSetupTransitionRef.current = false;
+      onSetupTransitionChange?.(false);
+    };
   }, [
+    applyPlayerMove,
     buildFormationSetupPlan,
     formation,
     formationMode,
+    normalizePlayerLane,
+    offenseDirection,
+    onSetupTransitionChange,
     resetAnimationScene,
+    scrollViewportToFootball,
+    syncFootballToCarrierDom,
+    updateLinePositions,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent a new play from being started before the previous play has been fully persisted and the field visually settled. 
- Ensure field lines move first and players animate to their new starting spots before controls are re-enabled so the UI matches persisted game state.

### Description
- Add an in-flight guard (`playInFlightRef`) and `isResettingPlay` state in `GameCenter.tsx` to block duplicate or premature play submissions while a save/animation/reset is active. (apps/web/src/components/league/GameCenter.tsx)
- Await the run animation (`animatePlay`) after `savePlayAndGame` completes and only release the in-flight guard after the animation finishes. (apps/web/src/components/league/GameCenter.tsx)
- Propagate a setup transition callback into the field component and wire a `disabled` prop into controls so play buttons are inert while saving or resetting. (apps/web/src/components/league/GameControls.tsx, GameCenter.tsx)
- Implement a field setup transition in `GameField.tsx` that updates LOS/first-down lines first and then animates players to their next starting locations (shorter phase durations), notifying the parent via `onSetupTransitionChange`. (apps/web/src/components/league/GameField.tsx)

### Testing
- Ran `npm run build` inside `apps/web` and the build completed successfully. 
- Ran `npm run lint` inside `apps/web` and ESLint completed with no errors.
- Attempted `npm run build` from the repo root which failed due to no root `package.json`, then re-ran the build from `apps/web` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d1a5fe2c08324938def3d060db6a1)