### PR TITLE
Update defensive line swipe selection

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -336,7 +336,7 @@ export function runPlay(
   }
   // Frontside branch: the runner found the intended lane and may face a swipe attempt.
   else {
-    // If the selected lane came from an OL win, the beaten DL can still make a last swipe at the runner's legs.
+    // If the selected lane came from an OL win, an adjacent DL who beat his blocker may swipe at the runner's legs.
     dlSwipeResult =
       runLaneTarget.selectedSide === "OL"
         ? performDlSwipeCheck(lineWinLossArray, runLaneTarget, ctx.players)

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -487,23 +487,53 @@ export type DlSwipeResult = {
   tackled: boolean;
 };
 
-/** Gives a beaten defensive lineman a chance to swipe the runner at the line. `runPlay` uses it on clean frontside lanes before the runner accelerates to linebackers. */
+/** Gives an adjacent defensive lineman who won his matchup a chance to swipe the runner at the line. `runPlay` uses it on clean frontside lanes before the runner accelerates to linebackers. */
 export function performDlSwipeCheck(
   lineWinLossArray: LineWinLossResult[],
   runLaneTarget: RunLaneTargetResult,
   players: PlayerTrait[],
-): DlSwipeResult {
-  const matchup = lineWinLossArray.find(
-    (battle) => battle.slot === runLaneTarget.selectedSlot,
+): DlSwipeResult | null {
+  const laneIndex = OL_SLOTS.indexOf(runLaneTarget.selectedSlot);
+  if (laneIndex === -1) return null;
+
+  const adjacentSlots = new Set(
+    [OL_SLOTS[laneIndex - 1], OL_SLOTS[laneIndex + 1]].filter(
+      (slot): slot is FormationSlot => slot !== undefined,
+    ),
   );
 
-  if (!matchup) {
-    throw new Error(
-      `No OL/DL matchup found for slot ${runLaneTarget.selectedSlot}.`,
+  const candidates = lineWinLossArray
+    .filter(
+      (battle) =>
+        adjacentSlots.has(battle.slot) &&
+        battle.winner === "DL" &&
+        Boolean(battle.defensePlayer),
+    )
+    .map((matchup) => ({
+      matchup,
+      defensivePlayer: findPlayerByName(players, matchup.defensePlayer),
+    }));
+
+  if (candidates.length === 0) return null;
+
+  let selectedCandidate = candidates[0];
+  if (candidates.length > 1) {
+    const totalTackling = candidates.reduce(
+      (sum, candidate) =>
+        sum + trait(candidate.defensivePlayer, "tackling"),
+      0,
     );
+    const selectionRoll = Math.random() * totalTackling;
+    let cumulativeTackling = 0;
+
+    selectedCandidate =
+      candidates.find((candidate) => {
+        cumulativeTackling += trait(candidate.defensivePlayer, "tackling");
+        return selectionRoll <= cumulativeTackling;
+      }) ?? candidates[candidates.length - 1];
   }
 
-  const defensivePlayer = findPlayerByName(players, matchup.defensePlayer);
+  const { matchup, defensivePlayer } = selectedCandidate;
 
   const dlTackling = trait(defensivePlayer, "tackling"); // TRAIT USED: Tackling
 


### PR DESCRIPTION
### Motivation
- Adjust swipe-tackle resolution so that adjacent defensive linemen (not the blocked DL) get the opportunity to swipe when the run lane is created by an OL win.
- Only allow swipe attempts from DLs that actually won their adjacent OL/DL matchup and choose between two eligible DLs in a tackling-weighted manner.

### Description
- Changed `performDlSwipeCheck` to return `DlSwipeResult | null` and added a lane-index lookup to identify adjacent OL slots using `OL_SLOTS`.
- Limited swipe candidates to adjacent slots whose `LineWinLossResult` winner is `"DL"` and who have a valid `defensePlayer`, building a `candidates` list from `lineWinLossArray` and `players`.
- When two candidates exist, select the swiping DL by a tackling-weighted random roll using the sum of `tackling` trait values, while a single eligible candidate attempts automatically; retained the original `swipeScore` calculation and success roll.
- Updated the frontside run branch comment in `runEngine.ts` to reflect that an adjacent winning DL now attempts the swipe instead of the beaten defender in the chosen lane.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which completed successfully.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64dc49adcc832488b5e0f48188330d)