### PR TITLE
Apply runner fatigue to run engine traits

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
@@ -1,20 +1,72 @@
-import type { EngineContext } from "./types";
-import { byName, n } from "./utils";
+import type { EngineContext, PlayerTrait } from "./types";
+
+const STATIC_TRAITS = new Set(["size", "strength"]);
+
+function number(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getPlayerName(player: PlayerTrait) {
+  return String(
+    player.name ?? player.Name ?? player.playername ?? player.PlayerName ?? "",
+  );
+}
+
+/** Returns the points removed from skill traits at the player's current in-game stamina. */
+export function fatigueTraitPenalty(
+  player: PlayerTrait | undefined,
+  traitName: string,
+) {
+  if (!player || STATIC_TRAITS.has(traitName.replace(/\s+/g, "").toLowerCase())) {
+    return 0;
+  }
+
+  // A fatigue score is added when this player first participates in a play.
+  // Players who have not participated must retain their roster trait values.
+  if (player.fatigue === undefined || player.fatigue === null) return 0;
+
+  const remainingStamina = number(player.fatigue);
+  if (remainingStamina < 0) return 8;
+  if (remainingStamina < 5) return 5;
+  if (remainingStamina < 15) return 3;
+  return 0;
+}
+
+/** Applies the in-game stamina penalty to a non-static trait value. */
+export function applyFatigueToTrait(
+  player: PlayerTrait | undefined,
+  traitName: string,
+  value: number,
+) {
+  return Math.max(0, value - fatigueTraitPenalty(player, traitName));
+}
+
 export function applyFatigue(
   ctx: EngineContext,
   playerName: string,
   actionType: string,
 ) {
-  const player = byName(ctx, playerName);
+  const player = ctx.players.find(
+    (candidate) => getPlayerName(candidate) === playerName,
+  );
   if (!player) return;
-  const drain = n(
+  const drain = number(
     (ctx.settings.drainSettings as Record<string, unknown> | undefined)?.[
       actionType
     ] ??
+      (ctx.settings.staminaDrains as Record<string, unknown> | undefined)?.[
+        actionType
+      ] ??
       (ctx.settings as Record<string, unknown>)[actionType] ??
       0,
   );
-  player.fatigue = Math.max(0, n(player.fatigue ?? 100) - drain);
+  const stamina = number(player.stamina ?? player.Stamina, 100);
+  const currentStamina = number(player.fatigue, stamina);
+
+  // `fatigue` is the player's remaining in-game stamina. Do not clamp it: the
+  // below-zero tier deliberately carries the largest skill penalty.
+  player.fatigue = currentStamina - drain;
 }
 export function applyFatigueFromPlayHistory() {
   return undefined;

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -39,6 +39,7 @@ import {
   performBruiserCheck,
   performCarryDefenderChecks,
 } from "./runEngineHelper";
+import { applyFatigue } from "./fatigueEngine";
 
 /** Chooses the most plausible tackler after a run or pass play has ended, weighting nearby defender groups by tackling ability. It is used by `runPlay` and pass-play fumble/tackle resolution when no specific tackler was already recorded. */
 export function determineTackler(
@@ -522,7 +523,7 @@ export function runPlay(
     winner: battle.winner,
   }));
 
-  return buildResult(
+  const playResult = buildResult(
     game,
     updated,
     "Run",
@@ -546,4 +547,10 @@ export function runPlay(
       jukes: successfulJukes,
     },
   );
+
+  // Charge the rush after resolving the play so this snap uses the stamina the
+  // runner brought into it and every subsequent snap sees the updated score.
+  applyFatigue(ctx, runnerName, "Run");
+
+  return playResult;
 }

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -9,6 +9,7 @@ import type {
   FrontendSettings,
   RunPlayState,
 } from "./types";
+import { applyFatigueToTrait } from "./fatigueEngine";
 
 const OL_SLOTS: FormationSlot[] = [
   "LT",
@@ -72,7 +73,7 @@ export function trait(player: PlayerTrait | undefined, key: string): number {
     player[camelKey] ??
     player[pascalKey];
 
-  return Number(value ?? 0);
+  return applyFatigueToTrait(player, key, Number(value ?? 0));
 }
 
 /** Looks up a player object by the display/name fields used across roster data. It is used anywhere the run engine has a player name but needs trait values. */

--- a/apps/web/src/components/league/gameplay/engine/utils.ts
+++ b/apps/web/src/components/league/gameplay/engine/utils.ts
@@ -1,6 +1,7 @@
 import type { LeagueGame } from "../../types";
 import { parseTimeToSeconds } from "../../leagueMappers";
 import type { ClockMode, EngineContext, PlayerTrait } from "./types";
+import { applyFatigueToTrait } from "./fatigueEngine";
 
 export const n = (v: unknown) => Number(v) || 0;
 export const str = (v: unknown) => String(v ?? "");
@@ -29,9 +30,9 @@ export function playerName(p: PlayerTrait | undefined, fallback = "") {
   return str(p?.name ?? p?.Name ?? fallback);
 }
 export function trait(p: PlayerTrait | undefined, key: string, fallback = 50) {
-  return (
-    Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)]) || fallback
-  );
+  const value =
+    Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)]) || fallback;
+  return applyFatigueToTrait(p, key, value);
 }
 export function teamPlayers(ctx: EngineContext, team: string) {
   return ctx.players.filter((p) => str(p.team ?? p.Team) === team);


### PR DESCRIPTION
### Motivation
- Ensure player fatigue meaningfully affects gameplay by charging stamina after every rush and reducing skill-based traits as stamina drains.
- Support the existing configuration sources for stamina drains (`drainSettings` and the Sheets-provided `staminaDrains`) so tuning data drives in-game stamina loss.

### Description
- Add `fatigueTraitPenalty` and `applyFatigueToTrait` in `fatigueEngine.ts` to compute tiered penalties (3 points when stamina < 15, 5 when < 5, 8 when < 0) and exclude static traits `size` and `strength` from penalties. 
- Change `applyFatigue` to persist a player-specific `fatigue` remaining-stamina value (allowing it to go below zero for the heaviest penalty tier) and read drain values from both `drainSettings` and `staminaDrains` settings maps. 
- Integrate fatigue into trait accessors by using `applyFatigueToTrait` in `utils.ts` and `runEngineHelper.ts` so all skill-related trait reads reflect current in-game fatigue. 
- Charge the runner's stamina after a completed rush by calling `applyFatigue(ctx, runnerName, "Run")` at the end of `runPlay` in `runEngine.ts` so subsequent plays observe updated fatigue.
- Add small helpers (`number`, `getPlayerName`) and guard logic to preserve roster trait values for players who haven’t participated yet.

### Testing
- Ran `npm run build` and the production bundle built successfully. 
- Ran `npm run lint` and no lint errors were reported. 
- Ran `git diff --check` and there were no whitespace/patch issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64e700e990832484ceeaa1d9ceea3e)