### PR TITLE
Animate truck attempts and post-contact defender drags

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -345,6 +345,14 @@ body {
     0 8px 18px rgba(0, 0, 0, 0.5);
 }
 
+.token.lowering-shoulder img {
+  transform: translateY(5px) rotate(8deg) scale(1.04);
+  box-shadow:
+    0 0 0 4px rgba(249, 115, 22, 0.9),
+    0 0 28px rgba(249, 115, 22, 0.8),
+    0 8px 18px rgba(0, 0, 0, 0.5);
+}
+
 .token.chasing img {
   box-shadow:
     0 0 0 4px rgba(251, 113, 133, 0.75),

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -449,6 +449,7 @@ export function runPlay(
           lbSecondLevelResult.secondChanceAttempt?.attempt === "Juke"
             ? lbSecondLevelResult.jukeResult?.juked
             : lbSecondLevelResult.truckResult?.trucked,
+        carryYards: lbSecondLevelResult.carryDefenderResult?.yardsAdded,
       };
     }
 

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -54,6 +54,7 @@ export type FirstRunChallenge = {
   wrapped: boolean;
   attempt?: "Juke" | "Truck";
   moveSucceeded?: boolean;
+  carryYards?: number;
 };
 
 /**
@@ -286,20 +287,39 @@ export function runPlayJSONAnimationBuilder(
                 ],
                 football: { mode: "carrier", carrierId: runnerId },
               }
-            : {
-                id: "first-challenge-truck",
-                caption: firstChallenge.moveSucceeded
-                  ? `${runnerName} trucks through ${firstChallenge.defender}.`
-                  : `${firstChallenge.defender} stands up ${runnerName}'s truck attempt.`,
-                durationMs: 600,
-                holdMs: firstChallenge.moveSucceeded ? 150 : 350,
-                players: [
-                  ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: firstChallenge.moveSucceeded ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "trucking" : "tackled" }] : []),
-                  ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: chosenHoleLane, yard: challengeYard, className: firstChallenge.moveSucceeded ? "trucked" : "tackling" }] : []),
-                ],
-                football: { mode: "carrier", carrierId: runnerId },
-              },
+            : [
+                {
+                  id: "first-challenge-truck-attempt",
+                  caption: `${runnerName} lowers his shoulder and tries to power through ${firstChallenge.defender}.`,
+                  durationMs: 350,
+                  players: [
+                    ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: challengeYard, className: "lowering-shoulder" }] : []),
+                    ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: chosenHoleLane, yard: challengeYard, className: "tackling" }] : []),
+                  ],
+                  football: { mode: "carrier", carrierId: runnerId },
+                },
+                {
+                  id: firstChallenge.moveSucceeded
+                    ? "first-challenge-truck"
+                    : firstChallenge.carryYards
+                      ? "first-challenge-truck-drag"
+                      : "first-challenge-failed-truck",
+                  caption: firstChallenge.moveSucceeded
+                    ? `${runnerName} trucks through ${firstChallenge.defender}.`
+                    : firstChallenge.carryYards
+                      ? `${firstChallenge.defender} stops the truck, but ${runnerName} drags him for ${firstChallenge.carryYards} ${firstChallenge.carryYards === 1 ? "yard" : "yards"}.`
+                      : `${firstChallenge.defender} stands up ${runnerName}'s truck attempt and tackles him at contact.`,
+                  durationMs: 600,
+                  holdMs: firstChallenge.moveSucceeded ? 150 : 350,
+                  players: [
+                    ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: firstChallenge.moveSucceeded || firstChallenge.carryYards ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "trucking" : "tackled" }] : []),
+                    ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: chosenHoleLane, yard: firstChallenge.carryYards ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "trucked" : "tackling" }] : []),
+                  ],
+                  football: { mode: "carrier", carrierId: runnerId },
+                },
+              ],
       ]
+        .flat()
     : [];
 
   // The resolved play selects either the line swipe or first-challenge


### PR DESCRIPTION
### Motivation

- Improve run animations to reflect a runner lowering his shoulder to `truck` at second level and to visually represent when a failed truck carries (drags) the defender for extra yards.

### Description

- Add `carryYards` to the `FirstRunChallenge` type and populate it from the linebackers-phase result in `runEngine.ts` by passing `lbSecondLevelResult.carryDefenderResult?.yardsAdded` into the `firstChallenge` metadata.
- Update `runPlayJSONAnimationBuilder.ts` to insert a dedicated truck-attempt phase where the runner lowers his shoulder and to emit distinct follow-up phases for successful trucks, failed trucks that drag the defender forward, and failed trucks that stop at contact, using the `carryYards` value to choose captions and end positions.
- Flatten the composed truck-phase array to keep the phase list shape and preserve existing behavior for jukes and swipe outcomes.
- Add visual styling for the shoulder-lowering posture via a new `.token.lowering-shoulder` rule in `GameField.css` so the animation has a distinct appearance during the truck attempt.

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and no lint errors were reported.
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a664e6a85008324afaeb21d78a69cc8)