### PR TITLE
Add filterable complete rushing leaders and player image class

### DIFF
--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -10,6 +10,25 @@ import { PLACEHOLDER_LOGOS } from "./leagueConstants";
 type StatsView = "Player" | "Team";
 type Leader = { name: string; image: string; value: number };
 
+const RUSHING_COLUMNS = [
+  "Carries",
+  "Yards",
+  "TD",
+  "Fum",
+  "Fum Lost",
+  "First Down",
+  "Juke",
+  "BrokenTackle",
+  "Avg",
+  "Loss",
+  "5+",
+  "10+",
+  "20+",
+  "30+",
+  "50+",
+  "Long",
+] as const;
+
 function playerImage(player: Player | undefined) {
   return (
     player?.Image ||
@@ -27,6 +46,7 @@ function LeaderTable({
   leaders,
   isLoading = false,
   error,
+  onComplete,
 }: {
   title: string;
   stat: string;
@@ -34,6 +54,7 @@ function LeaderTable({
   leaders?: Leader[];
   isLoading?: boolean;
   error?: string | null;
+  onComplete?: () => void;
 }) {
   const placeholderLeaders = Array.from({ length: 5 }, (_, i) => ({
     name: `${kind} Name`,
@@ -65,7 +86,7 @@ function LeaderTable({
               <tr key={`${leader.name}-${i}`}>
                 <td className="team-cell">
                   <span className="rank">{i + 1}</span>
-                  <img className="team-logo" src={leader.image} alt="" />
+                  <img className="player-stats-image" src={leader.image} alt="" />
                   <span className="team-link">{leader.name}</span>
                 </td>
                 <td className="stat-value">{leader.value}</td>
@@ -74,9 +95,11 @@ function LeaderTable({
           )}
         </tbody>
       </table>
-      {!isLoading && !error && rows.length > 0 && (
+      {!isLoading && !error && rows.length > 0 && onComplete && (
         <div className="complete-link">
-          <a href="#">Complete Leaders</a>
+          <button type="button" onClick={onComplete}>
+            Complete Leaders
+          </button>
         </div>
       )}
     </div>
@@ -89,6 +112,8 @@ export function LeagueStats() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showAllRushers, setShowAllRushers] = useState(false);
+  const [rusherFilter, setRusherFilter] = useState("");
   const hasRequestedPlayerStats = useRef(false);
 
   useEffect(() => {
@@ -124,6 +149,26 @@ export function LeagueStats() {
       .slice(0, 5);
   }, [players, stats]);
 
+  const allRushers = useMemo(() => {
+    const query = rusherFilter.trim().toLowerCase();
+    const playersByName = new Map(
+      players.map((player) => [player.Name?.trim().toLowerCase(), player]),
+    );
+
+    return stats
+      .filter((row) => Number(row.Carries) >= 1)
+      .filter((row) => !query || row.Player?.toLowerCase().includes(query))
+      .map((row) => ({
+        row,
+        image: playerImage(playersByName.get(row.Player.trim().toLowerCase())),
+      }))
+      .sort(
+        (a, b) =>
+          Number(b.row.Yards) - Number(a.row.Yards) ||
+          a.row.Player.localeCompare(b.row.Player),
+      );
+  }, [players, rusherFilter, stats]);
+
   return (
     <>
       <div className="stats-tabs">
@@ -146,14 +191,67 @@ export function LeagueStats() {
         {activeView === "Player" ? (
           <div className="stats-section">
             <div className="stats-section-title">Offensive Leaders</div>
-            <LeaderTable
-              title="RUSHING"
-              stat="YDS"
-              kind="Player"
-              leaders={rushingLeaders}
-              isLoading={isLoading}
-              error={error}
-            />
+            {showAllRushers ? (
+              <div className="complete-rushing-leaders">
+                <div className="complete-leaders-tools">
+                  <button type="button" onClick={() => setShowAllRushers(false)}>
+                    Back to Leaders
+                  </button>
+                  <label>
+                    <span>Filter rushers</span>
+                    <input
+                      type="search"
+                      value={rusherFilter}
+                      onChange={(event) => setRusherFilter(event.target.value)}
+                      placeholder="Player name"
+                    />
+                  </label>
+                </div>
+                <div className="complete-leaders-table-scroll">
+                  <table className="complete-leaders-table">
+                    <thead>
+                      <tr>
+                        <th>Player</th>
+                        {RUSHING_COLUMNS.map((column) => (
+                          <th key={column}>{column}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {allRushers.length === 0 ? (
+                        <tr>
+                          <td colSpan={RUSHING_COLUMNS.length + 1} className="leader-message">
+                            No rushers match this filter.
+                          </td>
+                        </tr>
+                      ) : (
+                        allRushers.map(({ row, image }) => (
+                          <tr key={row.Player}>
+                            <td className="complete-leader-player">
+                              <img className="player-stats-image" src={image} alt="" />
+                              <span>{row.Player}</span>
+                            </td>
+                            {RUSHING_COLUMNS.map((column) => (
+                              <td key={column}>{row[column] || "0"}</td>
+                            ))}
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : (
+              <LeaderTable
+                title="RUSHING"
+                stat="YDS"
+                kind="Player"
+                leaders={rushingLeaders}
+                isLoading={isLoading}
+                error={error}
+                onComplete={() => setShowAllRushers(true)}
+              />
+            )}
           </div>
         ) : (
           <>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -374,9 +374,10 @@
   align-items: center;
   gap: 1vw;
 }
-.team-cell .team-logo {
+.player-stats-image {
   width: 24px;
-  height: 24px;
+  height: auto;
+  flex: 0 0 auto;
 }
 .statCol1 {
   text-align: left !important;
@@ -391,6 +392,60 @@
 }
 .complete-link {
   padding: 1vw 2vw;
+}
+.complete-link button,
+.complete-leaders-tools button {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--text-light);
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.complete-leaders-tools {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.complete-leaders-tools label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-muted);
+}
+.complete-leaders-tools input {
+  min-width: min(280px, 60vw);
+  border: 1px solid var(--gray-light);
+  border-radius: 4px;
+  padding: 0.65rem;
+  background: var(--gray-medium);
+  color: var(--text-light);
+}
+.complete-leaders-table-scroll {
+  overflow-x: auto;
+}
+.complete-leaders-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--gray-medium);
+}
+.complete-leaders-table th,
+.complete-leaders-table td {
+  padding: 0.75rem;
+  border: 1px solid var(--gray-light);
+  text-align: right;
+  white-space: nowrap;
+}
+.complete-leaders-table th:first-child,
+.complete-leaders-table td:first-child {
+  text-align: left;
+}
+.complete-leader-player {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 .scoreboard {
   display: grid;


### PR DESCRIPTION
### Motivation

- Ensure player images in the stats/leader UI have a dedicated class and are constrained by width while preserving aspect ratio.
- Replace the static "Complete Leaders" link with an interactive control that reveals a full rushing leaderboard.
- Provide a filterable view that shows every player with at least one carry and the full rushing stat line requested.

### Description

- Added `RUSHING_COLUMNS` and a full, responsive complete rushing table rendering Carries, Yards, TD, Fum, Fum Lost, First Down, Juke, BrokenTackle, Avg, Loss, 5+, 10+, 20+, 30+, 50+, and Long in `LeagueStats.tsx` using an `allRushers` memoized list filtered to `Carries >= 1` and sortable by yards.
- Introduced `player-stats-image` CSS class and replaced inline uses of the previous image class with `<img className="player-stats-image" />` to constrain width to `24px` and keep `height: auto` so images keep aspect ratio.
- Made `LeaderTable` accept an `onComplete` callback and render a button to open the complete leaders view, added component state `showAllRushers` and `rusherFilter` to toggle the full table and perform case-insensitive name filtering, and added a back control to return to the condensed leaders.
- Added styling for the complete table including horizontally scrollable container, responsive input styling, and table cell layout in `league.css` to support wide stat lines on smaller viewports.

### Testing

- Built the web app using `npm run build` and the build completed successfully.
- Ran lint with `npm run lint` and no lint errors were reported.
- Ran `git diff --check` and no whitespace/format issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66454cd8d08324ba122aab6a8d8a43)