### PR TITLE
Reset player visual states between plays

### DIFF
--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -853,7 +853,7 @@ export default function GameField({
       plan.players.forEach((rawPlayer) => {
         const player = normalizePlayerLane(rawPlayer, plan.players);
         const el = document.createElement("div");
-        el.className = `token ${player.team.toLowerCase()} ${unitClassForPlayer(player)} ${player.className || ""}`;
+        el.className = `token ${player.team.toLowerCase()} ${unitClassForPlayer(player)} reset`;
         el.id = `player-${player.id}`;
         el.style.left = `${player.x}%`;
         el.style.top = `${yardToYPct(player.yard)}%`;
@@ -883,7 +883,7 @@ export default function GameField({
         field.appendChild(el);
         playersRef.current[player.id] = {
           ...player,
-          className: player.className || "",
+          className: "reset",
           el,
         };
       });
@@ -1120,6 +1120,19 @@ export default function GameField({
       onSetupTransitionChange?.(true);
       try {
         currentPlanRef.current = nextPlan;
+        Object.values(playersRef.current).forEach((player) => {
+          player.className = "reset";
+          player.el.className = `token ${player.team.toLowerCase()} ${unitClassForPlayer(player)} reset`;
+        });
+        fieldRef.current
+          ?.querySelectorAll(".battle-label")
+          .forEach((label) => label.remove());
+        labelsRef.current = {};
+        fieldRef.current?.classList.remove(
+          "first-down-flash",
+          "touchdown-flash",
+          "turnover-flash",
+        );
         updateLinePositions();
         await wait(350);
         if (cancelled) return;


### PR DESCRIPTION
### Motivation
- Prevent stale visual states (faded linemen, OL/DL win highlights, lingering battle labels and field flashes) from persisting across play resets or formation transitions.

### Description
- Initialize every player token DOM element with a neutral `reset` class when rebuilding the animation scene in `GameField.tsx`.
- Ensure `playersRef.current` entries use `className: "reset"` so runtime updates start from a known neutral state.
- During between-play formation transitions, reset each runtime player's `className` and DOM `el.className`, remove any lingering `.battle-label` nodes, clear `labelsRef.current`, and remove field-effect classes (`first-down-flash`, `touchdown-flash`, `turnover-flash`).
- Changes are localized to `apps/web/src/components/league/GameField.tsx` and affect scene rebuild and setup transition logic.

### Testing
- Ran `npm run build` (Vite/TypeScript build) which completed successfully. 
- Ran `npm run lint` (ESLint) which completed successfully. 
- Ran `git diff --check` to verify no whitespace/diff issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a664970fbf08324b48b342136c5180d)