### PR TITLE
Add clickable rushing player profiles and game logs

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -288,6 +288,53 @@ async function savePlayAndGameWithRetry(data: Record<string, unknown>, gameId: s
 gameRoutes.get("/health", (_req, res) => res.json({ ok: true, app: "football-game-api", message: "API is running" }));
 gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await readSheetObjects("Players!A1:AM") }); } catch (e) { next(e); } });
 gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AI") }); } catch (e) { next(e); } });
+gameRoutes.get("/players/:playerName/rushing-games", async (req, res, next) => {
+  try {
+    const [gamesSheet, historySheet] = await Promise.all([sheetRows("Games"), sheetRows("PlayHistory")]);
+    const playerName = req.params.playerName.trim().toLowerCase();
+    const index = (headers: string[], ...names: string[]) =>
+      headers.findIndex((header) => names.includes(normHeader(header)));
+    const playGame = index(historySheet.headers, "gameid");
+    const playPlayer = index(historySheet.headers, "player", "rusher");
+    const playType = index(historySheet.headers, "playtype");
+    const playYards = index(historySheet.headers, "yards", "yardsgained");
+    const playResult = index(historySheet.headers, "result", "description");
+    const rushes = historySheet.rows.filter((row) =>
+      String(cell(row, playPlayer)).trim().toLowerCase() === playerName &&
+      (!cell(row, playType) || /run|rush/i.test(String(cell(row, playType)))),
+    );
+    const byGame = new Map<string, Row[]>();
+    rushes.forEach((row) => {
+      const id = String(cell(row, playGame));
+      byGame.set(id, [...(byGame.get(id) ?? []), row]);
+    });
+    const gameId = index(gamesSheet.headers, "id", "gameid");
+    const home = index(gamesSheet.headers, "home");
+    const away = index(gamesSheet.headers, "away");
+    const homeScore = index(gamesSheet.headers, "homescore");
+    const awayScore = index(gamesSheet.headers, "awayscore");
+    const date = index(gamesSheet.headers, "date", "gamedate");
+    const possession = index(historySheet.headers, "possession", "team");
+    const games = gamesSheet.rows.flatMap((game) => {
+      const id = String(cell(game, gameId));
+      const plays = byGame.get(id);
+      if (!plays?.length) return [];
+      const homeTeam = String(cell(game, home));
+      const awayTeam = String(cell(game, away));
+      const playerTeam = String(cell(plays[0], possession));
+      const isHome = playerTeam.toLowerCase() === "home" || playerTeam === homeTeam;
+      const teamScore = asNumber(cell(game, isHome ? homeScore : awayScore));
+      const opponentScore = asNumber(cell(game, isHome ? awayScore : homeScore));
+      const yards = plays.map((play) => asNumber(cell(play, playYards)));
+      const touchdowns = plays.filter((play) => /touchdown|\btd\b/i.test(String(cell(play, playResult)))).length;
+      return [{ gameId: id, opponent: isHome ? awayTeam : homeTeam, location: isHome ? "vs" : "@",
+        result: `${teamScore > opponentScore ? "W" : teamScore < opponentScore ? "L" : "T"} ${teamScore}-${opponentScore}`,
+        carries: plays.length, yards: yards.reduce((sum, value) => sum + value, 0), touchdowns,
+        long: Math.max(0, ...yards), date: String(cell(game, date)) }];
+    });
+    res.json({ games });
+  } catch (e) { next(e); }
+});
 gameRoutes.get("/player-traits", async (_req, res, next) => { try { res.json({ players: await getPlayerTraitsFromSheet() }); } catch (e) { next(e); } });
 gameRoutes.get("/teams", async (_req, res, next) => { try { res.json({ teams: await getTeamsFromSheet() }); } catch (e) { next(e); } });
 gameRoutes.get("/games", async (_req, res, next) => { try { res.json({ games: await getGamesList() }); } catch (e) { next(e); } });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -37,6 +37,25 @@ export async function getPlayerStats(): Promise<{
 }> {
   return getJson("/player-stats", "Failed to load player stats");
 }
+export type PlayerRushingGame = {
+  gameId: string;
+  opponent: string;
+  location: "vs" | "@";
+  result: string;
+  carries: number;
+  yards: number;
+  touchdowns: number;
+  long: number;
+  date: string;
+};
+export async function getPlayerRushingGames(
+  playerName: string,
+): Promise<{ games: PlayerRushingGame[] }> {
+  return getJson(
+    `/players/${encodeURIComponent(playerName)}/rushing-games`,
+    "Failed to load player game log",
+  );
+}
 export async function getTeams(): Promise<{
   teams: Record<string, unknown>[];
 }> {

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getPlayers,
+  getPlayerRushingGames,
   getPlayerStats,
+  type PlayerRushingGame,
   type PlayerStats,
 } from "../../api/client";
 import type { Player } from "../players/types";
@@ -47,6 +49,7 @@ function LeaderTable({
   isLoading = false,
   error,
   onComplete,
+  onPlayerSelect,
 }: {
   title: string;
   stat: string;
@@ -55,6 +58,7 @@ function LeaderTable({
   isLoading?: boolean;
   error?: string | null;
   onComplete?: () => void;
+  onPlayerSelect?: (name: string) => void;
 }) {
   const placeholderLeaders = Array.from({ length: 5 }, (_, i) => ({
     name: `${kind} Name`,
@@ -87,7 +91,9 @@ function LeaderTable({
                 <td className="team-cell">
                   <span className="rank">{i + 1}</span>
                   <img className="player-stats-image" src={leader.image} alt="" />
-                  <span className="team-link">{leader.name}</span>
+                  <button className="team-link player-name-button" type="button" onClick={() => onPlayerSelect?.(leader.name)}>
+                    {leader.name}
+                  </button>
                 </td>
                 <td className="stat-value">{leader.value}</td>
               </tr>
@@ -114,6 +120,9 @@ export function LeagueStats() {
   const [error, setError] = useState<string | null>(null);
   const [showAllRushers, setShowAllRushers] = useState(false);
   const [rusherFilter, setRusherFilter] = useState("");
+  const [selectedPlayerName, setSelectedPlayerName] = useState<string | null>(null);
+  const [playerGames, setPlayerGames] = useState<PlayerRushingGame[]>([]);
+  const [isGameLogLoading, setIsGameLogLoading] = useState(false);
   const hasRequestedPlayerStats = useRef(false);
 
   useEffect(() => {
@@ -132,6 +141,20 @@ export function LeagueStats() {
       )
       .finally(() => setIsLoading(false));
   }, [activeView]);
+
+  useEffect(() => {
+    if (!selectedPlayerName) return;
+    getPlayerRushingGames(selectedPlayerName)
+      .then((result) => setPlayerGames(result.games))
+      .catch(() => setPlayerGames([]))
+      .finally(() => setIsGameLogLoading(false));
+  }, [selectedPlayerName]);
+
+  const selectPlayer = (name: string) => {
+    setPlayerGames([]);
+    setIsGameLogLoading(true);
+    setSelectedPlayerName(name);
+  };
 
   const rushingLeaders = useMemo(() => {
     const playersByName = new Map(
@@ -168,6 +191,61 @@ export function LeagueStats() {
           a.row.Player.localeCompare(b.row.Player),
       );
   }, [players, rusherFilter, stats]);
+
+  const selectedPlayer = players.find(
+    (player) => player.Name?.trim().toLowerCase() === selectedPlayerName?.toLowerCase(),
+  );
+  const selectedTotals = stats.find(
+    (row) => row.Player?.trim().toLowerCase() === selectedPlayerName?.toLowerCase(),
+  );
+
+  if (selectedPlayerName && selectedTotals) {
+    const average = Number(selectedTotals.Carries)
+      ? (Number(selectedTotals.Yards) / Number(selectedTotals.Carries)).toFixed(1)
+      : "0.0";
+    return (
+      <section className="player-rushing-profile">
+        <button className="profile-back" type="button" onClick={() => setSelectedPlayerName(null)}>← Back to rushing leaders</button>
+        <header className="player-profile-summary">
+          <div className="player-profile-image-wrap">
+            <img src={playerImage(selectedPlayer)} alt={selectedPlayerName} />
+          </div>
+          <div>
+            <p className="player-profile-kicker">{selectedPlayer?.Pos || "PLAYER"}</p>
+            <h2>{selectedPlayerName}</h2>
+            <p className="player-profile-team">{selectedPlayer?.Team || "Free Agent"}</p>
+            <dl className="player-profile-facts">
+              <div><dt>Position</dt><dd>{selectedPlayer?.Pos || "—"}</dd></div>
+              <div><dt>Offense</dt><dd>{selectedPlayer?.["Off Stars"] || "—"} stars</dd></div>
+              <div><dt>Speed</dt><dd>{selectedPlayer?.Speed || "—"}</dd></div>
+              <div><dt>Stamina</dt><dd>{selectedPlayer?.Stamina || "—"}</dd></div>
+            </dl>
+          </div>
+        </header>
+        <section className="season-totals-card">
+          <h3>Season 1 Rushing Totals</h3>
+          <div className="season-total-grid">
+            {[["CAR", selectedTotals.Carries], ["YDS", selectedTotals.Yards], ["TD", selectedTotals.TD || "0"], ["AVG", average], ["LONG", selectedTotals.Long || "0"]].map(([label, value]) => (
+              <div key={label}><span>{label}</span><strong>{value}</strong></div>
+            ))}
+          </div>
+        </section>
+        <section className="player-game-log">
+          <h3>Game Log</h3>
+          <div className="complete-leaders-table-scroll">
+            <table>
+              <thead><tr><th>Game</th><th>Opponent</th><th>Result</th><th>CAR</th><th>YDS</th><th>AVG</th><th>TD</th><th>LNG</th></tr></thead>
+              <tbody>
+                {isGameLogLoading ? <tr><td colSpan={8}>Loading game log…</td></tr> : playerGames.length === 0 ? <tr><td colSpan={8}>No game-by-game rushing stats available.</td></tr> : playerGames.map((game, index) => (
+                  <tr key={game.gameId}><td>{game.date || `Game ${index + 1}`}</td><td>{game.location} {game.opponent}</td><td><span className={`game-result ${game.result.startsWith("W") ? "win" : "loss"}`}>{game.result}</span></td><td>{game.carries}</td><td>{game.yards}</td><td>{game.carries ? (game.yards / game.carries).toFixed(1) : "0.0"}</td><td>{game.touchdowns}</td><td>{game.long}</td></tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+    );
+  }
 
   return (
     <>
@@ -229,7 +307,7 @@ export function LeagueStats() {
                           <tr key={row.Player}>
                             <td className="complete-leader-player">
                               <img className="player-stats-image" src={image} alt="" />
-                              <span>{row.Player}</span>
+                              <button className="player-name-button" type="button" onClick={() => selectPlayer(row.Player)}>{row.Player}</button>
                             </td>
                             {RUSHING_COLUMNS.map((column) => (
                               <td key={column}>{row[column] || "0"}</td>
@@ -250,6 +328,7 @@ export function LeagueStats() {
                 isLoading={isLoading}
                 error={error}
                 onComplete={() => setShowAllRushers(true)}
+                onPlayerSelect={selectPlayer}
               />
             )}
           </div>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -447,6 +447,64 @@
   align-items: center;
   gap: 0.65rem;
 }
+.player-name-button {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: #7cb7ff;
+  font: inherit;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+.player-name-button:hover,
+.player-name-button:focus-visible { color: #fff; }
+.player-rushing-profile { padding: clamp(1rem, 3vw, 2.5rem); }
+.profile-back {
+  margin-bottom: 1rem;
+  border: 0;
+  background: none;
+  color: #9ec9ff;
+  font: inherit;
+  cursor: pointer;
+}
+.player-profile-summary {
+  display: grid;
+  grid-template-columns: minmax(170px, 28%) 1fr;
+  gap: clamp(1.25rem, 4vw, 3.5rem);
+  align-items: center;
+  overflow: hidden;
+  background: linear-gradient(120deg, #151515, #252525);
+  border: 1px solid #3b3b3b;
+}
+.player-profile-image-wrap { align-self: stretch; min-height: 260px; background: radial-gradient(circle at 50% 60%, #444, #181818 70%); }
+.player-profile-image-wrap img { width: 100%; height: 100%; max-height: 340px; object-fit: contain; object-position: bottom; }
+.player-profile-kicker { margin: 0 0 .25rem; color: var(--accent-red); font-weight: 700; letter-spacing: .12em; }
+.player-profile-summary h2 { margin: 0; font-size: clamp(2rem, 5vw, 4rem); text-transform: uppercase; }
+.player-profile-team { margin: .35rem 0 1.25rem; color: var(--text-muted); font-size: 1.15rem; }
+.player-profile-facts { display: grid; grid-template-columns: repeat(2, minmax(100px, 190px)); gap: .8rem 2rem; margin: 0 1rem 1rem 0; }
+.player-profile-facts div { display: flex; justify-content: space-between; gap: 1rem; }
+.player-profile-facts dt { color: var(--text-muted); }
+.player-profile-facts dd { margin: 0; font-weight: 700; }
+.season-totals-card, .player-game-log { margin-top: 1.5rem; border: 1px solid var(--gray-light); background: var(--gray-medium); }
+.season-totals-card h3, .player-game-log h3 { margin: 0; padding: .75rem 1rem; background: #861117; text-transform: uppercase; letter-spacing: .04em; }
+.season-total-grid { display: grid; grid-template-columns: repeat(5, 1fr); }
+.season-total-grid div { display: grid; gap: .25rem; padding: 1.25rem; text-align: center; border-right: 1px solid var(--gray-light); }
+.season-total-grid span { color: var(--text-muted); font-size: .8rem; }
+.season-total-grid strong { font-size: clamp(1.5rem, 3vw, 2.4rem); }
+.player-game-log table { width: 100%; border-collapse: collapse; }
+.player-game-log th, .player-game-log td { padding: .8rem; border-bottom: 1px solid var(--gray-light); text-align: right; white-space: nowrap; }
+.player-game-log th:nth-child(-n+3), .player-game-log td:nth-child(-n+3) { text-align: left; }
+.game-result { font-weight: 700; }
+.game-result.win { color: #58d68d; }
+.game-result.loss { color: #ff7373; }
+@media (max-width: 640px) {
+  .player-profile-summary { grid-template-columns: 1fr; }
+  .player-profile-image-wrap { min-height: 210px; }
+  .player-profile-facts { grid-template-columns: 1fr; }
+  .season-total-grid { grid-template-columns: repeat(2, 1fr); }
+}
 .scoreboard {
   display: grid;
   grid-template-columns: 1fr auto 1fr;


### PR DESCRIPTION
### Motivation
- Make player names clickable in the rushing stats views so users can open a detailed player profile and game-by-game rushing log. 
- Surface a player image, season totals, and per-game outcomes to match the requested UI in the rushing stats experience. 

### Description
- Add a backend endpoint that aggregates rushing plays by game and joins them to the Games sheet to produce per-game rushing summaries at `GET /players/:playerName/rushing-games` (`apps/api/src/routes/gameRoutes.ts`).
- Add a typed client call `getPlayerRushingGames` and `PlayerRushingGame` type to the frontend API client (`apps/web/src/api/client.ts`).
- Make player names clickable in the rushing leader table and full rushing table and wire them to a `selectPlayer` flow that fetches and displays a player profile, season totals, and a per-game log (`apps/web/src/components/league/LeagueStats.tsx`).
- Add responsive styles and UI components for the player profile, season totals card, and game log including win/loss styling and clickable name styles (`apps/web/src/components/league/league.css`).

### Testing
- Ran API unit tests with `cd apps/api && npm test` and they passed. 
- Ran type checking for the API with `cd apps/api && npm run typecheck` and it succeeded. 
- Ran frontend lint and build with `cd apps/web && npm run lint` and `cd apps/web && npm run build`, both completed successfully. 
- Ran `git diff --check` to verify no outstanding whitespace/patch issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6656c3612c83249f6d7ae87ee09898)