### PR TITLE
Add fatigue-aware stamina rings to roster details

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -49,7 +49,32 @@ function teamOf(p: Player) {
   return str(p.team ?? p.Team);
 }
 function imgOf(p?: Player) {
-  return str(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo);
+  return str(
+    p?.image ??
+      p?.Image ??
+      p?.photo ??
+      p?.Photo ??
+      p?.["Player Image from AI"] ??
+      p?.["player image from ai"],
+  );
+}
+
+function staminaOf(player: Player) {
+  const value = Number(
+    player.fatigue ??
+      player.Fatigue ??
+      player.stamina ??
+      player.Stamina ??
+      100,
+  );
+  return Math.min(100, Math.max(0, Number.isFinite(value) ? value : 100));
+}
+
+function staminaColor(stamina: number) {
+  if (stamina < 10) return "#ef4444";
+  if (stamina < 25) return "#f97316";
+  if (stamina < 50) return "#facc15";
+  return "#22c55e";
 }
 function trait(p: Player | undefined, key: string) {
   return Number(p?.[key] ?? p?.[key[0].toUpperCase() + key.slice(1)] ?? 0);
@@ -150,9 +175,32 @@ function RosterDetails({ roster }: { roster: Player[] }) {
               <tr key={`${nameOf(player)}-${index}`}>
                 <td className="roster-position">{valueFor(player, "Position") as string}</td>
                 <td>
-                  <div className="roster-player-image">
-                    {imgOf(player) ? <img src={imgOf(player)} alt="" /> : <span>👤</span>}
-                  </div>
+                  {(() => {
+                    const stamina = staminaOf(player);
+                    return (
+                      <div
+                        className="roster-stamina-ring"
+                        style={{
+                          "--stamina": `${stamina * 3.6}deg`,
+                          "--stamina-color": staminaColor(stamina),
+                        } as React.CSSProperties}
+                        role="img"
+                        aria-label={`${nameOf(player)} stamina: ${Math.round(stamina)}%`}
+                        title={`${Math.round(stamina)}% stamina`}
+                      >
+                        <div className="roster-player-image" aria-hidden="true">
+                          {imgOf(player) ? (
+                            <img src={imgOf(player)} alt="" />
+                          ) : (
+                            <span>👤</span>
+                          )}
+                        </div>
+                        <span className="roster-stamina-value">
+                          {Math.round(stamina)}%
+                        </span>
+                      </div>
+                    );
+                  })()}
                 </td>
                 <th scope="row">{nameOf(player)}</th>
                 {traitColumns.map((column) => (

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1279,13 +1279,29 @@
   color: #fca5a5;
   font-weight: 900;
 }
+.roster-stamina-ring {
+  --stamina: 360deg;
+  --stamina-color: #22c55e;
+  position: relative;
+  display: grid;
+  width: 58px;
+  height: 58px;
+  margin: auto;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--stamina-color) 0deg var(--stamina),
+    #334155 var(--stamina) 360deg
+  );
+  box-shadow: 0 0 10px color-mix(in srgb, var(--stamina-color) 35%, transparent);
+}
 .roster-player-image {
   display: grid;
-  width: 46px;
-  height: 46px;
+  width: 48px;
+  height: 48px;
   place-items: center;
   overflow: hidden;
-  border: 1px solid #ffffff2e;
+  border: 2px solid #111827;
   border-radius: 50%;
   background: #0f172a;
   font-size: 22px;
@@ -1294,6 +1310,20 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+.roster-stamina-value {
+  position: absolute;
+  right: -8px;
+  bottom: -5px;
+  min-width: 30px;
+  padding: 2px 4px;
+  border: 1px solid var(--stamina-color);
+  border-radius: 999px;
+  background: #111827;
+  color: var(--stamina-color);
+  font-size: 10px;
+  font-weight: 900;
+  line-height: 1.2;
 }
 .formation-grid {
   display: grid;


### PR DESCRIPTION
### Motivation
- Update the roster details view to show a circular stamina indicator around each player portrait that reflects current stamina/fatigue and uses color thresholds (green/yellow/orange/red) as fatigue accumulates.

### Description
- Added fallback lookups to `imgOf` to support AI-generated image fields (`Player Image from AI` / `player image from ai`).
- Introduced `staminaOf` to normalize and clamp a player's stamina/fatigue to `0–100` and `staminaColor` to map thresholds to colors (`#22c55e`, `#facc15`, `#f97316`, `#ef4444`).
- Wrapped each roster portrait in a `roster-stamina-ring` element in `RosterDetails` that sets CSS variables for a conic-gradient fill, includes a visible percentage badge, and exposes the current stamina via `aria-label` and `title` for accessibility.
- Added CSS in `league.css` for `.roster-stamina-ring`, adjusted `.roster-player-image` sizing/border, and added `.roster-stamina-value` styling for the numeric badge.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and no lint errors were reported.
- Ran `git diff --check` and no whitespace or diff issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64e86b85e883248dccc2cbce47781b)