### PR TITLE
Animate a runner's first challenge after hitting the hole

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -368,6 +368,19 @@ body {
     0 8px 18px rgba(0, 0, 0, 0.5);
 }
 
+.token.juked img {
+  filter: grayscale(0.75) brightness(0.8);
+  transform: rotate(-18deg) scale(0.92);
+  box-shadow:
+    0 0 0 4px rgba(168, 85, 247, 0.7),
+    0 8px 18px rgba(0, 0, 0, 0.5);
+}
+
+.token.trucked img {
+  filter: brightness(0.75);
+  transform: rotate(18deg) scale(0.9);
+}
+
 .token.celebrating img {
   animation: celebrate-bounce 650ms ease-in-out infinite alternate;
   box-shadow:

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -40,7 +40,10 @@ import {
   performCarryDefenderChecks,
 } from "./runEngineHelper";
 import { applyFatigue } from "./fatigueEngine";
-import { runPlayJSONAnimationBuilder } from "./runPlayJSONAnimationBuilder";
+import {
+  runPlayJSONAnimationBuilder,
+  type FirstRunChallenge,
+} from "./runPlayJSONAnimationBuilder";
 
 /** Chooses the most plausible tackler after a run or pass play has ended, weighting nearby defender groups by tackling ability. It is used by `runPlay` and pass-play fumble/tackle resolution when no specific tackler was already recorded. */
 export function determineTackler(
@@ -178,6 +181,7 @@ export function runPlay(
   let bruiserCarryDefenderResult: ReturnType<
     typeof performCarryDefenderChecks
   > | null = null;
+  let firstChallenge: FirstRunChallenge | undefined;
 
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
@@ -434,6 +438,20 @@ export function runPlay(
       jukedBackfieldDefenders,
     );
 
+    if (lbSecondLevelResult?.linebacker && lbSecondLevelResult.wrapResult) {
+      firstChallenge = {
+        defender: lbSecondLevelResult.linebacker.player,
+        position: lbSecondLevelResult.linebacker.position,
+        accelerationYards: accelToSecondLevelYards,
+        wrapped: lbSecondLevelResult.wrapResult.wrapped,
+        attempt: lbSecondLevelResult.secondChanceAttempt?.attempt,
+        moveSucceeded:
+          lbSecondLevelResult.secondChanceAttempt?.attempt === "Juke"
+            ? lbSecondLevelResult.jukeResult?.juked
+            : lbSecondLevelResult.truckResult?.trucked,
+      };
+    }
+
     console.log("LB second level result:", lbSecondLevelResult);
   }
 
@@ -563,6 +581,7 @@ export function runPlay(
       visionCheck,
       runLaneTarget,
       dlSwipeResult,
+      firstChallenge,
     ),
   });
 

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -47,6 +47,15 @@ export type RunAnimationPlan = {
   phases: Array<Record<string, unknown>>;
 };
 
+export type FirstRunChallenge = {
+  defender: string;
+  position: string;
+  accelerationYards: number;
+  wrapped: boolean;
+  attempt?: "Juke" | "Truck";
+  moveSucceeded?: boolean;
+};
+
 /**
  * Builds the animation data only after the run simulation has resolved. The
  * final phase carries the result to its ending yard before the next setup.
@@ -62,6 +71,7 @@ export function runPlayJSONAnimationBuilder(
   visionCheck?: VisionCheckResult,
   runLaneTarget?: RunLaneTargetResult,
   dlSwipeResult?: DlSwipeResult | null,
+  firstChallenge?: FirstRunChallenge,
   random: () => number = Math.random,
 ): RunAnimationPlan {
   const formation = options.formation ?? {};
@@ -203,10 +213,97 @@ export function runPlayJSONAnimationBuilder(
   const swipeBlockerLane = dlSwipeResult?.slot;
   const chosenHoleLane = runLaneTarget?.selectedSlot ?? handoffLane;
   const hiddenLabels = labels.map((label) => ({ ...label, visible: false }));
+  const challengeDefenderId = firstChallenge
+    ? defenseIds.get(firstChallenge.defender)
+    : undefined;
+  const challengeYard = Number(
+    (los + direction * (firstChallenge?.accelerationYards ?? 0)).toFixed(2),
+  );
+  const challengeAssignment = firstChallenge
+    ? defense.find((assignment) => assignment.player === firstChallenge.defender)
+    : undefined;
+  const challengeLane = challengeAssignment?.align ?? chosenHoleLane;
+  const cutLanes = ["LTL", "LT", "LG", "CL", "C", "CR", "RG", "RT", "RTR"];
+  const holeIndex = Math.max(0, cutLanes.indexOf(chosenHoleLane));
+  const fakeLeft = random() < 0.5;
+  const fakeLane = cutLanes[
+    Math.max(0, Math.min(cutLanes.length - 1, holeIndex + (fakeLeft ? -1 : 1)))
+  ];
+  const cutLane = cutLanes[
+    Math.max(0, Math.min(cutLanes.length - 1, holeIndex + (fakeLeft ? 1 : -1)))
+  ];
 
-  // Phase three currently specializes only the completed "hit hole + swipe"
-  // branch. Other outcomes retain the existing result animation until their
-  // first-challenge choreography is implemented.
+  const firstChallengePhases: Array<Record<string, unknown>> = firstChallenge
+    ? [
+        {
+          id: "accelerate-to-first-challenge",
+          caption: `${runnerName} accelerates through the hole and meets ${firstChallenge.defender}.`,
+          durationMs: 650,
+          players: [
+            ...(runnerId
+              ? [{ playerId: runnerId, lane: chosenHoleLane, yard: challengeYard, className: "ball-carrier accelerating" }]
+              : []),
+            ...(challengeDefenderId
+              ? [{ playerId: challengeDefenderId, lane: challengeLane, yard: challengeYard, className: "chasing" }]
+              : []),
+          ],
+          labels: hiddenLabels,
+          football: { mode: "carrier", carrierId: runnerId },
+        },
+        firstChallenge.wrapped
+          ? {
+              id: "first-challenge-wrap-tackle",
+              caption: `${firstChallenge.defender} wraps up ${runnerName} at the point of contact.`,
+              durationMs: 450,
+              holdMs: 350,
+              players: [
+                ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: challengeYard, className: "tackled" }] : []),
+                ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: chosenHoleLane, yard: challengeYard, className: "tackling" }] : []),
+              ],
+              football: { mode: "carrier", carrierId: runnerId },
+            }
+          : firstChallenge.attempt === "Juke"
+            ? {
+                id: firstChallenge.moveSucceeded ? "first-challenge-juke" : "first-challenge-failed-juke",
+                caption: firstChallenge.moveSucceeded
+                  ? `${runnerName} steps ${fakeLeft ? "left" : "right"}, cuts back hard, and jukes ${firstChallenge.defender}.`
+                  : `${runnerName} cuts back, but ${firstChallenge.defender} delivers an immediate tackle.`,
+                durationMs: 700,
+                holdMs: firstChallenge.moveSucceeded ? 150 : 350,
+                players: [
+                  ...(runnerId
+                    ? [{
+                        playerId: runnerId,
+                        path: [
+                          { lane: fakeLane, yard: challengeYard, className: "juking", durationMs: 250 },
+                          { lane: cutLane, yard: firstChallenge.moveSucceeded ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "ball-carrier accelerating" : "tackled", durationMs: 450 },
+                        ],
+                      }]
+                    : []),
+                  ...(challengeDefenderId
+                    ? [{ playerId: challengeDefenderId, lane: cutLane, yard: challengeYard, className: firstChallenge.moveSucceeded ? "juked" : "tackling" }]
+                    : []),
+                ],
+                football: { mode: "carrier", carrierId: runnerId },
+              }
+            : {
+                id: "first-challenge-truck",
+                caption: firstChallenge.moveSucceeded
+                  ? `${runnerName} trucks through ${firstChallenge.defender}.`
+                  : `${firstChallenge.defender} stands up ${runnerName}'s truck attempt.`,
+                durationMs: 600,
+                holdMs: firstChallenge.moveSucceeded ? 150 : 350,
+                players: [
+                  ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: firstChallenge.moveSucceeded ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "trucking" : "tackled" }] : []),
+                  ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: chosenHoleLane, yard: challengeYard, className: firstChallenge.moveSucceeded ? "trucked" : "tackling" }] : []),
+                ],
+                football: { mode: "carrier", carrierId: runnerId },
+              },
+      ]
+    : [];
+
+  // The resolved play selects either the line swipe or first-challenge
+  // choreography; animation randomness is limited to the juke's fake side.
   const resultPhases: Array<Record<string, unknown>> = successfulHoleSwipe
     ? [
         {
@@ -285,7 +382,9 @@ export function runPlayJSONAnimationBuilder(
           football: { mode: "carrier", carrierId: runnerId },
         },
       ]
-    : [
+    : firstChallengePhases.length > 0
+      ? firstChallengePhases
+      : [
         {
           id: "run-result",
           caption: `${runnerName} runs for ${yardsGained} yard${Math.abs(yardsGained) === 1 ? "" : "s"}.`,


### PR DESCRIPTION
### Motivation
- Provide explicit phase-three and phase-four choreography when a runner hits the hole and meets a first-line challenger so the animation matches the simulated result.
- Support both wrap-tackle and runner counter-moves (juke or truck) with a randomized juke fake direction and visual markers for juked/trucked defenders.

### Description
- Add a `FirstRunChallenge` type and propagate a `firstChallenge` parameter from `runPlay` into `runPlayJSONAnimationBuilder` so the animation can consume the resolved second-level interaction.
- Collect the resolved second-level challenger, acceleration yards, wrap result, chosen move, and move outcome in `runEngine.runPlay` and pass it into the animation builder.
- Implement `firstChallengePhases` in `runPlayJSONAnimationBuilder` to animate acceleration-to-challenge, wrap-tackle, juke (with randomized fake side and hard cut), failed-juke immediate tackle, and truck attempts, and fall back to existing swipe/result phases when appropriate.
- Add CSS states in `GameField.css` for `.token.juked` and `.token.trucked` to visually mark defenders after those outcomes.

### Testing
- Ran `npm run build` (TypeScript build + `vite build`) and the build completed successfully.
- Ran `npm run lint` and ESLint completed without blocking errors.
- Ran `git diff --check` and pre-commit checks passed with no remaining whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a664cad684083249dc7f9a27cbf2b8d)