### PR TITLE
Add sortable roster details to coaching controls

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -14,6 +14,11 @@ const REQUIRED = new Set<FormationSlot>(["QB", "LG", "C", "RG"]);
 const EXPECTED_PLAYERS_PER_SIDE = 8;
 const ROUTES = ["No Route", "Screen", "Short", "Medium", "Deep", "Bomb"];
 const READS = ["1st", "2nd", "3rd", "4th", "5th"];
+const PLAYER_IDENTITY_FIELDS = new Set([
+  "team", "name", "position", "pos", "defpos", "image", "photo",
+  "player image from ai", "translatex", "translatey", "scale", "jersey",
+  "jersey image",
+]);
 
 type Player = Record<string, unknown>;
 type Props = {
@@ -48,6 +53,118 @@ function imgOf(p?: Player) {
 }
 function trait(p: Player | undefined, key: string) {
   return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0);
+}
+
+function playerFieldLabel(key: string) {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\bqb\b/gi, "QB")
+    .replace(/\bdef\b/gi, "Def")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function RosterDetails({ roster }: { roster: Player[] }) {
+  const traitColumns = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          roster.flatMap((player) =>
+            Object.keys(player).filter(
+              (key) => !PLAYER_IDENTITY_FIELDS.has(key.toLowerCase()),
+            ),
+          ),
+        ),
+      ),
+    [roster],
+  );
+  const columns = ["Position", "Image", "Name", ...traitColumns];
+  const [sort, setSort] = useState<{ key: string; direction: "asc" | "desc" }>({
+    key: "Position",
+    direction: "asc",
+  });
+  const valueFor = (player: Player, key: string): unknown => {
+    if (key === "Position")
+      return [posOf(player), str(player.defPos ?? player.DefPos)]
+        .filter(Boolean)
+        .join(" / ");
+    if (key === "Name") return nameOf(player);
+    return player[key];
+  };
+  const sortedRoster = useMemo(
+    () =>
+      [...roster].sort((a, b) => {
+        const aValue = valueFor(a, sort.key);
+        const bValue = valueFor(b, sort.key);
+        const aNumber = Number(aValue);
+        const bNumber = Number(bValue);
+        const result =
+          aValue !== "" && bValue !== "" && Number.isFinite(aNumber) && Number.isFinite(bNumber)
+            ? aNumber - bNumber
+            : str(aValue).localeCompare(str(bValue), undefined, {
+                numeric: true,
+                sensitivity: "base",
+              });
+        return sort.direction === "asc" ? result : -result;
+      }),
+    [roster, sort],
+  );
+  const changeSort = (key: string) =>
+    setSort((current) => ({
+      key,
+      direction:
+        current.key === key && current.direction === "asc" ? "desc" : "asc",
+    }));
+
+  return (
+    <>
+      <div className="roster-details-heading">
+        <div>
+          <h3>Roster Details</h3>
+          <p>{roster.length} players · Select any column to sort</p>
+        </div>
+      </div>
+      <div className="roster-table-wrap">
+        <table className="roster-details-table">
+          <thead>
+            <tr>
+              {columns.map((column) => (
+                <th key={column} scope="col">
+                  {column === "Image" ? (
+                    "Image"
+                  ) : (
+                    <button type="button" onClick={() => changeSort(column)}>
+                      {playerFieldLabel(column)}
+                      <span aria-hidden="true">
+                        {sort.key === column
+                          ? sort.direction === "asc" ? " ▲" : " ▼"
+                          : " ↕"}
+                      </span>
+                    </button>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRoster.map((player, index) => (
+              <tr key={`${nameOf(player)}-${index}`}>
+                <td className="roster-position">{valueFor(player, "Position") as string}</td>
+                <td>
+                  <div className="roster-player-image">
+                    {imgOf(player) ? <img src={imgOf(player)} alt="" /> : <span>👤</span>}
+                  </div>
+                </td>
+                <th scope="row">{nameOf(player)}</th>
+                {traitColumns.map((column) => (
+                  <td key={column}>{str(valueFor(player, column)) || "—"}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
 }
 /**
  * Reusable modal shell for routes, run selection, and clock management. It
@@ -175,7 +292,7 @@ export function GameControls({
   disabled = false,
 }: Props) {
   const [activeMenu, setActiveMenu] = useState<"coach" | "play" | null>(null);
-  const [modal, setModal] = useState<"routes" | "run" | "clock" | null>(null);
+  const [modal, setModal] = useState<"routes" | "run" | "clock" | "roster" | null>(null);
   const [settingFormation, setSettingFormation] = useState(false);
   const [selected, setSelected] = useState<string>("");
   const [detail, setDetail] = useState<string>("");
@@ -316,6 +433,9 @@ export function GameControls({
               </button>
               <button type="button" onClick={() => setModal("clock")}>
                 Clock Management
+              </button>
+              <button type="button" onClick={() => setModal("roster")}>
+                Roster Details
               </button>
               <button
                 type="button"
@@ -631,6 +751,11 @@ export function GameControls({
             </button>
             <button onClick={() => setModal(null)}>Save</button>
           </div>
+        </ControlModal>
+      )}
+      {modal === "roster" && (
+        <ControlModal full onClose={() => setModal(null)}>
+          <RosterDetails roster={roster} />
         </ControlModal>
       )}
       {modal === "run" && (

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1219,6 +1219,82 @@
   background: var(--gray-medium);
   box-shadow: 0 20px 60px #000a;
 }
+.roster-details-heading h3 {
+  margin: 0;
+  font-size: clamp(24px, 3vw, 36px);
+}
+.roster-details-heading p {
+  margin: 6px 0 18px;
+  color: var(--text-muted);
+}
+.roster-table-wrap {
+  max-height: calc(92vh - 150px);
+  overflow: auto;
+  border: 1px solid #ffffff1f;
+  border-radius: 12px;
+}
+.roster-details-table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13px;
+}
+.roster-details-table th,
+.roster-details-table td {
+  padding: 10px 12px;
+  border-right: 1px solid #ffffff12;
+  border-bottom: 1px solid #ffffff12;
+  text-align: center;
+  white-space: nowrap;
+}
+.roster-details-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #111827;
+  color: #f8fafc;
+}
+.roster-details-table thead button {
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  font: inherit;
+  font-weight: 800;
+}
+.roster-details-table thead button:hover {
+  color: #fca5a5;
+}
+.roster-details-table tbody tr:nth-child(even) {
+  background: #ffffff08;
+}
+.roster-details-table tbody tr:hover {
+  background: #c102061c;
+}
+.roster-details-table tbody th {
+  text-align: left;
+  font-size: 14px;
+}
+.roster-details-table .roster-position {
+  color: #fca5a5;
+  font-weight: 900;
+}
+.roster-player-image {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #ffffff2e;
+  border-radius: 50%;
+  background: #0f172a;
+  font-size: 22px;
+}
+.roster-player-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
 .formation-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));


### PR DESCRIPTION
### Motivation
- Provide coaches a quick way to inspect the full team roster and player traits in-game to support roster move and personnel decisions.
- Surface all available trait fields from the player data API in a single sortable view so staff can compare players across many attributes.

### Description
- Added a `RosterDetails` React component to `apps/web/src/components/league/GameControls.tsx` that builds a table of roster players, auto-detects trait columns (excluding identity fields), and supports numeric-aware ascending/descending sorting per column.
- Exposed the new view from the in-game Coach radial menu by adding a `Roster Details` button which opens the roster in a modal (`ControlModal`) via the new `modal === "roster"` state.
- Implemented `playerFieldLabel` for nicer column headers and `PLAYER_IDENTITY_FIELDS` to filter identity fields out of trait columns when composing the table.
- Added responsive table styling and player avatar support in `apps/web/src/components/league/league.css` (sticky headers, scrollable body, hover/striping, circular images, and sort indicators).

### Testing
- Ran `npm run build` in `apps/web` and the production build completed successfully.
- Ran `npm run lint` and linting completed with no blocking errors.
- Verified repository checks with `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64e587afd08324b97adc1d7a162f0b)