### PR TITLE
Keep the football visible on the ball carrier

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -460,7 +460,10 @@ body {
   background: #8b4513;
   border: 2px solid #f4d3a1;
   transform: translate(-50%, -50%) rotate(-20deg);
-  z-index: 90;
+  /* Keep the ball visible on top of the carrier. Runner/celebration tokens use
+     elevated stacking levels during a play and otherwise cover the football
+     even though its position is synchronized to the carrier. */
+  z-index: 130;
   transition:
     left 700ms ease,
     top 700ms ease,


### PR DESCRIPTION
### Motivation
- Ensure the animated football remains visually on top of the ball carrier during play animations because runner/celebration tokens can otherwise obscure it.

### Description
- Raise the `.football` stacking context in `apps/web/src/components/league/GameField.css` by changing `z-index` from `90` to `130` and add a clarifying comment explaining why the ball needs the highest in-play stacking level.

### Testing
- Ran `npm run build` which completed successfully; ran `npm run lint` which completed successfully; and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a681b88c1948324977dc3c07aa9132c)