### PR TITLE
Fix roster details modal sizing and scrolling

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import type { LeagueGame } from "./types";
 import type {
   PlayCallOptions,
@@ -230,7 +231,7 @@ function ControlModal({
   wide?: boolean;
   full?: boolean;
 }) {
-  return (
+  const modal = (
     <div className="game-modal open">
       <div
         className={`game-modal-panel formation-panel ${wide ? "routes-panel" : ""} ${full ? "formation-full-panel" : ""}`}
@@ -242,6 +243,11 @@ function ControlModal({
       </div>
     </div>
   );
+
+  // Field controls live inside a transformed, zero-height overlay. Portaling the
+  // modal to the league root keeps viewport sizing independent of that overlay.
+  const modalRoot = document.querySelector(".league-app") ?? document.body;
+  return createPortal(modal, modalRoot);
 }
 /**
  * Determines who can receive a pass from the current formation. Wide receivers

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1228,8 +1228,12 @@
   color: var(--text-muted);
 }
 .roster-table-wrap {
-  max-height: calc(92vh - 150px);
-  overflow: auto;
+  min-height: 0;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   border: 1px solid #ffffff1f;
   border-radius: 12px;
 }
@@ -1413,11 +1417,13 @@
 
 /* Legacy-style play caller modals */
 .formation-full-panel {
-  width: 100%;
-  height: 100%;
+  display: flex;
+  width: min(96vw, 1600px);
+  height: 90vh;
   max-width: none;
-  border-radius: 0;
-  overflow: auto;
+  max-height: 90vh;
+  flex-direction: column;
+  overflow: hidden;
 }
 .formation-panel {
   background: var(--gray-light);
@@ -1754,7 +1760,6 @@
 .eligible-receiver-chip:active {
   cursor: grabbing;
 }
-.formation-full-panel { width: 100%; height: 100%; max-width: none; border-radius: 0; overflow: auto; }
 .formation-panel { background: var(--gray-light); }
 .formation-field { margin-bottom: 4vw; overflow-x: auto; min-width: 720px; }
 .formation-row { display: flex; justify-content: center; align-items: center; gap: 2vw; margin-bottom: 4vw; }


### PR DESCRIPTION
### Motivation
- The roster details modal was being squished to the height of a transformed, zero-height field overlay which restricted its usable height and prevented easy horizontal scrolling of the roster table.
- The change aims to present the full roster panel at a sensible viewport height and provide independent horizontal and vertical scrolling for the table content.

### Description
- Portaled control modals to the league application root using `createPortal` so the field overlay no longer constrains modal layout in `GameControls.tsx`.
- Sized the full roster panel (`.formation-full-panel`) to `90vh` with a responsive `min(96vw, 1600px)` width and a column flex layout to use available vertical space in `league.css`.
- Updated `.roster-table-wrap` to use `flex: 1`, allow independent `overflow-x`/`overflow-y`, and added `overscroll-behavior: contain` and `scrollbar-gutter: stable` to ensure stable scrollbars and contained overscroll.
- Removed the duplicate overriding `.formation-full-panel` rule to avoid conflicting sizing.

### Testing
- Ran `npm run build` in `apps/web` and the production build completed successfully.
- Ran `npm run lint` and ESLint completed with no errors reported for the modified files.
- Ran `git diff --check` and there were no whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64ebaad1488324873dd748982ecf72)