### PR TITLE
Populate player rushing leaders from PlayerStats

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -287,6 +287,7 @@ async function savePlayAndGameWithRetry(data: Record<string, unknown>, gameId: s
 
 gameRoutes.get("/health", (_req, res) => res.json({ ok: true, app: "football-game-api", message: "API is running" }));
 gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await readSheetObjects("Players!A1:AM") }); } catch (e) { next(e); } });
+gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AI") }); } catch (e) { next(e); } });
 gameRoutes.get("/player-traits", async (_req, res, next) => { try { res.json({ players: await getPlayerTraitsFromSheet() }); } catch (e) { next(e); } });
 gameRoutes.get("/teams", async (_req, res, next) => { try { res.json({ teams: await getTeamsFromSheet() }); } catch (e) { next(e); } });
 gameRoutes.get("/games", async (_req, res, next) => { try { res.json({ games: await getGamesList() }); } catch (e) { next(e); } });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -27,6 +27,16 @@ export async function getApiHealth(): Promise<ApiHealth> {
 export async function getPlayers(): Promise<{ players: Player[] }> {
   return getJson("/players", "Failed to load players from backend API");
 }
+export type PlayerStats = Record<string, string> & {
+  Player: string;
+  Carries: string;
+  Yards: string;
+};
+export async function getPlayerStats(): Promise<{
+  playerStats: PlayerStats[];
+}> {
+  return getJson("/player-stats", "Failed to load player stats");
+}
 export async function getTeams(): Promise<{
   teams: Record<string, unknown>[];
 }> {

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -1,13 +1,47 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  getPlayers,
+  getPlayerStats,
+  type PlayerStats,
+} from "../../api/client";
+import type { Player } from "../players/types";
 import { PLACEHOLDER_LOGOS } from "./leagueConstants";
+
+type StatsView = "Player" | "Team";
+type Leader = { name: string; image: string; value: number };
+
+function playerImage(player: Player | undefined) {
+  return (
+    player?.Image ||
+    player?.["Player Image from AI"] ||
+    player?.Jersey ||
+    player?.["Jersey Image"] ||
+    PLACEHOLDER_LOGOS.team
+  );
+}
+
 function LeaderTable({
   title,
   stat,
   kind,
+  leaders,
+  isLoading = false,
+  error,
 }: {
   title: string;
   stat: string;
-  kind: "Player" | "Team";
+  kind: StatsView;
+  leaders?: Leader[];
+  isLoading?: boolean;
+  error?: string | null;
 }) {
+  const placeholderLeaders = Array.from({ length: 5 }, (_, i) => ({
+    name: `${kind} Name`,
+    image: PLACEHOLDER_LOGOS.team,
+    value: [308.5, 298.7, 296.4, 294.0, 291.7][i],
+  }));
+  const rows = leaders ?? placeholderLeaders;
+
   return (
     <div className="leader-group">
       <table className="leader-table">
@@ -18,60 +52,132 @@ function LeaderTable({
           </tr>
         </thead>
         <tbody>
-          {Array.from({ length: 5 }, (_, i) => (
-            <tr key={i}>
-              <td className="team-cell">
-                <span className="rank">{i + 1}</span>
-                <img
-                  className="team-logo"
-                  src={PLACEHOLDER_LOGOS.team}
-                  alt=""
-                />
-                <a href="#" className="team-link">
-                  {kind} Name
-                </a>
-              </td>
-              <td className="stat-value">
-                {[308.5, 298.7, 296.4, 294.0, 291.7][i]}
+          {isLoading || error || rows.length === 0 ? (
+            <tr>
+              <td className="leader-message" colSpan={2}>
+                {isLoading
+                  ? "Loading leaders…"
+                  : error || "No rushing stats available."}
               </td>
             </tr>
-          ))}
+          ) : (
+            rows.map((leader, i) => (
+              <tr key={`${leader.name}-${i}`}>
+                <td className="team-cell">
+                  <span className="rank">{i + 1}</span>
+                  <img className="team-logo" src={leader.image} alt="" />
+                  <span className="team-link">{leader.name}</span>
+                </td>
+                <td className="stat-value">{leader.value}</td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
-      <div className="complete-link">
-        <a href="#">Complete Leaders</a>
-      </div>
+      {!isLoading && !error && rows.length > 0 && (
+        <div className="complete-link">
+          <a href="#">Complete Leaders</a>
+        </div>
+      )}
     </div>
   );
 }
+
 export function LeagueStats() {
+  const [activeView, setActiveView] = useState<StatsView>("Team");
+  const [stats, setStats] = useState<PlayerStats[]>([]);
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasRequestedPlayerStats = useRef(false);
+
+  useEffect(() => {
+    if (activeView !== "Player" || hasRequestedPlayerStats.current) return;
+
+    hasRequestedPlayerStats.current = true;
+    setIsLoading(true);
+    setError(null);
+    Promise.all([getPlayerStats(), getPlayers()])
+      .then(([statsResult, playersResult]) => {
+        setStats(statsResult.playerStats);
+        setPlayers(playersResult.players);
+      })
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Unable to load leaders"),
+      )
+      .finally(() => setIsLoading(false));
+  }, [activeView]);
+
+  const rushingLeaders = useMemo(() => {
+    const playersByName = new Map(
+      players.map((player) => [player.Name?.trim().toLowerCase(), player]),
+    );
+
+    return stats
+      .filter((row) => row.Player?.trim())
+      .map((row) => {
+        const name = row.Player.trim();
+        const player = playersByName.get(name.toLowerCase());
+        return { name, image: playerImage(player), value: Number(row.Yards) || 0 };
+      })
+      .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name))
+      .slice(0, 5);
+  }, [players, stats]);
+
   return (
     <>
       <div className="stats-tabs">
-        <button className="stats-tab">Player</button>
-        <button className="stats-tab active">Team</button>
+        {(["Player", "Team"] as StatsView[]).map((view) => (
+          <button
+            className={`stats-tab ${activeView === view ? "active" : ""}`}
+            key={view}
+            type="button"
+            aria-pressed={activeView === view}
+            onClick={() => setActiveView(view)}
+          >
+            {view}
+          </button>
+        ))}
       </div>
       <div className="season-row">
         <button className="season-pill">Season 1 ▾</button>
       </div>
       <div className="stats-content active">
-        <div className="stats-section">
-          <div className="stats-section-title">Offensive Leaders</div>
-          {["TOTAL YARDS", "PASSING", "RUSHING"].map((t) => (
-            <LeaderTable key={t} title={t} stat="YDS/G" kind="Team" />
-          ))}
-        </div>
-        <div className="stats-section">
-          <div className="stats-section-title">Defensive Leaders</div>
-          {["TACKLES", "SACKS", "INTERCEPTIONS"].map((t) => (
+        {activeView === "Player" ? (
+          <div className="stats-section">
+            <div className="stats-section-title">Offensive Leaders</div>
             <LeaderTable
-              key={t}
-              title={t}
-              stat={t === "TACKLES" ? "TOT" : t === "SACKS" ? "SACK" : "INT"}
+              title="RUSHING"
+              stat="YDS"
               kind="Player"
+              leaders={rushingLeaders}
+              isLoading={isLoading}
+              error={error}
             />
-          ))}
-        </div>
+          </div>
+        ) : (
+          <>
+            <div className="stats-section">
+              <div className="stats-section-title">Offensive Leaders</div>
+              {["TOTAL YARDS", "PASSING", "RUSHING"].map((title) => (
+                <LeaderTable key={title} title={title} stat="YDS/G" kind="Team" />
+              ))}
+            </div>
+            <div className="stats-section">
+              <div className="stats-section-title">Defensive Leaders</div>
+              {["TACKLES", "SACKS", "INTERCEPTIONS"].map((title) => (
+                <LeaderTable
+                  key={title}
+                  title={title}
+                  stat={
+                    title === "TACKLES" ? "TOT" : title === "SACKS" ? "SACK" : "INT"
+                  }
+                  kind="Player"
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -384,6 +384,11 @@
 .stat-value {
   text-align: right !important;
 }
+.leader-message {
+  color: var(--text-muted);
+  padding: 2vw !important;
+  text-align: center !important;
+}
 .complete-link {
   padding: 1vw 2vw;
 }


### PR DESCRIPTION
### Motivation
- Enable the Player stats tab to fetch real per-player rushing/defensive data from the spreadsheet and render a leaders list with player images and ranks, starting with the rushing yards table.

### Description
- Add a new backend endpoint `GET /player-stats` that reads the `PlayerStats!A1:AI` sheet and returns the rows as objects.
- Add a typed client call `getPlayerStats()` and `PlayerStats` type in `apps/web/src/api/client.ts` to fetch the new endpoint.
- Replace `LeagueStats` with an interactive component that toggles `Player`/`Team` views, lazily loads `PlayerStats` and `Players` on first selection, computes the top five rushers by `Yards`, and matches names to `Players` rows for an image to show in the leaders list.
- Add loading, empty, and error states in the leaders table and a small CSS rule `.leader-message` to style leader-table status messages.

### Testing
- Ran frontend lint with `cd apps/web && npm run lint`, which succeeded.
- Built the frontend with `cd apps/web && npm run build`, which produced a successful build.
- Ran typecheck with `cd apps/api && npm run typecheck`, which succeeded with no errors.
- Ran API tests with `cd apps/api && npm test`, and all tests passed (3 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66434da8008324b7f59f3f355a3861)