### PR TITLE
Fix transparent field controls blocking player interactions

### DIFF
--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1950,7 +1950,19 @@
   transform: translateY(-50%);
 }
 
-.field-controls-overlay .control-panel {
+.field-controls-overlay .control-panel,
+.field-controls-overlay .radial-control-dock,
+.field-controls-overlay .radial-control-group {
+  /* These layout wrappers are much wider than the visible controls. Let field
+     interactions pass through their transparent area instead of treating the
+     entire control panel as a click-blocking layer. */
+  pointer-events: none;
+}
+
+.field-controls-overlay .radial-control-button,
+.field-controls-overlay .radial-flyout,
+.field-controls-overlay .radial-status-card,
+.field-controls-overlay .field-formation-bench {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
### Motivation

- The transparent control overlay and its layout wrappers were intercepting pointer events across a wide area, preventing clicks and drags on the underlying field (so players could not be placed or selected).

### Description

- Update `apps/web/src/components/league/league.css` to stop treating the entire overlay wrapper as interactive by adding `.field-controls-overlay .control-panel`, `.field-controls-overlay .radial-control-dock`, and `.field-controls-overlay .radial-control-group` with `pointer-events: none` and an explanatory comment.
- Restore pointer interactions on visible controls by enabling `pointer-events: auto` for `.field-controls-overlay .radial-control-button`, `.field-controls-overlay .radial-flyout`, `.field-controls-overlay .radial-status-card`, and `.field-controls-overlay .field-formation-bench` so buttons and flyouts remain usable.
- Keep existing layout and positioning for the play-caller and radial caller components so visual behavior is unchanged while clicks pass through transparent areas.

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and ESLint completed without errors.
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64d92ece248324bf58df7f2cb42e87)