### PR TITLE
Run generated play animations before advancing the field

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -17,7 +17,7 @@ import {
   savePlayAndGame,
 } from "../../api/client";
 import { GameScoreboard } from "./GameScoreboard";
-import GameField from "./GameField";
+import GameField, { type AnimationPlan } from "./GameField";
 import { GameControls } from "./GameControls";
 import { buildDefense } from "./formationDefense";
 import { GameLog } from "./GameLog";
@@ -31,7 +31,6 @@ import {
   runPlay,
   spikeBall,
 } from "./gameplay/gameEngine";
-import { animatePlay } from "./gameplay/engine/animationAdapter";
 import { applyFatigueFromPlayHistory } from "./gameplay/engine/fatigueEngine";
 import type {
   FormationSlot,
@@ -1397,6 +1396,15 @@ export function GameCenter({
   const [autoCloseFormationOnSave, setAutoCloseFormationOnSave] =
     useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
+  const [animationRequest, setAnimationRequest] = useState<{
+    id: number;
+    plan: AnimationPlan;
+  } | null>(null);
+  const animationSequenceRef = useRef(0);
+  const animationResolverRef = useRef<{
+    id: number;
+    resolve: () => void;
+  } | null>(null);
   const previousPossessionRef = useRef(currentGame.Possession);
   const playInFlightRef = useRef(false);
   const ctx = useMemo(
@@ -1476,11 +1484,7 @@ export function GameCenter({
     if (playInFlightRef.current) return;
     playInFlightRef.current = true;
     const previousGame = currentGame;
-    const previousBallOn = currentGame.BallOn;
     setIsSavingPlay(true);
-    setCurrentGame(result.game);
-    setHistory((h) => [...h, result.play]);
-    setLog((l) => [result.text, ...l]);
     const gamePayload = {
       gameId: result.game.GameId,
       quarter: result.game.Qtr,
@@ -1504,25 +1508,24 @@ export function GameCenter({
         play: result.play,
         game: gamePayload,
       });
-      if (result.play.playtype === "Run") {
-        try {
-          await animatePlay("Run", null, {
-            ...result.game,
-            Previous: previousBallOn,
-          });
-        } catch (error: unknown) {
-          setLog((l) => [
-            `Play animation skipped: ${error instanceof Error ? error.message : String(error)}`,
-            ...l,
-          ]);
-        }
+      const animation = (result.play as Record<string, unknown>).animation;
+      if (animation && typeof animation === "object") {
+        const id = ++animationSequenceRef.current;
+        await new Promise<void>((resolve) => {
+          animationResolverRef.current = { id, resolve };
+          setAnimationRequest({ id, plan: animation as AnimationPlan });
+        });
       }
+      // Preserve the pre-snap situation while the play runs. This state change
+      // advances the markers and resets the formation only after animation.
+      setCurrentGame(result.game);
+      setHistory((h) => [...h, result.play]);
+      setLog((l) => [result.text, ...l]);
     } catch (error) {
       setCurrentGame(previousGame);
-      setHistory((h) => h.filter((play) => play !== result.play));
       setLog((l) => [
-        `Save failed and optimistic play was rolled back: ${error instanceof Error ? error.message : String(error)}`,
-        ...l.filter((entry) => entry !== result.text),
+        `Save failed: ${error instanceof Error ? error.message : String(error)}`,
+        ...l,
       ]);
     } finally {
       setIsSavingPlay(false);
@@ -1677,6 +1680,14 @@ export function GameCenter({
                   "Primary Color",
                 )}
                 awayTeam={currentGame.Away}
+                animationRequest={animationRequest}
+                onAnimationComplete={(id) => {
+                  const pending = animationResolverRef.current;
+                  if (!pending || pending.id !== id) return;
+                  animationResolverRef.current = null;
+                  setAnimationRequest(null);
+                  pending.resolve();
+                }}
                 onFormationSlotClick={(slot) => {
                   const currentFormation = playOptions.formation ?? {};
                   const selectedPlayer = selectedFormationPlayer;

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -65,7 +65,7 @@ type AnimationPhase = {
     turnoverFlash?: boolean;
   };
 };
-type AnimationPlan = {
+export type AnimationPlan = {
   meta?: {
     playId?: string;
     playType?: string;
@@ -344,6 +344,8 @@ export default function GameField({
   homeTeamPrimaryColor,
   awayTeam,
   onSetupTransitionChange,
+  animationRequest,
+  onAnimationComplete,
   children,
 }: {
   formationMode?: boolean;
@@ -364,6 +366,8 @@ export default function GameField({
   homeTeamPrimaryColor?: string;
   awayTeam?: string;
   onSetupTransitionChange?: (active: boolean) => void;
+  animationRequest?: { id: number; plan: unknown } | null;
+  onAnimationComplete?: (id: number) => void;
   children?: ReactNode;
 }) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
@@ -380,6 +384,7 @@ export default function GameField({
   const labelsRef = useRef<Record<string, HTMLDivElement>>({});
   const footballCarrierIdRef = useRef<string | null>(null);
   const isRunningRef = useRef(false);
+  const lastAnimationRequestRef = useRef<number | null>(null);
   const isSetupTransitionRef = useRef(false);
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
@@ -1024,6 +1029,23 @@ export default function GameField({
       updateScreenPositionsWithoutFootball,
     ],
   );
+  useEffect(() => {
+    if (!animationRequest) return;
+    if (lastAnimationRequestRef.current === animationRequest.id) return;
+    lastAnimationRequestRef.current = animationRequest.id;
+
+    const executeRequestedAnimation = async () => {
+      try {
+        await runAnimationPlan(validatePlan(animationRequest.plan));
+      } catch (error) {
+        console.error(error);
+        showError(error instanceof Error ? error.message : String(error));
+      } finally {
+        onAnimationComplete?.(animationRequest.id);
+      }
+    };
+    void executeRequestedAnimation();
+  }, [animationRequest, onAnimationComplete, runAnimationPlan, showError]);
   const loadExampleJson = useCallback(() => {
     if (jsonInputRef.current)
       jsonInputRef.current.value = JSON.stringify(

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -43,8 +43,8 @@ export type RunAnimationPlan = {
 };
 
 /**
- * Builds the animation data only after the run simulation has resolved. For
- * now it deliberately stops after the snap and handoff/line-battle phases.
+ * Builds the animation data only after the run simulation has resolved. The
+ * final phase carries the result to its ending yard before the next setup.
  */
 export function runPlayJSONAnimationBuilder(
   previousGame: LeagueGame,
@@ -225,6 +225,31 @@ export function runPlayJSONAnimationBuilder(
         players: phaseTwoPlayers,
         labels,
         football: { mode: "carrier", carrierId: runnerId },
+      },
+      {
+        id: "run-result",
+        caption: `${runnerName} runs for ${yardsGained} yard${Math.abs(yardsGained) === 1 ? "" : "s"}.`,
+        durationMs: 900,
+        holdMs: 250,
+        players: runnerId
+          ? [
+              {
+                playerId: runnerId,
+                lane: handoffLane,
+                yard: Number(updatedGame.BallOn),
+                className: "ball-carrier",
+              },
+            ]
+          : [],
+        labels: labels.map((label) => ({ ...label, visible: false })),
+        football: { mode: "carrier", carrierId: runnerId },
+        fieldEffects: {
+          touchdownFlash:
+            Number(updatedGame.BallOn) === 0 ||
+            Number(updatedGame.BallOn) === 100,
+          firstDownFlash:
+            Number(previousGame.Distance) <= Math.max(0, yardsGained),
+        },
       },
     ],
   };


### PR DESCRIPTION
### Motivation
- Ensure the frontend actually shows the resolved play animation before advancing the line-of-scrimmage, first-down marker, and player positions so the UI reflects the play visually prior to updating state.
- Let the engine-produced animation JSON drive the live `GameField` rather than running a separate, hardcoded animation path during persistence.

### Description
- Wire the engine animation JSON into the live field by exporting `AnimationPlan` and adding `animationRequest` / `onAnimationComplete` props to `GameField`, which now accepts a requested plan, validates it, runs it via the existing runner, and calls back when finished (files: `GameField.tsx`).
- Change `GameCenter` persistence flow to send `result.play.animation` to `GameField` and await its completion before applying the new `currentGame`, appending to history, and updating the log; this preserves the pre-snap situation while the animation runs and prevents advancing markers early (file: `GameCenter.tsx`).
- Extend the run animation builder to include a final `run-result` phase that carries the ball-carrier and football to the resolved end-yard and emits `firstDown` / `touchdown` field effects so the UI can show the play finish before the next formation (file: `runPlayJSONAnimationBuilder.ts`).
- Remove the legacy direct `animatePlay` hard-coded call from the save path and use a request/ack pattern so each animation runs exactly once; include a small runtime cast to safely access `result.play.animation` from persisted plays.

### Testing
- Built and linted the web app successfully with `npm run build` and `npm run lint` (both succeeded after a type access adjustment). 
- Verified repository hygiene with `git diff --check` and committed the changes.
- Manual runtime verification is expected in the browser (no headless browser drive was used in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66476b384883249f81720af998e5cd)