### PR TITLE
Restore player fatigue when loading games

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -32,6 +32,7 @@ import {
   spikeBall,
 } from "./gameplay/gameEngine";
 import { animatePlay } from "./gameplay/engine/animationAdapter";
+import { applyFatigueFromPlayHistory } from "./gameplay/engine/fatigueEngine";
 import type {
   FormationSlot,
   FrontendSettings,
@@ -1421,11 +1422,21 @@ export function GameCenter({
     ])
       .then(([stateRes, historyRes, playerRes, settingsRes, teamsRes]) => {
         if (!active) return;
+        const loadedSettings = normalizeFrontendSettings(settingsRes);
+        const loadedPlayers = playerRes.players.map((player) => ({ ...player }));
+        applyFatigueFromPlayHistory(
+          {
+            players: loadedPlayers,
+            settings: loadedSettings,
+            historyLength: historyRes.plays.length,
+          },
+          historyRes.plays,
+        );
         setCurrentGame(normalizeGame(game, stateRes.gameState));
         setHistory(historyRes.plays);
-        setPlayers(playerRes.players);
+        setPlayers(loadedPlayers);
         setTeams(teamsRes.teams as LeagueTeam[]);
-        setSettings(normalizeFrontendSettings(settingsRes));
+        setSettings(loadedSettings);
         setLog(
           historyRes.plays.length
             ? historyRes.plays

--- a/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
@@ -68,6 +68,39 @@ export function applyFatigue(
   // below-zero tier deliberately carries the largest skill penalty.
   player.fatigue = currentStamina - drain;
 }
-export function applyFatigueFromPlayHistory() {
-  return undefined;
+
+type HistoricalPlay = Record<string, unknown>;
+
+function historicalField(play: HistoricalPlay, fieldName: string) {
+  const normalizedFieldName = fieldName.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  const entry = Object.entries(play).find(
+    ([key]) =>
+      key.replace(/[^a-z0-9]/gi, "").toLowerCase() === normalizedFieldName,
+  );
+  return entry?.[1];
+}
+
+/**
+ * Rebuilds in-game stamina from persisted plays.
+ *
+ * Player fatigue is intentionally not stored with the game, so loading a game
+ * must replay each recorded action using the same drain settings as a live
+ * play. Resetting every player first makes this safe to call again if game data
+ * is refreshed, rather than charging the history more than once.
+ */
+export function applyFatigueFromPlayHistory(
+  ctx: EngineContext,
+  playHistory: HistoricalPlay[],
+) {
+  ctx.players.forEach((player) => {
+    player.fatigue = number(player.stamina ?? player.Stamina, 100);
+  });
+
+  playHistory.forEach((play) => {
+    const playerName = String(historicalField(play, "player") ?? "").trim();
+    const actionType = String(historicalField(play, "playtype") ?? "").trim();
+    if (playerName && actionType) applyFatigue(ctx, playerName, actionType);
+  });
+
+  return ctx.players;
 }


### PR DESCRIPTION
### Motivation

- The frontend must reconstruct in-game fatigue because player fatigue is not persisted with saved games, so loading a game should replay prior actions to derive current stamina.
- Historical play records can use inconsistent key casing/formatting, so field-name normalization is required to interpret legacy/backend play rows.
- Rebuilding fatigue must be idempotent so refreshing or reloading game data does not double-charge drains.

### Description

- Add `applyFatigueFromPlayHistory(ctx, playHistory)` to `apps/web/src/components/league/gameplay/engine/fatigueEngine.ts`, which resets each player’s `fatigue` to their base `stamina` and replays each historical play using existing drain settings to recompute remaining stamina.
- Implement `historicalField` to normalize legacy/backend field names when reading play records so keys like `player`, `Player`, or `PLAYER` are handled uniformly.
- Update `apps/web/src/components/league/GameCenter.tsx` to normalize settings and players, call `applyFatigueFromPlayHistory` after loading `getPlayerTraits()`, `getFrontendSettings()`, and `getPlayHistory()`, and then store the fatigue-adjusted player objects in state.
- Use a shallow clone of loaded players and normalized settings when reconstructing fatigue to avoid mutating upstream data and ensure predictable state updates.

### Testing

- Ran `npm run build` in `apps/web` and the production build completed successfully.
- Ran `npm run lint` in `apps/web` and ESLint completed without errors.
- Ran `git diff --check` and no whitespace or diff-check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64ea771d908324a5ffec645dab92af)