### PR TITLE
Make rushing escapes and pursuit play out fully

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -583,6 +583,7 @@ export function runPlay(
       runChallenges,
       tackler,
       runState.log.some((entry) => /\bBreakaway\b/.test(entry) && !/skipped/i.test(entry)),
+      runState.pursuitEvents,
     ),
   });
 

--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -345,6 +345,7 @@ export function createRunPlayState(runner: string): RunPlayState {
     runner,
     stopped: false,
     log: [],
+    pursuitEvents: [],
   };
 }
 
@@ -883,6 +884,7 @@ function addSecondarySpeedYards(
   settings: FrontendSettings | undefined,
   defenseFormation: DefensiveAssignment[] = [],
 ) {
+  const pursuitStart = runState.yards;
   const secondarySpeedYards = getSecondarySpeedYards(
     findPlayerByName(players, runState.runner),
     settings,
@@ -901,9 +903,18 @@ function addSecondarySpeedYards(
     defenseFormation,
     players,
   );
+  if (pursuitResult?.chaser) {
+    runState.pursuitEvents.push({
+      stage: "secondary",
+      chaser: pursuitResult.chaser,
+      startYards: pursuitStart,
+      endYards: runState.yards,
+      escaped: pursuitResult.escaped,
+    });
+  }
   if (pursuitResult?.escaped) {
     addSecondaryBreakawayYards(runState, players, settings);
-    tackleByFastestSecondaryDefender(runState, defenseFormation, players);
+    resolveBreakawayPursuit(runState, defenseFormation, players, pursuitResult.chaser);
   }
 }
 
@@ -985,10 +996,11 @@ function addSecondaryBreakawayYards(
   }
 }
 
-function tackleByFastestSecondaryDefender(
+function resolveBreakawayPursuit(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
   players: PlayerTrait[],
+  initialChaser?: string,
 ) {
   if (runState.stopped) return;
 
@@ -1008,15 +1020,32 @@ function tackleByFastestSecondaryDefender(
 
   if (!fastestDefender) return;
 
-  handleRunnerTackle(
-    runState,
-    fastestDefender.assignment.player,
-    "Breakaway End Fastest Secondary Defender",
-    players,
+  const startYards = runState.yards;
+  const chaser = fastestDefender.assignment.player;
+  const runnerSpeed = trait(findPlayerByName(players, runState.runner), "speed");
+  // A defender already beaten in the first chase has less leverage on a second
+  // attempt; a new pursuit angle gets a small positioning advantage.
+  const catchChance = Math.max(
+    8,
+    Math.min(82, 48 + fastestDefender.speed - runnerSpeed + (chaser === initialChaser ? -12 : 6)),
   );
-  runState.log.push(
-    `${fastestDefender.assignment.player} makes the automatic tackle after the breakaway as the fastest DB/LB/S on the field.`,
-  );
+  const caught = Math.random() * 100 < catchChance;
+  if (caught) {
+    handleRunnerTackle(runState, chaser, "Breakaway Pursuit", players);
+    runState.log.push(`${chaser} stays in hot pursuit and tracks down ${runState.runner} after the breakaway.`);
+  } else {
+    // Crossing the goal line is clamped to the actual remaining field distance
+    // by runPlay's scoreboard resolution.
+    addYards(runState, 100, `${runState.runner} pulls away from ${chaser} and races to the end zone`);
+    runState.log.push(`${chaser} cannot close the gap; ${runState.runner} finishes the escape in the end zone.`);
+  }
+  runState.pursuitEvents.push({
+    stage: "breakaway",
+    chaser,
+    startYards,
+    endYards: runState.yards,
+    escaped: !caught,
+  });
 }
 
 export type SecondaryPursuitResult = {

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -57,6 +57,14 @@ export type FirstRunChallenge = {
   carryYards?: number;
 };
 
+export type RunPursuitEvent = {
+  stage: "secondary" | "breakaway";
+  chaser: string;
+  startYards: number;
+  endYards: number;
+  escaped: boolean;
+};
+
 /** Converts runner speed into an open-field animation pace of 6-9 yards/sec. */
 export const breakawayDurationMs = (yards: number, speed: number) => {
   const normalizedSpeed = Math.max(0, Math.min(100, speed));
@@ -82,6 +90,7 @@ export function runPlayJSONAnimationBuilder(
   runChallenges: FirstRunChallenge[] = [],
   tacklerName = "NA",
   isBreakaway = false,
+  pursuitEvents: RunPursuitEvent[] = [],
   random: () => number = Math.random,
 ): RunAnimationPlan {
   const formation = options.formation ?? {};
@@ -600,6 +609,45 @@ export function runPlayJSONAnimationBuilder(
       }]
     : [];
 
+  const pursuitPhases: Array<Record<string, unknown>> = pursuitEvents.flatMap((event, index) => {
+    const chaserId = defenseIds.get(event.chaser);
+    if (!runnerId || !chaserId) return [];
+    const endYard = event.escaped && event.stage === "breakaway"
+      ? (direction === 1 ? 100 : 0)
+      : Number((los + direction * event.endYards).toFixed(2));
+    const chaseYard = Number((los + direction * event.startYards).toFixed(2));
+    const prefix = `${event.stage}-pursuit-${index + 1}`;
+    return [
+      {
+        id: `${prefix}-chase`,
+        caption: `${event.chaser} is in hot pursuit of ${runnerName}.`,
+        durationMs: 800,
+        players: [
+          { playerId: runnerId, lane: chosenHoleLane, yard: chaseYard, className: "ball-carrier accelerating" },
+          { playerId: chaserId, lane: chosenHoleLane, yard: Number((chaseYard - direction * 2).toFixed(2)), className: "chasing" },
+        ],
+        labels: hiddenLabels,
+        football: { mode: "carrier", carrierId: runnerId },
+      },
+      {
+        id: `${prefix}-${event.escaped ? "escape" : "tackle"}`,
+        caption: event.escaped
+          ? event.stage === "breakaway"
+            ? `${runnerName} pulls away from ${event.chaser} and reaches the end zone!`
+            : `${runnerName} escapes ${event.chaser}, but the defense keeps chasing.`
+          : `${event.chaser} catches ${runnerName} from behind and makes the tackle.`,
+        durationMs: event.stage === "breakaway" ? openFieldDurationMs : 700,
+        holdMs: event.escaped ? 150 : 400,
+        players: [
+          { playerId: runnerId, lane: chosenHoleLane, yard: endYard, className: event.escaped ? "ball-carrier accelerating" : "tackled" },
+          { playerId: chaserId, lane: chosenHoleLane, yard: event.escaped ? Number((endYard - direction * 3).toFixed(2)) : endYard, className: event.escaped ? "chasing" : "tackling" },
+        ],
+        football: { mode: "carrier", carrierId: runnerId },
+        fieldEffects: { touchdownFlash: event.escaped && event.stage === "breakaway" },
+      },
+    ];
+  });
+
   const touchdownCelebrationPhase: Array<Record<string, unknown>> = isTouchdown
     ? [{
         id: "touchdown-celebration",
@@ -684,8 +732,8 @@ export function runPlayJSONAnimationBuilder(
       },
       ...chooseLanePhases,
       ...resultPhases,
-      ...breakawayPhase,
-      ...finalTacklePhase,
+      ...(pursuitPhases.length ? pursuitPhases : breakawayPhase),
+      ...(pursuitPhases.length ? [] : finalTacklePhase),
       ...touchdownCelebrationPhase,
     ],
   };

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -118,6 +118,13 @@ export type RunPlayState = {
   stopped: boolean;
   stopReason?: string;
   log: string[];
+  pursuitEvents: Array<{
+    stage: "secondary" | "breakaway";
+    chaser: string;
+    startYards: number;
+    endYards: number;
+    escaped: boolean;
+  }>;
 };
 export type LineStatMatchup = {
   slot: FormationSlot;


### PR DESCRIPTION
### Motivation

- Ensure recursive juke/truck interactions can lead to a real escape and that post-escape pursuit is resolved and visible in the animation instead of an automatic stop. 
- Record the secondary and breakaway pursuit outcomes so the animation can show who chased the runner, whether they closed the gap, and the resulting catch or successful breakaway to the end zone.

### Description

- Add `pursuitEvents` to `RunPlayState` in `types.ts` and initialize it in `createRunPlayState` to persist pursuit metadata across the run pipeline. 
- Record secondary pursuit results in `addSecondarySpeedYards` and push a `secondary` pursuit event when `resolveSecondaryPursuit` returns a chaser. 
- Replace the prior automatic post-breakaway tackle with `resolveBreakawayPursuit` in `runEngineHelper.ts`, which selects the best chaser, computes a speed-based catch chance, applies a real tackle on success or awards end-zone yards on failure, and appends a `breakaway` pursuit event. 
- Thread `runState.pursuitEvents` into `runPlayJSONAnimationBuilder`, add a `RunPursuitEvent` type, and generate `pursuitPhases` so each recorded chaser is animated in hot pursuit with distinct chase and result (tackle or escape/end-zone) phases that are played after the recursive juke/truck challenge choreography. 

### Testing

- Built the web app with `npm run build` and the build completed successfully. 
- Ran the linter with `npm run lint` and there were no lint failures. 
- Ran `git diff --check` to verify there are no whitespace or diff errors and it passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66582b6e28832490d830324e6741b7)