### PR TITLE
Throttle and report Google Sheets write requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "dist/server.js",
   "scripts": {
-    "dev": "tsx src/server.ts"
+    "dev": "tsx src/server.ts",
+    "test": "node --import tsx --test src/**/*.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/apps/api/src/services/sheets.ts
+++ b/apps/api/src/services/sheets.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 import { google } from "googleapis";
+import { sheetsWriteThrottle } from "./writeRequestThrottle.js";
 
 dotenv.config();
 
@@ -57,7 +58,7 @@ export async function readSheetObjects(range: string) {
 }
 
 export async function appendSheetRow(range: string, row: unknown[]) {
-  const response = await sheets.spreadsheets.values.append({
+  const response = await sheetsWriteThrottle.run(() => sheets.spreadsheets.values.append({
     spreadsheetId: sheetId,
     range,
     valueInputOption: "USER_ENTERED",
@@ -65,7 +66,7 @@ export async function appendSheetRow(range: string, row: unknown[]) {
     requestBody: {
       values: [row]
     }
-  });
+  }));
 
   return response.data;
 }
@@ -75,13 +76,13 @@ export async function batchUpdateSheetValues(
 ) {
   if (data.length === 0) return;
 
-  const response = await sheets.spreadsheets.values.batchUpdate({
+  const response = await sheetsWriteThrottle.run(() => sheets.spreadsheets.values.batchUpdate({
     spreadsheetId: sheetId,
     requestBody: {
       valueInputOption: "USER_ENTERED",
       data
     }
-  });
+  }));
 
   return response.data;
 }

--- a/apps/api/src/services/writeRequestThrottle.test.ts
+++ b/apps/api/src/services/writeRequestThrottle.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WriteRequestThrottle } from "./writeRequestThrottle.js";
+
+test("spaces every queued write request four seconds apart", async () => {
+  let now = Date.parse("2026-07-25T12:00:00.000Z");
+  const waits: number[] = [];
+  const starts: number[] = [];
+  const throttle = new WriteRequestThrottle({
+    now: () => now,
+    sleep: async (milliseconds) => {
+      waits.push(milliseconds);
+      now += milliseconds;
+    },
+    logger: () => undefined,
+  });
+
+  await Promise.all(Array.from({ length: 3 }, () => throttle.run(async () => starts.push(now))));
+
+  assert.deepEqual(waits, [4_000, 4_000]);
+  assert.deepEqual(starts, [
+    Date.parse("2026-07-25T12:00:00.000Z"),
+    Date.parse("2026-07-25T12:00:04.000Z"),
+    Date.parse("2026-07-25T12:00:08.000Z"),
+  ]);
+});
+
+test("logs the write count for its UTC minute and resets in the next minute", async () => {
+  let now = Date.parse("2026-07-25T12:00:56.000Z");
+  const entries: Record<string, unknown>[] = [];
+  const throttle = new WriteRequestThrottle({
+    now: () => now,
+    sleep: async (milliseconds) => { now += milliseconds; },
+    logger: (_message, details) => entries.push(details),
+  });
+
+  await throttle.run(async () => undefined);
+  await throttle.run(async () => undefined);
+
+  assert.deepEqual(entries.map(({ minute, writeRequestsThisMinute }) => ({ minute, writeRequestsThisMinute })), [
+    { minute: "2026-07-25T12:00Z", writeRequestsThisMinute: 1 },
+    { minute: "2026-07-25T12:01Z", writeRequestsThisMinute: 1 },
+  ]);
+});
+
+test("continues processing the queue after a failed write", async () => {
+  let now = 0;
+  const throttle = new WriteRequestThrottle({
+    now: () => now,
+    sleep: async (milliseconds) => { now += milliseconds; },
+    logger: () => undefined,
+  });
+
+  await assert.rejects(throttle.run(async () => { throw new Error("write failed"); }));
+  const result = await throttle.run(async () => "saved");
+
+  assert.equal(result, "saved");
+  assert.equal(now, 4_000);
+});

--- a/apps/api/src/services/writeRequestThrottle.ts
+++ b/apps/api/src/services/writeRequestThrottle.ts
@@ -1,0 +1,68 @@
+const DEFAULT_INTERVAL_MS = 4_000;
+
+type Sleep = (milliseconds: number) => Promise<void>;
+type Logger = (message: string, details: Record<string, unknown>) => void;
+
+export type WriteRequestThrottleOptions = {
+  intervalMs?: number;
+  now?: () => number;
+  sleep?: Sleep;
+  logger?: Logger;
+};
+
+/**
+ * Serializes outbound write requests and spaces their start times apart.
+ * A four-second interval caps a single API process at 15 write attempts in
+ * every 60-second period, including retries and requests that ultimately fail.
+ */
+export class WriteRequestThrottle {
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+  private readonly sleep: Sleep;
+  private readonly logger: Logger;
+  private queue: Promise<void> = Promise.resolve();
+  private lastRequestStartedAt: number | undefined;
+  private minute = "";
+  private requestsThisMinute = 0;
+
+  constructor(options: WriteRequestThrottleOptions = {}) {
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+    this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.logger = options.logger ?? ((message, details) => console.info(message, details));
+
+    if (!Number.isFinite(this.intervalMs) || this.intervalMs < 0) {
+      throw new Error("Write request interval must be a non-negative number.");
+    }
+  }
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const request = this.queue.then(async () => {
+      if (this.lastRequestStartedAt !== undefined) {
+        const waitMs = this.lastRequestStartedAt + this.intervalMs - this.now();
+        if (waitMs > 0) await this.sleep(waitMs);
+      }
+
+      const startedAt = this.now();
+      this.lastRequestStartedAt = startedAt;
+      const minute = new Date(startedAt).toISOString().slice(0, 16);
+      if (minute !== this.minute) {
+        this.minute = minute;
+        this.requestsThisMinute = 0;
+      }
+      this.requestsThisMinute += 1;
+      this.logger("Google Sheets write request", {
+        minute: `${minute}Z`,
+        writeRequestsThisMinute: this.requestsThisMinute,
+        intervalMs: this.intervalMs,
+      });
+
+      return operation();
+    });
+
+    this.queue = request.then(() => undefined, () => undefined);
+    return request;
+  }
+}
+
+export const sheetsWriteThrottle = new WriteRequestThrottle();


### PR DESCRIPTION
### Motivation
- Prevent bursts of Google Sheets write calls from a single API process by serializing outbound writes and enforcing spacing to avoid exceeding quota and causing transient failures. 
- Ensure retries and legacy write paths are included in throttling so the effective write attempts per process remain under the target limit. 
- Emit a structured, per-minute log so operators can monitor how many write attempts the process has started within each UTC minute.

### Description
- Add `WriteRequestThrottle` in `apps/api/src/services/writeRequestThrottle.ts` which queues write operations, enforces a default 4,000ms interval between request starts, tracks per-UTC-minute counts, and emits structured logs for each write attempt. 
- Export a singleton `sheetsWriteThrottle` and route Sheets write calls through it by wrapping `sheets.spreadsheets.values.append` and `sheets.spreadsheets.values.batchUpdate` in `apps/api/src/services/sheets.ts`. 
- Add unit tests in `apps/api/src/services/writeRequestThrottle.test.ts` that verify 4s spacing, per-minute counting/reset behavior, and continued queue processing after a failure. 
- Add `test` and `typecheck` scripts to `apps/api/package.json` to run the new tests and static type checks.

### Testing
- Ran `cd apps/api && npm test` which executed the throttle unit tests (3 tests) and they all passed. 
- Ran `cd apps/api && npm run typecheck` which completed without type errors. 
- Built and linted the web app with `cd apps/web && npm run build` and `cd apps/web && npm run lint`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a652cee109c8324bda020d454cd9ef0)