### PR TITLE
Make game field branding home-team dynamic

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { LeagueGame, GameTab } from "./types";
+import type { LeagueGame, GameTab, LeagueTeam } from "./types";
 import "./GameCenter.css";
 import {
   formatBallOnForPoss,
@@ -11,6 +11,7 @@ import {
 import {
   getFrontendSettings,
   getGameState,
+  getTeams,
   getPlayerTraits,
   getPlayHistory,
   savePlayAndGame,
@@ -38,6 +39,8 @@ import type {
 } from "./gameplay/gameEngine";
 
 const EXPECTED_PLAYERS_PER_SIDE = 8;
+const teamValue = (team: LeagueTeam | undefined, key: string) =>
+  String(team?.[key] ?? "").trim();
 
 type Play = Record<string, unknown>;
 type LineStatMatchup = {
@@ -1373,6 +1376,7 @@ export function GameCenter({
   const [currentGame, setCurrentGame] = useState(game);
   const [history, setHistory] = useState<Play[]>([]);
   const [players, setPlayers] = useState<Play[]>([]);
+  const [teams, setTeams] = useState<LeagueTeam[]>([]);
   const [settings, setSettings] = useState<FrontendSettings>(
     normalizeFrontendSettings({}),
   );
@@ -1398,6 +1402,14 @@ export function GameCenter({
     () => ({ players, settings, historyLength: history.length }),
     [players, settings, history.length],
   );
+  const homeTeamDetails = useMemo(() => {
+    const homeAbbrev = String(currentGame.Home || "")
+      .trim()
+      .toLowerCase();
+    return teams.find(
+      (team) => teamValue(team, "Abbrev").toLowerCase() === homeAbbrev,
+    );
+  }, [currentGame.Home, teams]);
   useEffect(() => {
     let active = true;
     Promise.all([
@@ -1405,12 +1417,14 @@ export function GameCenter({
       getPlayHistory(game.GameId),
       getPlayerTraits(),
       getFrontendSettings(),
+      getTeams(),
     ])
-      .then(([stateRes, historyRes, playerRes, settingsRes]) => {
+      .then(([stateRes, historyRes, playerRes, settingsRes, teamsRes]) => {
         if (!active) return;
         setCurrentGame(normalizeGame(game, stateRes.gameState));
         setHistory(historyRes.plays);
         setPlayers(playerRes.players);
+        setTeams(teamsRes.teams as LeagueTeam[]);
         setSettings(normalizeFrontendSettings(settingsRes));
         setLog(
           historyRes.plays.length
@@ -1637,8 +1651,20 @@ export function GameCenter({
                 distance={currentGame.Distance}
                 possession={currentGame.Possession}
                 selectedFormationPlayer={selectedFormationPlayer}
-                homeLogo={currentGame.HomeLogo}
+                homeLogo={
+                  teamValue(homeTeamDetails, "Logo") || currentGame.HomeLogo
+                }
                 homeTeam={currentGame.Home}
+                homeTeamName={
+                  teamValue(homeTeamDetails, "Name") || currentGame.Home
+                }
+                homeTeamLocation={
+                  teamValue(homeTeamDetails, "Location") || currentGame.Home
+                }
+                homeTeamPrimaryColor={teamValue(
+                  homeTeamDetails,
+                  "Primary Color",
+                )}
                 awayTeam={currentGame.Away}
                 onFormationSlotClick={(slot) => {
                   const currentFormation = playOptions.formation ?? {};

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -338,6 +338,9 @@ export default function GameField({
   possession = "Home",
   homeLogo,
   homeTeam,
+  homeTeamName,
+  homeTeamLocation,
+  homeTeamPrimaryColor,
   awayTeam,
   onSetupTransitionChange,
 }: {
@@ -354,6 +357,9 @@ export default function GameField({
   possession?: string;
   homeLogo?: string;
   homeTeam?: string;
+  homeTeamName?: string;
+  homeTeamLocation?: string;
+  homeTeamPrimaryColor?: string;
   awayTeam?: string;
   onSetupTransitionChange?: (active: boolean) => void;
 }) {
@@ -374,6 +380,12 @@ export default function GameField({
   const isSetupTransitionRef = useRef(false);
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
+  const teamEndStyle = homeTeamPrimaryColor
+    ? { background: homeTeamPrimaryColor }
+    : undefined;
+  const teamEndTopText = homeTeamName || homeTeam || "HOME";
+  const teamEndBottomText = homeTeamLocation || homeTeam || "HOME";
+
   const [selectedPlayerMenu, setSelectedPlayerMenu] = useState<{
     player: AnimationPlayer;
     leftPct: number;
@@ -823,7 +835,8 @@ export default function GameField({
           lane,
           x: lane ? (LANES[lane] ?? target.x) : target.x,
           yard:
-            losYard + offenseDirection * (player.assignment.cushionYards ?? 1.9),
+            losYard +
+            offenseDirection * (player.assignment.cushionYards ?? 1.9),
         };
       });
       plan.players.forEach((rawPlayer) => {
@@ -1058,7 +1071,9 @@ export default function GameField({
       return;
     }
 
-    const currentLos = currentPlan.lines.find((line) => line.id === "los")?.yard;
+    const currentLos = currentPlan.lines.find(
+      (line) => line.id === "los",
+    )?.yard;
     const nextLos = nextPlan.lines.find((line) => line.id === "los")?.yard;
     const currentFirstDown = currentPlan.lines.find(
       (line) => line.id === "firstDown",
@@ -1162,11 +1177,19 @@ export default function GameField({
           onClick={() => setSelectedPlayerMenu(null)}
         >
           <div className="field-title">Dynamic Football Animation View</div>
-          <div className="team-end team-end--top" id="awayEnd">
-            KINGSMEN
+          <div
+            className="team-end team-end--top"
+            id="awayEnd"
+            style={teamEndStyle}
+          >
+            {teamEndTopText}
           </div>
-          <div className="team-end team-end--bottom" id="homeEnd">
-            CHARLOTTE
+          <div
+            className="team-end team-end--bottom"
+            id="homeEnd"
+            style={teamEndStyle}
+          >
+            {teamEndBottomText}
           </div>
           {homeLogo && (
             <img


### PR DESCRIPTION
### Motivation
- Surface team-specific branding (name, location, logo, primary color) from the `Teams` sheet so the field UI reflects the home team for each game.

### Description
- Load the `Teams` sheet via `getTeams()` in `GameCenter` and add a `teamValue` helper and `teams` state to resolve the active game's home-team record by `Abbrev`.
- Compute `homeTeamDetails` in `GameCenter` and pass `homeTeamName`, `homeTeamLocation`, `homeTeamPrimaryColor`, and the sheet-driven `Logo` into `GameField`, falling back to existing `currentGame` values when fields are missing.
- Update `GameField` to accept the new props and use `homeTeamPrimaryColor` to build an inline `teamEndStyle` that overrides the `.team-end` background, and render `teamEndTopText` and `teamEndBottomText` for the two endzones.
- Keep the midfield logo dynamic by rendering the passed `homeLogo` (sheet `Logo` or fallback) in the existing `field-midfield-logo` element.

### Testing
- `npm run build` completed successfully and produced a production build of the web app.
- `npm run lint` completed successfully with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62b3de6fec83249ce70620e396c6dc)