### PR TITLE
Limit accel-to-LB modifier to initial burst

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -739,14 +739,14 @@ export function getAccelToLBYards(
   const acceleration = trait(runner, "acceleration"); // TRAIT USED: Acceleration
   const vision = trait(runner, "vision"); // TRAIT USED: Vision
   const accelerationMod = (acceleration / 10) ** 2 / 12;
-  //For only the very first acceltoLB should vision be considered, otherwise:
-  const recursiveAccelerationMod = (acceleration / 10) ** 2 / 9;
   const visionMod = (vision / 10) ** 2 / 12;
+  const isRestart = type === "restart";
 
-  let adjustedRoll = Math.min(100, baseRoll + accelerationMod + visionMod);
-  if (type == "restart") {
-    adjustedRoll = Math.min(100, baseRoll + recursiveAccelerationMod);
-  }
+  // Acceleration and vision bonuses only apply to the initial burst through the hole.
+  // Recursive restarts after LB/DL interactions use the unmodified bucket roll.
+  const adjustedRoll = isRestart
+    ? baseRoll
+    : Math.min(100, baseRoll + accelerationMod + visionMod);
 
   let cumulative = 0;
   const accelToLBSettings = settingArray<RunAccelToLBSetting>(
@@ -775,7 +775,7 @@ export function getAccelToLBYards(
     if (adjustedRoll <= cumulative) {
       const yards = yardsForRange(range);
       modLog?.push(
-        `Yard +${yards} Accel to LB (${range.label}, roll ${adjustedRoll.toFixed(2)} = ${baseRoll.toFixed(2)}${type === "restart" ? ` + ${recursiveAccelerationMod.toFixed(2)} Accel` : ` + ${accelerationMod.toFixed(2)} Accel + ${visionMod.toFixed(2)} Vision`})`,
+        `Yard +${yards} Accel to LB (${range.label}, roll ${adjustedRoll.toFixed(2)} = ${baseRoll.toFixed(2)}${isRestart ? " unmodified restart" : ` + ${accelerationMod.toFixed(2)} Accel + ${visionMod.toFixed(2)} Vision`})`,
       );
       return yards;
     }


### PR DESCRIPTION
### Motivation
- Prevent acceleration and vision bonuses from being applied on recursive second-level restarts so subsequent recursions do not get an unfair accel boost. 
- Ensure the accel-to-LB roll only benefits from runner traits on the initial burst through the hole, matching intended game mechanics.

### Description
- Modified `getAccelToLBYards` in `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` to introduce an `isRestart` check and compute `adjustedRoll` without acceleration/vision when `type === "restart"`.
- Removed the prior recursive acceleration modifier path and replaced it with an unmodified base roll for restarts.
- Updated the run log message to explicitly label restart rolls as an "unmodified restart" instead of printing acceleration modifiers.

### Testing
- Ran `npm run build` in `apps/web` which completed successfully.
- Ran `npm run lint` in `apps/web` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61307946208324bde3a6dbee6990aa)