### PR TITLE
Animate sequential rushing challenges realistically

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -181,7 +181,7 @@ export function runPlay(
   let bruiserCarryDefenderResult: ReturnType<
     typeof performCarryDefenderChecks
   > | null = null;
-  let firstChallenge: FirstRunChallenge | undefined;
+  let runChallenges: FirstRunChallenge[] = [];
 
   // Backfield branch: the runner missed the hole and must beat the winning DL.
   if (!visionCheck.getsPastDL) {
@@ -438,20 +438,18 @@ export function runPlay(
       jukedBackfieldDefenders,
     );
 
-    if (lbSecondLevelResult?.linebacker && lbSecondLevelResult.wrapResult) {
-      firstChallenge = {
-        defender: lbSecondLevelResult.linebacker.player,
-        position: lbSecondLevelResult.linebacker.position,
-        accelerationYards: accelToSecondLevelYards,
-        wrapped: lbSecondLevelResult.wrapResult.wrapped,
-        attempt: lbSecondLevelResult.secondChanceAttempt?.attempt,
-        moveSucceeded:
-          lbSecondLevelResult.secondChanceAttempt?.attempt === "Juke"
-            ? lbSecondLevelResult.jukeResult?.juked
-            : lbSecondLevelResult.truckResult?.trucked,
-        carryYards: lbSecondLevelResult.carryDefenderResult?.yardsAdded,
-      };
-    }
+    runChallenges = (lbSecondLevelResult?.challenges ?? []).map((challenge) => ({
+      defender: challenge.linebacker.player,
+      position: challenge.linebacker.position,
+      accelerationYards: challenge.challengeYards,
+      wrapped: challenge.wrapResult.wrapped,
+      attempt: challenge.secondChanceAttempt?.attempt,
+      moveSucceeded:
+        challenge.secondChanceAttempt?.attempt === "Juke"
+          ? challenge.jukeResult?.juked
+          : challenge.truckResult?.trucked,
+      carryYards: challenge.carryDefenderResult?.yardsAdded,
+    }));
 
     console.log("LB second level result:", lbSecondLevelResult);
   }
@@ -582,7 +580,7 @@ export function runPlay(
       visionCheck,
       runLaneTarget,
       dlSwipeResult,
-      firstChallenge,
+      runChallenges,
       tackler,
       runState.log.some((entry) => /\bBreakaway\b/.test(entry) && !/skipped/i.test(entry)),
     ),

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -1351,6 +1351,18 @@ export type LbSecondLevelResult = {
   truckAccelerationResult?: TruckOrJukeAccelerationResult;
   nextLevelPressure?: LbNextLevelPressureResult;
   stopped: boolean;
+  /** Every contact in order, including contacts reached after a successful move. */
+  challenges: LbSecondLevelChallenge[];
+};
+
+export type LbSecondLevelChallenge = {
+  linebacker: DefensiveAssignment;
+  challengeYards: number;
+  wrapResult: DefenderWrapResult;
+  jukeResult?: LbJukeResult;
+  carryDefenderResult?: CarryDefenderResult;
+  secondChanceAttempt?: RunnerDefenderSecondChanceAttempt;
+  truckResult?: TruckAttemptResult;
 };
 
 export type LbNextLevelPressureResult = {
@@ -1439,7 +1451,7 @@ export function resolveLinebackerSecondLevel(
       `${runState.runner} reaches the second level with no linebacker in position and breaks into the secondary.`,
     );
     addSecondarySpeedYards(runState, players, settings, defenseFormation);
-    return { stopped: false };
+    return { stopped: false, challenges: [] };
   }
 
   const restartSecondLevelCycle = (
@@ -1531,6 +1543,7 @@ export function resolveLinebackerSecondLevel(
   );
 
   const wrapResult = performDefenderWrapCheck(linebacker.player, players);
+  const challengeYards = runState.yards;
   let carryDefenderResult: CarryDefenderResult | undefined;
   let fallForwardResult: FallForwardResult | undefined;
   let jukeResult: LbJukeResult | undefined;
@@ -1586,6 +1599,18 @@ export function resolveLinebackerSecondLevel(
             secondChanceAttempt,
             truckResult,
             stopped: runState.stopped,
+            challenges: [
+              {
+                linebacker,
+                challengeYards,
+                wrapResult,
+                jukeResult,
+                carryDefenderResult,
+                secondChanceAttempt,
+                truckResult,
+              },
+              ...recursiveResult.challenges,
+            ],
           };
         }
       } else {
@@ -1633,6 +1658,18 @@ export function resolveLinebackerSecondLevel(
             secondChanceAttempt,
             truckResult,
             stopped: runState.stopped,
+            challenges: [
+              {
+                linebacker,
+                challengeYards,
+                wrapResult,
+                jukeResult,
+                carryDefenderResult,
+                secondChanceAttempt,
+                truckResult,
+              },
+              ...recursiveResult.challenges,
+            ],
           };
         }
       }
@@ -1648,6 +1685,15 @@ export function resolveLinebackerSecondLevel(
     secondChanceAttempt,
     truckResult,
     stopped: runState.stopped,
+    challenges: [{
+      linebacker,
+      challengeYards,
+      wrapResult,
+      jukeResult,
+      carryDefenderResult,
+      secondChanceAttempt,
+      truckResult,
+    }],
   };
 }
 

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -79,7 +79,7 @@ export function runPlayJSONAnimationBuilder(
   visionCheck?: VisionCheckResult,
   runLaneTarget?: RunLaneTargetResult,
   dlSwipeResult?: DlSwipeResult | null,
-  firstChallenge?: FirstRunChallenge,
+  runChallenges: FirstRunChallenge[] = [],
   tacklerName = "NA",
   isBreakaway = false,
   random: () => number = Math.random,
@@ -236,6 +236,7 @@ export function runPlayJSONAnimationBuilder(
   const swipeBlockerLane = dlSwipeResult?.slot;
   const chosenHoleLane = runLaneTarget?.selectedSlot ?? handoffLane;
   const hiddenLabels = labels.map((label) => ({ ...label, visible: false }));
+  const firstChallenge = runChallenges[0];
   const challengeDefenderId = firstChallenge
     ? defenseIds.get(firstChallenge.defender)
     : undefined;
@@ -321,11 +322,11 @@ export function runPlayJSONAnimationBuilder(
                         path: jukeMove === "spin"
                           ? [
                               { lane: chosenHoleLane, yard: challengeYard, className: "spinning", durationMs: 400 },
-                              { lane: chosenHoleLane, yard: firstChallenge.moveSucceeded && !isBreakaway ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "ball-carrier accelerating" : "tackled", durationMs: 300 },
+                              { lane: chosenHoleLane, yard: challengeYard, className: firstChallenge.moveSucceeded ? "ball-carrier accelerating" : "tackled", durationMs: 300 },
                             ]
                           : [
                               { lane: fakeLane, yard: challengeYard, className: "juking", durationMs: 250 },
-                              { lane: cutLane, yard: firstChallenge.moveSucceeded && !isBreakaway ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? "ball-carrier accelerating" : "tackled", durationMs: 450 },
+                              { lane: cutLane, yard: challengeYard, className: firstChallenge.moveSucceeded ? "ball-carrier accelerating" : "tackled", durationMs: 450 },
                             ],
                       }]
                     : []),
@@ -364,7 +365,7 @@ export function runPlayJSONAnimationBuilder(
                   durationMs: 600,
                   holdMs: firstChallenge.moveSucceeded ? 150 : 350,
                   players: [
-                    ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: firstChallenge.moveSucceeded && isBreakaway ? challengeYard : firstChallenge.moveSucceeded || firstChallenge.carryYards ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? powerMove === "truck" ? "trucking" : "stiff-arming" : "tackled" }] : []),
+                    ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: firstChallenge.moveSucceeded ? challengeYard : firstChallenge.carryYards ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? powerMove === "truck" ? "trucking" : "stiff-arming" : "tackled" }] : []),
                     ...(challengeDefenderId ? [{ playerId: challengeDefenderId, lane: firstChallenge.moveSucceeded && powerMove === "stiff-arm" ? stiffArmLane : chosenHoleLane, yard: firstChallenge.carryYards ? resultYard : challengeYard, className: firstChallenge.moveSucceeded ? powerMove === "truck" ? "trucked" : "stiff-armed" : "tackling" }] : []),
                   ],
                   football: { mode: "carrier", carrierId: runnerId },
@@ -373,6 +374,53 @@ export function runPlayJSONAnimationBuilder(
       ]
         .flat()
     : [];
+
+  // A runner can beat several defenders. Preserve every simulation contact in
+  // the animation instead of jumping from the first move to the final spot.
+  // Each pursuit phase brings the *next* challenger to the contact point while
+  // the runner accelerates there, so the defender is established before the
+  // tackle, juke, or truck begins.
+  const followingChallengePhases: Array<Record<string, unknown>> = runChallenges
+    .slice(1)
+    .flatMap((challenge, index) => {
+      const defenderId = defenseIds.get(challenge.defender);
+      const assignment = defense.find(({ player }) => player === challenge.defender);
+      const lane = assignment?.align ?? chosenHoleLane;
+      const yard = Number((los + direction * challenge.accelerationYards).toFixed(2));
+      const succeeded = Boolean(challenge.moveSucceeded);
+      const move = challenge.attempt?.toLowerCase() ?? "wrap";
+      const stopped = challenge.wrapped || (challenge.attempt && !succeeded);
+      return [
+        {
+          id: `pursuit-to-challenge-${index + 2}`,
+          caption: `${runnerName} tries to accelerate away, but ${challenge.defender} closes at the next challenge point.`,
+          durationMs: 650,
+          players: [
+            ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard, className: "ball-carrier accelerating" }] : []),
+            ...(defenderId ? [{ playerId: defenderId, lane, yard, className: "chasing" }] : []),
+          ],
+          labels: hiddenLabels,
+          football: { mode: "carrier", carrierId: runnerId },
+        },
+        {
+          id: `challenge-${index + 2}-${stopped ? "tackle" : move}`,
+          caption: challenge.wrapped
+            ? `${challenge.defender} gets into position and wraps up ${runnerName}.`
+            : succeeded
+              ? `${runnerName} ${move === "juke" ? "jukes" : "trucks through"} ${challenge.defender} and looks to accelerate again.`
+              : `${challenge.defender} defeats ${runnerName}'s ${move} attempt and makes the tackle.`,
+          durationMs: 600,
+          holdMs: stopped ? 350 : 150,
+          players: [
+            ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard, className: stopped ? "tackled" : move === "juke" ? "juking" : "trucking" }] : []),
+            ...(defenderId ? [{ playerId: defenderId, lane: chosenHoleLane, yard, className: stopped ? "tackling" : move === "juke" ? "juked" : "trucked" }] : []),
+          ],
+          football: { mode: "carrier", carrierId: runnerId },
+        },
+      ];
+    });
+
+  const challengePhases = [...firstChallengePhases, ...followingChallengePhases];
 
   // The resolved play selects either the line swipe or first-challenge
   // choreography; animation randomness only selects the juke fake side and
@@ -455,8 +503,8 @@ export function runPlayJSONAnimationBuilder(
           football: { mode: "carrier", carrierId: runnerId },
         },
       ]
-    : firstChallengePhases.length > 0
-      ? firstChallengePhases
+    : challengePhases.length > 0
+      ? challengePhases
       : [
         {
           id: "run-result",
@@ -483,10 +531,11 @@ export function runPlayJSONAnimationBuilder(
         },
       ];
 
+  const lastChallenge = runChallenges.at(-1);
   const firstChallengeShowsTackle = Boolean(
-    firstChallenge &&
-      (firstChallenge.wrapped ||
-        (!firstChallenge.moveSucceeded && firstChallenge.attempt)),
+    lastChallenge &&
+      (lastChallenge.wrapped ||
+        (!lastChallenge.moveSucceeded && lastChallenge.attempt)),
   );
   const needsFinalTackle = Boolean(
     tacklerName &&
@@ -497,6 +546,16 @@ export function runPlayJSONAnimationBuilder(
   );
   const finalTacklePhase: Array<Record<string, unknown>> = needsFinalTackle
     ? [
+        {
+          id: "final-tackle-pursuit",
+          caption: `${tacklerName} tracks ${runnerName} into position for the final challenge.`,
+          durationMs: 550,
+          players: [
+            ...(runnerId ? [{ playerId: runnerId, lane: chosenHoleLane, yard: resultYard, className: "ball-carrier accelerating" }] : []),
+            { playerId: tacklerId, lane: chosenHoleLane, yard: resultYard, className: "chasing" },
+          ],
+          football: { mode: "carrier", carrierId: runnerId },
+        },
         {
           id: "final-tackle",
           caption: `${tacklerName} closes on ${runnerName} and makes the tackle.`,


### PR DESCRIPTION
### Motivation
- Ensure the full ordered sequence of second-level rushing challenges is preserved so successful jukes/trucks can naturally lead into additional defender challenges instead of skipping to the play end. 
- Make the animation reflect defenders moving into position during the phases leading up to a challenge so challengers do not appear to "fly in" at contact.

### Description
- Add a `LbSecondLevelChallenge` type and a `challenges: LbSecondLevelChallenge[]` field on `LbSecondLevelResult` to record every second-level contact and its `challengeYards` in `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts`.
- Capture the ordered `runChallenges` in the run resolution and pass the full sequence into the animation builder by changing `runPlay` to produce and pass `runChallenges` from `apps/web/src/components/league/gameplay/engine/runEngine.ts`.
- Update `apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts` to accept `runChallenges`, use the first challenge for initial choreography, and build `followingChallengePhases` from subsequent challenges so each upcoming defender is animated closing into position before contact; also adjust challenge-phase yard assignments so the defender is placed in position prior to tackles/jukes/trucks.
- Add a visible pursuit setup phase (`final-tackle-pursuit`) before fallback final tackles so a closing tackler visibly tracks the runner into position.

### Testing
- Ran `npm run build` in the web app and the build completed successfully.
- Ran `npm run lint` and no lint errors were reported.
- Ran `git diff --check` and there were no whitespace or index issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66562817348324ae8d7be51e615f14)