### PR TITLE
Show run-lane cuts and every resolved tackler

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -583,6 +583,7 @@ export function runPlay(
       runLaneTarget,
       dlSwipeResult,
       firstChallenge,
+      tackler,
     ),
   });
 

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -73,6 +73,7 @@ export function runPlayJSONAnimationBuilder(
   runLaneTarget?: RunLaneTargetResult,
   dlSwipeResult?: DlSwipeResult | null,
   firstChallenge?: FirstRunChallenge,
+  tacklerName = "NA",
   random: () => number = Math.random,
 ): RunAnimationPlan {
   const formation = options.formation ?? {};
@@ -224,6 +225,7 @@ export function runPlayJSONAnimationBuilder(
     ? defense.find((assignment) => assignment.player === firstChallenge.defender)
     : undefined;
   const challengeLane = challengeAssignment?.align ?? chosenHoleLane;
+  const tacklerId = defenseIds.get(tacklerName);
   const cutLanes = ["LTL", "LT", "LG", "CL", "C", "CR", "RG", "RT", "RTR"];
   const holeIndex = Math.max(0, cutLanes.indexOf(chosenHoleLane));
   const fakeLeft = random() < 0.5;
@@ -414,7 +416,7 @@ export function runPlayJSONAnimationBuilder(
             ? [
                 {
                   playerId: runnerId,
-                  lane: handoffLane,
+                  lane: chosenHoleLane,
                   yard: resultYard,
                   className: "ball-carrier",
                 },
@@ -429,6 +431,74 @@ export function runPlayJSONAnimationBuilder(
           },
         },
       ];
+
+  const firstChallengeShowsTackle = Boolean(
+    firstChallenge &&
+      (firstChallenge.wrapped ||
+        (!firstChallenge.moveSucceeded && firstChallenge.attempt)),
+  );
+  const needsFinalTackle = Boolean(
+    tacklerName &&
+      tacklerName !== "NA" &&
+      tacklerId &&
+      !successfulHoleSwipe &&
+      !firstChallengeShowsTackle,
+  );
+  const finalTacklePhase: Array<Record<string, unknown>> = needsFinalTackle
+    ? [
+        {
+          id: "final-tackle",
+          caption: `${tacklerName} closes on ${runnerName} and makes the tackle.`,
+          durationMs: 500,
+          holdMs: 400,
+          players: [
+            ...(runnerId
+              ? [
+                  {
+                    playerId: runnerId,
+                    lane: chosenHoleLane,
+                    yard: resultYard,
+                    className: "tackled",
+                  },
+                ]
+              : []),
+            {
+              playerId: tacklerId,
+              lane: chosenHoleLane,
+              yard: resultYard,
+              className: "tackling",
+            },
+          ],
+          football: { mode: "carrier", carrierId: runnerId },
+        },
+      ]
+    : [];
+
+  // On successful reads, make the backfield cut its own phase. This prevents
+  // the carrier from appearing to run straight through a winning lineman and
+  // establishes the blocker-created gap before any upfield acceleration.
+  const chooseLanePhases: Array<Record<string, unknown>> =
+    visionCheck?.getsPastDL && runLaneTarget?.selectedSide === "OL"
+      ? [
+          {
+            id: "choose-run-lane",
+            caption: `${runnerName} presses the backfield, then cuts behind ${runLaneTarget.selectedPlayer}.`,
+            durationMs: 450,
+            players: runnerId
+              ? [
+                  {
+                    playerId: runnerId,
+                    lane: chosenHoleLane,
+                    yard: Number((los - direction * 2.25).toFixed(2)),
+                    className: "ball-carrier choosing-lane",
+                  },
+                ]
+              : [],
+            labels: hiddenLabels,
+            football: { mode: "carrier", carrierId: runnerId },
+          },
+        ]
+      : [];
 
   return {
     meta: {
@@ -473,7 +543,9 @@ export function runPlayJSONAnimationBuilder(
         labels,
         football: { mode: "carrier", carrierId: runnerId },
       },
+      ...chooseLanePhases,
       ...resultPhases,
+      ...finalTacklePhase,
     ],
   };
 }


### PR DESCRIPTION
### Motivation

- Make the visual run choreography match the simulation by explicitly showing when and who makes tackles. 
- Ensure the ball-carrier visibly picks the correct hole and cuts behind the blocker before accelerating upfield.

### Description

- Pass the resolved `tackler` from the run simulation into `runPlayJSONAnimationBuilder` (`runEngine.ts` -> `runPlayJSONAnimationBuilder` call).
- Add a terminal `final-tackle` phase that places the credited defender on the carrier with `tackling`/`tackled` visuals when earlier choreography hasn’t already shown the tackle (`runPlayJSONAnimationBuilder.ts`).
- Insert a `choose-run-lane` backfield phase so the runner presses the backfield and cuts behind the winning offensive lineman before accelerating, and keep the carrier in the selected hole lane for the run result (`runPlayJSONAnimationBuilder.ts`).
- Avoid duplicating tackle visuals when first-challenge or successful swipe choreography already depicted the stop; compute when the final-tackle phase is needed and append it to `phases` (`runPlayJSONAnimationBuilder.ts`).
- Modified files: `apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts` and `apps/web/src/components/league/gameplay/engine/runEngine.ts`.

### Testing

- `npm run build` (apps/web) completed successfully (TypeScript build + `vite build`).
- `npm run lint` (apps/web) completed successfully (`eslint` passed).
- `git diff --check` completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a664fb8fb1c832490c0208958928182)