### PR TITLE
Replace open controls tab with left-side radial Coach / Call Play menus

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -174,7 +174,7 @@ export function GameControls({
   requestedFormationMode,
   disabled = false,
 }: Props) {
-  const [collapsed, setCollapsed] = useState(true);
+  const [activeMenu, setActiveMenu] = useState<"coach" | "play" | null>(null);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
   const [settingFormation, setSettingFormation] = useState(false);
   const [selected, setSelected] = useState<string>("");
@@ -206,6 +206,17 @@ export function GameControls({
     [...REQUIRED].every((slot) => formation[slot]);
   const canPass = receivers.some(
     (r) => routes[r.player] && routes[r.player] !== "No Route",
+  );
+  const pendingPointAfter = Boolean(
+    (game as unknown as Record<string, unknown>).pendingFGTeam,
+  );
+  const canPunt = Number(game.Down) === 4;
+  const canKickoff =
+    !pendingPointAfter && Number(game.Down) === 1 && Number(game.Distance) === 10;
+  const currentTimeouts = Number(
+    (game as unknown as Record<string, unknown>)[
+      game.Possession === "Home" ? "HomeTimeouts" : "AwayTimeouts"
+    ] ?? 3,
   );
   const setOpt = (patch: Partial<PlayCallOptions>) => {
     const nextOptions = { ...options, ...patch };
@@ -271,55 +282,147 @@ export function GameControls({
   };
 
   return (
-    <div
-      className={`control-panel play-caller ${collapsed ? "collapsed" : ""}`}
-    >
-      <button
-        className="control-panel-toggle"
-        type="button"
-        onClick={() => setCollapsed(!collapsed)}
+    <div className="control-panel play-caller radial-play-caller">
+      <div
+        className="radial-control-dock"
+        aria-label={`${offenseTeam} controls`}
       >
-        {collapsed ? "Open Controls" : "Minimize Controls"}
-      </button>
-      {!collapsed && (
-        <>
-          <h3>{offenseTeam} Control Console</h3>
-          <div className="play-call-summary">
-            <span>
-              {validFormation
-                ? "Formation ready"
-                : `Set ${EXPECTED_PLAYERS_PER_SIDE}-player formation`}
+        <div className="radial-control-group">
+          <button
+            className={`radial-control-button ${activeMenu === "coach" ? "active" : ""}`}
+            type="button"
+            aria-expanded={activeMenu === "coach"}
+            onClick={() =>
+              setActiveMenu(activeMenu === "coach" ? null : "coach")
+            }
+          >
+            <span className="radial-control-icon" aria-hidden="true">
+              👤
             </span>
-            <span>
-              Players: {formationPlayerCount}/{EXPECTED_PLAYERS_PER_SIDE}
+            <span className="radial-control-label">Coach</span>
+          </button>
+          {activeMenu === "coach" && (
+            <div className="radial-flyout coach-flyout">
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => setFormationMode(!activeFormationMode)}
+              >
+                Personnel
+              </button>
+              <button type="button" onClick={() => setModal("clock")}>
+                Clock Management
+              </button>
+              <button
+                type="button"
+                disabled={disabled || currentTimeouts <= 0}
+                onClick={() => onAction("Timeout", optionsWithDefense())}
+              >
+                Call Timeout
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="radial-control-group">
+          <button
+            className={`radial-control-button ${activeMenu === "play" ? "active" : ""}`}
+            type="button"
+            aria-expanded={activeMenu === "play"}
+            onClick={() =>
+              setActiveMenu(activeMenu === "play" ? null : "play")
+            }
+          >
+            <span className="radial-control-icon" aria-hidden="true">
+              ✕○
             </span>
-            <span>Runner: {options.runner || "Auto"}</span>
-            <span>Clock: {options.clockMode || "Normal"}</span>
-          </div>
-          <div className="game-controls primary">
-            <button disabled={disabled} onClick={() => setFormationMode(!activeFormationMode)}>
-              {activeFormationMode ? "Hide Bench" : "Set Formation"}
-            </button>
-            <button
-              disabled={disabled || !validFormation || runners.length === 0}
-              onClick={() => setModal("run")}
-            >
-              Call Run Play
-            </button>
-            <button
-              disabled={disabled || !validFormation}
-              onClick={() => {
-                if (!canPass) setModal("routes");
-                else onAction("Pass Play", optionsWithDefense());
-              }}
-            >
-              Call Pass Play
-            </button>
-            <button disabled={disabled} onClick={() => onAction("Punt", optionsWithDefense())}>
-              Call Punt Play
-            </button>
-          </div>
-        </>
+            <span className="radial-control-label">Call Play</span>
+          </button>
+          {activeMenu === "play" && (
+            <div className="radial-flyout play-flyout">
+              <button
+                disabled={disabled || !validFormation || runners.length === 0}
+                onClick={() => setModal("run")}
+                type="button"
+              >
+                Run
+              </button>
+              <button
+                disabled={disabled || !validFormation}
+                onClick={() => {
+                  if (!canPass) setModal("routes");
+                  else onAction("Pass Play", optionsWithDefense());
+                }}
+                type="button"
+              >
+                Pass
+              </button>
+              <button
+                disabled={disabled}
+                onClick={() => onAction("Field Goal", optionsWithDefense())}
+                type="button"
+              >
+                Field Goal
+              </button>
+              {canPunt && (
+                <button
+                  disabled={disabled}
+                  onClick={() => onAction("Punt", optionsWithDefense())}
+                  type="button"
+                >
+                  Punt
+                </button>
+              )}
+              {canKickoff && (
+                <>
+                  <button
+                    disabled={disabled}
+                    onClick={() => onAction("Kickoff", optionsWithDefense())}
+                    type="button"
+                  >
+                    Kickoff
+                  </button>
+                  <button
+                    disabled={disabled}
+                    onClick={() => onAction("Onside", optionsWithDefense())}
+                    type="button"
+                  >
+                    Onside
+                  </button>
+                </>
+              )}
+              {pendingPointAfter && (
+                <>
+                  <button
+                    disabled={disabled}
+                    onClick={() => onAction("Field Goal", optionsWithDefense())}
+                    type="button"
+                  >
+                    XP
+                  </button>
+                  <button
+                    disabled={disabled}
+                    onClick={() => onAction("Two Point", optionsWithDefense())}
+                    type="button"
+                  >
+                    2-Pt
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      {activeMenu && (
+        <div className="radial-status-card">
+          <strong>{offenseTeam}</strong>
+          <span>
+            {validFormation
+              ? "Formation ready"
+              : `${formationPlayerCount}/${EXPECTED_PLAYERS_PER_SIDE} players set`}
+          </span>
+          <span>Runner: {options.runner || "Auto"}</span>
+          <span>Clock: {options.clockMode || "Normal"}</span>
+        </div>
       )}
       {activeFormationMode && (
         <div className="field-formation-bench" aria-label="Offensive bench">

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1812,3 +1812,128 @@
 @media (max-width: 900px) {
   .bench-ten-wide { grid-template-columns: repeat(5, minmax(0, 1fr)); }
 }
+
+.field-console-stage .radial-play-caller {
+  left: 12px;
+  right: auto;
+  top: 330px;
+  width: auto;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  transform: translateY(-50%);
+  backdrop-filter: none;
+}
+
+.radial-control-dock {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.radial-control-group {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.radial-control-button {
+  width: 74px;
+  height: 74px;
+  border: 3px solid rgba(248, 250, 252, 0.92);
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.48);
+  display: grid;
+  place-items: center;
+  gap: 0;
+  cursor: pointer;
+  font-weight: 900;
+}
+
+.radial-control-button.active,
+.radial-control-button:hover {
+  border-color: var(--accent-red);
+  background: #0f172a;
+}
+
+.radial-control-icon {
+  font-size: 26px;
+  line-height: 1;
+}
+
+.radial-control-label {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.radial-flyout {
+  position: absolute;
+  left: 86px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 310;
+  display: grid;
+  gap: 8px;
+  min-width: 176px;
+  padding: 10px;
+  border: 1px solid rgba(248, 250, 252, 0.24);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.52);
+}
+
+.radial-flyout button {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: var(--accent-red);
+  color: white;
+  font-weight: 900;
+  text-align: left;
+  cursor: pointer;
+}
+
+.radial-flyout button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.play-flyout {
+  grid-template-columns: repeat(2, minmax(104px, 1fr));
+  min-width: 260px;
+}
+
+.radial-status-card {
+  position: absolute;
+  left: 86px;
+  top: calc(100% + 12px);
+  display: grid;
+  gap: 3px;
+  min-width: 190px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.86);
+  color: #e2e8f0;
+  font-size: 12px;
+}
+
+@media (max-width: 720px) {
+  .field-console-stage .radial-play-caller {
+    top: 50%;
+  }
+
+  .radial-control-button {
+    width: 60px;
+    height: 60px;
+  }
+
+  .radial-flyout,
+  .radial-status-card {
+    left: 70px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the single collapsed "Open Controls" panel with a compact, field-anchored control dock to make play- and personnel-actions faster to access. 

### Description
- Replaced the collapsed controls panel UI with a left-side radial dock implemented in `apps/web/src/components/league/GameControls.tsx` using a new `activeMenu` state and two circular buttons: `Coach` and `Call Play`.
- Implemented the `Coach` flyout with `Personnel` (toggles the existing formation editor), `Clock Management` (opens the existing clock modal), and `Call Timeout` (uses current timeout count), and wired these to existing handlers.
- Implemented the `Call Play` flyout with Run, Pass, Field Goal, and conditional items for `Punt`, `Kickoff`/`Onside`, and point-after options (`XP` / `2-Pt`) using new availability checks (`pendingFGTeam`, `game.Down`, `game.Distance`, timeout counts).
- Added styling for the dock, circular icon buttons, pop-out flyouts, and a small status card in `apps/web/src/components/league/league.css` and left-positioned the dock so menus are glued to the left side of the field.

### Testing
- Ran `npm --prefix apps/web run build` and the production build completed successfully.
- Ran `npm --prefix apps/web run lint` and ESLint returned no errors.
- Verified the app compiles and the new UI renders (development server started) during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62b6d821748324b5b4b40248101ab8)