### PR TITLE
Sort DBs by coverage+readQB+speed+acceleration with defStars tiebreaker

### DIFF
--- a/apps/web/src/components/league/formationDefense.ts
+++ b/apps/web/src/components/league/formationDefense.ts
@@ -17,12 +17,21 @@ function teamOf(p: Player) {
 function trait(p: Player | undefined, key: string) {
   return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0);
 }
+function dbCoverageScore(p: Player) {
+  return (
+    trait(p, "coverage") +
+    trait(p, "readQB") +
+    trait(p, "speed") +
+    trait(p, "acceleration")
+  );
+}
 
 /**
  * Creates an eight-player defensive preview from the offense formation. It
  * picks the non-possessing team, ranks defenders by defensive stars inside each
- * position group, aligns coverage to receivers, aligns linemen to blockers, and
- * fills any remaining spots with linebackers/safeties.
+ * position group, ranks DBs by coverage, Read QB, speed, and acceleration
+ * with defensive stars as the tiebreaker, aligns coverage to receivers, aligns
+ * linemen to blockers, and fills any remaining spots with linebackers/safeties.
  */
 export function buildDefense(
   game: LeagueGame,
@@ -39,7 +48,18 @@ export function buildDefense(
           str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === d,
       )
       .sort((a, b) => trait(b, sortBy) - trait(a, sortBy));
-  const dbs = by("DB", "coverage"),
+  const byDbCoverage = () =>
+    defenders
+      .filter(
+        (p) =>
+          str(p.defPos ?? p.DefPos ?? p.defensePosition).toUpperCase() === "DB",
+      )
+      .sort(
+        (a, b) =>
+          dbCoverageScore(b) - dbCoverageScore(a) ||
+          trait(b, "defStars") - trait(a, "defStars"),
+      );
+  const dbs = byDbCoverage(),
     dls = by("DL", "size"),
     lbs = by("LB"),
     safeties = by("S");
@@ -83,7 +103,7 @@ export function buildDefense(
   };
   const byName = (playerName?: string) =>
     players.find((p) => nameOf(p) === playerName);
-  // Saved receivers and linemen are ranked by offensive stars so the best coverage DBs and biggest DLs match the best WRs/OLs.
+  // Saved receivers and linemen are ranked by offensive stars so the best DB coverage-score defenders and biggest DLs match the best WRs/OLs.
   const byOffStars = (a: FormationSlot, b: FormationSlot) =>
     trait(byName(formation[b]), "offStars") -
     trait(byName(formation[a]), "offStars");

--- a/apps/web/src/components/league/gameplay/engine/formationEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/formationEngine.ts
@@ -37,7 +37,20 @@ export function generateDefensiveFormation(
     defenders
       .filter((p) => str(p.defPos ?? p.DefPos).toUpperCase() === defPos)
       .sort((a, b) => trait(b, "defStars") - trait(a, "defStars"));
-  const dbs = group("DB"),
+  const dbCoverageScore = (p: PlayerTrait) =>
+    trait(p, "coverage") +
+    trait(p, "readQB") +
+    trait(p, "speed") +
+    trait(p, "acceleration");
+  const groupDbsByCoverage = () =>
+    defenders
+      .filter((p) => str(p.defPos ?? p.DefPos).toUpperCase() === "DB")
+      .sort(
+        (a, b) =>
+          dbCoverageScore(b) - dbCoverageScore(a) ||
+          trait(b, "defStars") - trait(a, "defStars"),
+      );
+  const dbs = groupDbsByCoverage(),
     dls = group("DL"),
     lbs = group("LB"),
     safeties = group("S");
@@ -74,7 +87,7 @@ export function generateDefensiveFormation(
     trait(byName(ctx, b.player), "offStars", 0) -
     trait(byName(ctx, a.player), "offStars", 0);
 
-  // Wide receivers create the first defensive obligations: the best available DBs travel to the highest-star receivers first.
+  // Wide receivers create the first defensive obligations: the best available DB coverage-score defenders travel to the highest-star receivers first.
   offense
     .filter((s) => s.position.startsWith("WR"))
     .sort(offenseByPlayerStars)


### PR DESCRIPTION
### Motivation
- Defensive back assignments should prioritize a combined coverage metric of coverage, Read QB, speed, and acceleration with defensive stars as a tiebreaker so the best DBs match top receivers both in the UI preview and gameplay resolution.

### Description
- Add a `dbCoverageScore` that sums `coverage`, `readQB`, `speed`, and `acceleration` in `apps/web/src/components/league/formationDefense.ts` and use it to order DBs with `defStars` as the tie-breaker.  
- Mirror the same coverage-score ordering in gameplay defensive formation generation by adding `dbCoverageScore` and `groupDbsByCoverage` in `apps/web/src/components/league/gameplay/engine/formationEngine.ts`.  
- Update comments to document that DBs are ranked by the new coverage score and that defensive stars break ties.  
- Keep existing fallback and selection logic unchanged so only DB ordering behavior is affected.

### Testing
- Ran the web build with `npm --prefix apps/web run build` and it completed successfully.  
- Ran the linter with `npm --prefix apps/web run lint` and it reported no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d1b7de9048324827df8d7dd087a8a)