### PR TITLE
Move control-panel into field viewport; hide coach flyout on Personnel and ensure field auto-scroll

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1730,23 +1730,24 @@ export function GameCenter({
                   setSettingFormation(true);
                 }}
                 onSetupTransitionChange={setIsResettingPlay}
-              />
+              >
+                <GameControls
+                  game={currentGame}
+                  players={players}
+                  options={playOptions}
+                  onOptionsChange={setPlayOptions}
+                  onAction={action}
+                  onFormationModeChange={(active) => {
+                    setAutoCloseFormationOnSave(false);
+                    setSettingFormation(active);
+                  }}
+                  onSelectedFormationPlayerChange={setSelectedFormationPlayer}
+                  selectedFormationPlayer={selectedFormationPlayer}
+                  requestedFormationMode={settingFormation}
+                  disabled={isSavingPlay || isResettingPlay}
+                />
+              </GameField>
             </div>
-            <GameControls
-              game={currentGame}
-              players={players}
-              options={playOptions}
-              onOptionsChange={setPlayOptions}
-              onAction={action}
-              onFormationModeChange={(active) => {
-                setAutoCloseFormationOnSave(false);
-                setSettingFormation(active);
-              }}
-              onSelectedFormationPlayerChange={setSelectedFormationPlayer}
-              selectedFormationPlayer={selectedFormationPlayer}
-              requestedFormationMode={settingFormation}
-              disabled={isSavingPlay || isResettingPlay}
-            />
           </div>
           {lastPlay && (
             <div className="last-play-desc">

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -278,6 +278,7 @@ export function GameControls({
     // Saving closes the bench but keeps `options.formation` plus the generated defensive mirror available for the next play call.
     onOptionsChange(optionsWithDefense());
     setFormationMode(false);
+    setActiveMenu("coach");
     setSelected("");
   };
 
@@ -306,7 +307,10 @@ export function GameControls({
               <button
                 type="button"
                 disabled={disabled}
-                onClick={() => setFormationMode(!activeFormationMode)}
+                onClick={() => {
+                  setActiveMenu(null);
+                  setFormationMode(!activeFormationMode);
+                }}
               >
                 Personnel
               </button>
@@ -507,6 +511,7 @@ export function GameControls({
               type="button"
               onClick={() => {
                 setFormationMode(false);
+                setActiveMenu("coach");
                 setSelected("");
               }}
             >

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -44,6 +44,7 @@ body {
 }
 
 .field-viewport {
+  position: relative;
   width: 100%;
   height: 680px;
   overflow-y: auto;

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { DefensiveAssignment, FormationSlot } from "./gameplay/gameEngine";
 
 import "./GameField.css";
@@ -343,6 +343,7 @@ export default function GameField({
   homeTeamPrimaryColor,
   awayTeam,
   onSetupTransitionChange,
+  children,
 }: {
   formationMode?: boolean;
   formation?: Partial<Record<FormationSlot, string>>;
@@ -362,6 +363,7 @@ export default function GameField({
   homeTeamPrimaryColor?: string;
   awayTeam?: string;
   onSetupTransitionChange?: (active: boolean) => void;
+  children?: ReactNode;
 }) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<HTMLDivElement>(null);
@@ -1170,6 +1172,7 @@ export default function GameField({
   return (
     <div className="game-shell">
       <div className="field-viewport" id="fieldViewport" ref={fieldViewportRef}>
+        {children && <div className="field-controls-overlay">{children}</div>}
         <div
           className="field-wrap"
           id="field"

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1936,3 +1936,29 @@
     left: 70px;
   }
 }
+
+.field-controls-overlay {
+  position: sticky;
+  top: 50%;
+  left: 0;
+  z-index: 300;
+  height: 0;
+  width: 0;
+  overflow: visible;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.field-controls-overlay .control-panel {
+  pointer-events: auto;
+}
+
+.field-controls-overlay .play-caller,
+.field-console-stage .field-controls-overlay .play-caller,
+.field-console-stage .field-controls-overlay .radial-play-caller {
+  position: relative;
+  top: auto;
+  left: 0;
+  right: auto;
+  transform: none;
+}


### PR DESCRIPTION
### Motivation
- The control panel needs to live inside the field viewport so it scrolls with the field and can overlay the current yardline/formation. 
- The coach submenu (Personnel / Clock Management / Call Timeout) should hide immediately when the user enters Personnel and reappear when exiting or saving the formation. 
- Opening Personnel should scroll the field view to the current yardline/formation so users see the relevant part of the field.

### Description
- Added a `children` prop to `GameField` and render a `field-controls-overlay` inside the `field-viewport` so injected controls live inside the scrollable viewport (`apps/web/src/components/league/GameField.tsx`).
- Moved `GameControls` to be passed as children of `GameField` so the `control-panel` (radial play-caller) is visually contained within the `field-viewport` (`apps/web/src/components/league/GameCenter.tsx`).
- Introduced CSS rules for `.field-controls-overlay` and adjusted `.field-viewport` positioning to make the radial controls sticky/overlayed while preserving field scrolling (`apps/web/src/components/league/league.css`, `apps/web/src/components/league/GameField.css`).
- Updated `GameControls` behavior so the coach flyout is dismissed when entering Personnel (`setActiveMenu(null)`), and restored on Exit/Save via `setActiveMenu("coach")`, so the sub-coach list hides while editing a formation (`apps/web/src/components/league/GameControls.tsx`).
- Leveraged existing `GameField` scrolling logic that centers the view on the football/formation when a formation plan is built so opening Personnel focuses the field on the current yardline/formation.

### Testing
- Ran `npm --prefix apps/web run build` and the build completed successfully.
- Started the dev server with `npm --prefix apps/web run dev` and it launched successfully (no automated browser checks were executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62c25fda308324b91089dcc7f477e2)