### PR TITLE
Layer team jerseys behind every player image

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -43,6 +43,31 @@ async function getTeamsFromSheet() {
   const { headers, rows } = await sheetRows("Teams");
   return rows.filter((r) => r?.[0] !== "" && r?.[0] != null).slice(0, 10).map((r) => objectFrom(headers, r));
 }
+async function getTeamJerseys() {
+  const teams = await getTeamsFromSheet();
+  const jerseys = new Map<string, unknown>();
+  const add = (key: unknown, jersey: unknown) => {
+    const normalized = String(key ?? "").trim().toLowerCase();
+    if (normalized && jersey) jerseys.set(normalized, jersey);
+  };
+  teams.forEach((team) => {
+    const jersey = team.Jersey;
+    add(team.Team, jersey);
+    add(team.Name, jersey);
+    add(team.Abbrev, jersey);
+  });
+  return jerseys;
+}
+async function getPlayersWithTeamJerseys() {
+  const [players, jerseys] = await Promise.all([
+    readSheetObjects("Players!A1:AM"),
+    getTeamJerseys(),
+  ]);
+  return players.map((player) => ({
+    ...player,
+    Jersey: jerseys.get(String(player.Team ?? "").trim().toLowerCase()) ?? "",
+  }));
+}
 function normalizeSettingLabel(label: unknown) {
   return String(label || "").toLowerCase().replace(/[^a-z0-9]/g, "");
 }
@@ -125,11 +150,12 @@ async function getFrontendSettingsFromSheet() {
   };
 }
 async function getPlayerTraitsFromSheet() {
+  const jerseys = await getTeamJerseys();
   const { headers, rows } = await sheetRows("Players"); const headerIndex: Record<string, number> = {};
   headers.forEach((h, i) => { const k = normHeader(h); if (k) headerIndex[k] = i; });
   const val = (row: Row, ...hs: string[]) => { for (const h of hs) { const i = headerIndex[normHeader(h)]; if (i !== undefined) return row[i] ?? ""; } return ""; };
   return rows.filter((r) => val(r, "Team") !== "" && val(r, "Team") != null).map((r) => { const stamina = val(r, "Stamina"); return {
-    team: val(r,"Team"), name: val(r,"Name"), position: val(r,"Pos"), offStars: val(r,"Off Stars"), defStars: val(r,"Def Stars"), size: val(r,"Size"), strength: val(r,"Strength"), speed: val(r,"Speed"), stamina, poise: val(r,"Poise"), accuracy: val(r,"Accuracy"), armStrength: val(r,"Arm-Strength","Arm Strength"), readDefense: val(r,"Read Defense"), juke: val(r,"Juke"), vision: val(r,"Vision"), acceleration: val(r,"Acceleration"), routeRunning: val(r,"Route Running"), jump: val(r,"Jump"), hands: val(r,"Hands"), ballsecurity: val(r,"Ball Security"), qbFavorite: val(r,"QB Favorite"), runBlocking: val(r,"Run Blocking"), passProtect: val(r,"Pass Protect"), runStop: val(r,"RunStop","Run Stop"), tackling: val(r,"Tackling"), runDef: val(r,"Run Def"), tackleChance: val(r,"Tackle Chance"), strip: val(r,"Strip"), passRush: val(r,"PassRush","Pass Rush"), sackChance: val(r,"Sack Chance"), ballHawk: val(r,"Ball Hawk"), readQB: val(r,"Read QB"), coverage: val(r,"Coverage"), defPos: val(r,"DefPos","Def Pos"), image: val(r,"Image","Player Image from AI"), translateX: val(r,"translateX"), translateY: val(r,"translateY"), scale: val(r,"scale"), jersey: val(r,"jersey","Jersey","Jersey Image"), carries: 0, fatigue: stamina } });
+    team: val(r,"Team"), name: val(r,"Name"), position: val(r,"Pos"), offStars: val(r,"Off Stars"), defStars: val(r,"Def Stars"), size: val(r,"Size"), strength: val(r,"Strength"), speed: val(r,"Speed"), stamina, poise: val(r,"Poise"), accuracy: val(r,"Accuracy"), armStrength: val(r,"Arm-Strength","Arm Strength"), readDefense: val(r,"Read Defense"), juke: val(r,"Juke"), vision: val(r,"Vision"), acceleration: val(r,"Acceleration"), routeRunning: val(r,"Route Running"), jump: val(r,"Jump"), hands: val(r,"Hands"), ballsecurity: val(r,"Ball Security"), qbFavorite: val(r,"QB Favorite"), runBlocking: val(r,"Run Blocking"), passProtect: val(r,"Pass Protect"), runStop: val(r,"RunStop","Run Stop"), tackling: val(r,"Tackling"), runDef: val(r,"Run Def"), tackleChance: val(r,"Tackle Chance"), strip: val(r,"Strip"), passRush: val(r,"PassRush","Pass Rush"), sackChance: val(r,"Sack Chance"), ballHawk: val(r,"Ball Hawk"), readQB: val(r,"Read QB"), coverage: val(r,"Coverage"), defPos: val(r,"DefPos","Def Pos"), image: val(r,"Image","Player Image from AI"), translateX: val(r,"translateX"), translateY: val(r,"translateY"), scale: val(r,"scale"), jersey: jerseys.get(String(val(r,"Team")).trim().toLowerCase()) ?? "", carries: 0, fatigue: stamina } });
 }
 async function getPlayHistory(gameId: string) {
   const { headers, rows } = await sheetRows("PlayHistory");
@@ -286,7 +312,7 @@ async function savePlayAndGameWithRetry(data: Record<string, unknown>, gameId: s
 }
 
 gameRoutes.get("/health", (_req, res) => res.json({ ok: true, app: "football-game-api", message: "API is running" }));
-gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await readSheetObjects("Players!A1:AM") }); } catch (e) { next(e); } });
+gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await getPlayersWithTeamJerseys() }); } catch (e) { next(e); } });
 gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AI") }); } catch (e) { next(e); } });
 gameRoutes.get("/players/:playerName/rushing-games", async (req, res, next) => {
   try {

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -104,7 +104,7 @@ body {
   grid-row: 1;
 }
 
-#player-card-image {
+.player-card-image {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -194,25 +194,6 @@ body {
 }
 .progress-bar.dark-green {
   background: #27ae60;
-}
-
-#jersey-wrapper {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 2;
-  transform-origin: top center;
-  transform: scale(1) translateY(0px);
-}
-
-#jersey {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  transition:
-    transform 0.4s ease,
-    opacity 0.4s ease;
-  opacity: 1;
 }
 
 .players-message {

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -21,6 +21,7 @@ import GameField, { type AnimationPlan } from "./GameField";
 import { GameControls } from "./GameControls";
 import { buildDefense } from "./formationDefense";
 import { GameLog } from "./GameLog";
+import { PlayerImage } from "../players/PlayerImage";
 import {
   goForTwo,
   handleTimeout,
@@ -1217,12 +1218,10 @@ function LeaderCard({
       .filter((s) => s.team === team)
       .sort((a, b) => num(b[field]) - num(a[field]))[0];
   const img = (s?: Stat) => {
-    const src = s
-      ? str(trait(s.playername)?.image ?? trait(s.playername)?.Image)
-      : "";
+    const player = s ? trait(s.playername) : undefined;
     return (
       <div className="player-placeholder">
-        {src ? <img src={src} alt="" /> : <span>👤</span>}
+        <PlayerImage player={player} fallback={<span>👤</span>} />
       </div>
     );
   };

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -6,6 +6,8 @@ import type {
   FormationSlot,
 } from "./gameplay/gameEngine";
 import { buildDefense } from "./formationDefense";
+import { PlayerImage } from "../players/PlayerImage";
+import { playerImageUrl } from "../players/playerImageUrls";
 
 const str = (v: unknown) => String(v ?? "");
 const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
@@ -50,14 +52,7 @@ function teamOf(p: Player) {
   return str(p.team ?? p.Team);
 }
 function imgOf(p?: Player) {
-  return str(
-    p?.image ??
-      p?.Image ??
-      p?.photo ??
-      p?.Photo ??
-      p?.["Player Image from AI"] ??
-      p?.["player image from ai"],
-  );
+  return playerImageUrl(p);
 }
 
 function staminaOf(player: Player) {
@@ -190,11 +185,7 @@ function RosterDetails({ roster }: { roster: Player[] }) {
                         title={`${Math.round(stamina)}% stamina`}
                       >
                         <div className="roster-player-image" aria-hidden="true">
-                          {imgOf(player) ? (
-                            <img src={imgOf(player)} alt="" />
-                          ) : (
-                            <span>👤</span>
-                          )}
+                          <PlayerImage player={player} fallback={<span>👤</span>} />
                         </div>
                         <span className="roster-stamina-value">
                           {Math.round(stamina)}%

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -262,7 +262,7 @@ body {
   z-index: 120;
 }
 
-.token img {
+.token > .player-image-layers {
   width: 54px;
   height: 54px;
   display: block;
@@ -275,11 +275,17 @@ body {
     0 0 0 3px rgba(15, 23, 42, 0.65);
 }
 
-.token.home img {
+.token .player-image-layer {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.token.home > .player-image-layers {
   border-color: #38bdf8;
 }
 
-.token.away img {
+.token.away > .player-image-layers {
   border-color: #fb7185;
 }
 
@@ -723,7 +729,7 @@ textarea {
   background: transparent;
 }
 
-.field-formation-slot img,
+.field-formation-slot > .player-image-layers,
 .field-formation-avatar {
   width: 100%;
   height: 100%;
@@ -734,6 +740,11 @@ textarea {
   border-radius: 50%;
   background: #fff;
   object-fit: cover;
+}
+
+.field-formation-slot .player-image-layer {
+  border: 0;
+  background: transparent;
 }
 
 .field-formation-slot.qb { border-color: #64b5f6; color: #64b5f6; }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { DefensiveAssignment, FormationSlot } from "./gameplay/gameEngine";
+import { PlayerImage } from "../players/PlayerImage";
+import { playerImageUrl, playerJerseyUrl } from "../players/playerImageUrls";
 
 import "./GameField.css";
 
@@ -22,6 +24,7 @@ type AnimationPlayer = {
   x?: number;
   yard?: number;
   headUrl?: string;
+  jerseyUrl?: string;
   className?: string;
   unit?: "offense" | "defense";
   alignmentSlot?: FormationSlot;
@@ -223,8 +226,7 @@ const REQUIRED_FORMATION_SLOTS = new Set<FormationSlot>([
   "RG",
 ]);
 const nameOf = (p?: FormationPlayer) => String(p?.name ?? p?.Name ?? "");
-const imgOf = (p?: FormationPlayer) =>
-  String(p?.image ?? p?.Image ?? p?.photo ?? p?.Photo ?? "");
+const imgOf = (p?: FormationPlayer) => playerImageUrl(p);
 
 const OFFENSIVE_DEFAULT_LANES: Record<string, string> = Object.fromEntries(
   Object.entries(DEFAULT_LINEUPS_BY_POSITION).map(([position, setup]) => [
@@ -437,6 +439,7 @@ export default function GameField({
           role: slot,
           unit: "offense" as const,
           headUrl: imgOf(player),
+          jerseyUrl: playerJerseyUrl(player),
         },
       ];
     });
@@ -455,6 +458,7 @@ export default function GameField({
         unit: "defense" as const,
         alignmentSlot: assignment.align as FormationSlot | undefined,
         headUrl: imgOf(player),
+        jerseyUrl: playerJerseyUrl(player),
       };
     });
 
@@ -878,13 +882,24 @@ export default function GameField({
         el.id = `player-${player.id}`;
         el.style.left = `${player.x}%`;
         el.style.top = `${yardToYPct(player.yard)}%`;
+        const portrait = document.createElement("span");
+        portrait.className = "player-image-layers";
+        if (player.jerseyUrl) {
+          const jersey = document.createElement("img");
+          jersey.className = "player-image-layer player-image-layer--jersey";
+          jersey.src = player.jerseyUrl;
+          jersey.alt = "";
+          portrait.appendChild(jersey);
+        }
         const img = document.createElement("img");
+        img.className = "player-image-layer player-image-layer--player";
         img.src = player.headUrl || "";
         img.alt = player.name;
+        portrait.appendChild(img);
         const label = document.createElement("div");
         label.className = "name";
         label.textContent = player.name;
-        el.appendChild(img);
+        el.appendChild(portrait);
         el.appendChild(label);
         el.tabIndex = 0;
         el.setAttribute("role", "button");
@@ -1304,7 +1319,7 @@ export default function GameField({
                 >
                   {playerName ? (
                     playerImage ? (
-                      <img src={playerImage} alt={playerName} />
+                      <PlayerImage player={player} alt={playerName} />
                     ) : (
                       <span className="field-formation-avatar">👤</span>
                     )
@@ -1337,7 +1352,7 @@ export default function GameField({
                   aria-hidden="true"
                 >
                   {playerImage ? (
-                    <img src={playerImage} alt="" />
+                    <PlayerImage player={player} />
                   ) : (
                     <span className="field-formation-avatar">👤</span>
                   )}

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -8,9 +8,10 @@ import {
 } from "../../api/client";
 import type { Player } from "../players/types";
 import { PLACEHOLDER_LOGOS } from "./leagueConstants";
+import { PlayerImage } from "../players/PlayerImage";
 
 type StatsView = "Player" | "Team";
-type Leader = { name: string; image: string; value: number };
+type Leader = { name: string; image: string; player?: Player; value: number };
 
 const RUSHING_COLUMNS = [
   "Carries",
@@ -60,7 +61,7 @@ function LeaderTable({
   onComplete?: () => void;
   onPlayerSelect?: (name: string) => void;
 }) {
-  const placeholderLeaders = Array.from({ length: 5 }, (_, i) => ({
+  const placeholderLeaders: Leader[] = Array.from({ length: 5 }, (_, i) => ({
     name: `${kind} Name`,
     image: PLACEHOLDER_LOGOS.team,
     value: [308.5, 298.7, 296.4, 294.0, 291.7][i],
@@ -90,7 +91,7 @@ function LeaderTable({
               <tr key={`${leader.name}-${i}`}>
                 <td className="team-cell">
                   <span className="rank">{i + 1}</span>
-                  <img className="player-stats-image" src={leader.image} alt="" />
+                  <PlayerImage player={leader.player ? { ...leader.player } : { Image: leader.image }} className="player-stats-image" />
                   <button className="team-link player-name-button" type="button" onClick={() => onPlayerSelect?.(leader.name)}>
                     {leader.name}
                   </button>
@@ -166,7 +167,7 @@ export function LeagueStats() {
       .map((row) => {
         const name = row.Player.trim();
         const player = playersByName.get(name.toLowerCase());
-        return { name, image: playerImage(player), value: Number(row.Yards) || 0 };
+        return { name, image: playerImage(player), player, value: Number(row.Yards) || 0 };
       })
       .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name))
       .slice(0, 5);
@@ -184,6 +185,7 @@ export function LeagueStats() {
       .map((row) => ({
         row,
         image: playerImage(playersByName.get(row.Player.trim().toLowerCase())),
+        player: playersByName.get(row.Player.trim().toLowerCase()),
       }))
       .sort(
         (a, b) =>
@@ -208,7 +210,7 @@ export function LeagueStats() {
         <button className="profile-back" type="button" onClick={() => setSelectedPlayerName(null)}>← Back to rushing leaders</button>
         <header className="player-profile-summary">
           <div className="player-profile-image-wrap">
-            <img src={playerImage(selectedPlayer)} alt={selectedPlayerName} />
+            <PlayerImage player={selectedPlayer ? { ...selectedPlayer } : { Image: playerImage(selectedPlayer) }} alt={selectedPlayerName} />
           </div>
           <div>
             <p className="player-profile-kicker">{selectedPlayer?.Pos || "PLAYER"}</p>
@@ -303,10 +305,10 @@ export function LeagueStats() {
                           </td>
                         </tr>
                       ) : (
-                        allRushers.map(({ row, image }) => (
+                        allRushers.map(({ row, image, player }) => (
                           <tr key={row.Player}>
                             <td className="complete-leader-player">
-                              <img className="player-stats-image" src={image} alt="" />
+                              <PlayerImage player={player ? { ...player } : { Image: image }} className="player-stats-image" />
                               <button className="player-name-button" type="button" onClick={() => selectPlayer(row.Player)}>{row.Player}</button>
                             </td>
                             {RUSHING_COLUMNS.map((column) => (

--- a/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
+++ b/apps/web/src/components/league/gameplay/engine/runPlayJSONAnimationBuilder.ts
@@ -27,6 +27,8 @@ const imageOf = (player?: Record<string, unknown>) =>
       player?.headUrl ??
       "",
   );
+const jerseyOf = (player?: Record<string, unknown>) =>
+  String(player?.jersey ?? player?.Jersey ?? player?.["Jersey Image"] ?? "");
 
 const randomYards = (min: number, max: number, random: () => number) =>
   Number((min + random() * (max - min)).toFixed(2));
@@ -120,6 +122,7 @@ export function runPlayJSONAnimationBuilder(
       role: slot,
       unit: "offense",
       headUrl: imageOf(rosterByName.get(name)),
+      jerseyUrl: jerseyOf(rosterByName.get(name)),
     });
   }
 
@@ -135,6 +138,7 @@ export function runPlayJSONAnimationBuilder(
       unit: "defense",
       alignmentSlot: assignment.align as FormationSlot | undefined,
       headUrl: imageOf(rosterByName.get(assignment.player)),
+      jerseyUrl: jerseyOf(rosterByName.get(assignment.player)),
     });
   }
 

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -376,7 +376,7 @@
 }
 .player-stats-image {
   width: 24px;
-  height: auto;
+  height: 24px;
   flex: 0 0 auto;
 }
 .statCol1 {
@@ -479,7 +479,7 @@
   border: 1px solid #3b3b3b;
 }
 .player-profile-image-wrap { align-self: stretch; min-height: 260px; background: radial-gradient(circle at 50% 60%, #444, #181818 70%); }
-.player-profile-image-wrap img { width: 100%; height: 100%; max-height: 340px; object-fit: contain; object-position: bottom; }
+.player-profile-image-wrap > .player-image-layers { min-height: 260px; max-height: 340px; object-fit: contain; object-position: bottom; }
 .player-profile-kicker { margin: 0 0 .25rem; color: var(--accent-red); font-weight: 700; letter-spacing: .12em; }
 .player-profile-summary h2 { margin: 0; font-size: clamp(2rem, 5vw, 4rem); text-transform: uppercase; }
 .player-profile-team { margin: .35rem 0 1.25rem; color: var(--text-muted); font-size: 1.15rem; }

--- a/apps/web/src/components/players/PlayerCard.tsx
+++ b/apps/web/src/components/players/PlayerCard.tsx
@@ -1,5 +1,6 @@
 import type { Player } from "./types";
 import { Stars } from "./Stars";
+import { PlayerImage } from "./PlayerImage";
 
 const FALLBACK_PLAYER_IMAGE =
   "https://andrew-jacobson06.github.io/public-audio/baby.png";
@@ -70,10 +71,6 @@ function getPlayerImage(player: Player) {
   );
 }
 
-function getJerseyImage(player: Player) {
-  return firstNonEmpty(player.jersey, player.Jersey, player["Jersey Image"]);
-}
-
 type PlayerCardProps = {
   player: Player;
   onBack: () => void;
@@ -81,7 +78,6 @@ type PlayerCardProps = {
 
 export function PlayerCard({ player, onBack }: PlayerCardProps) {
   const playerImage = getPlayerImage(player);
-  const jerseyImage = getJerseyImage(player);
 
   return (
     <div id="playerCardView">
@@ -95,19 +91,14 @@ export function PlayerCard({ player, onBack }: PlayerCardProps) {
       </button>
       <div className="player-card-layout">
         <div id="playerImageContainer" className="player-image-container">
-          <img
-            id="player-card-image"
-            src={playerImage}
-            alt="Player"
+          <PlayerImage
+            player={{ ...player, Image: playerImage }}
+            alt={player.Name || "Player"}
+            className="player-card-image"
             style={{
               transform: `translate(${numberValue(player.translateX)}px, ${numberValue(player.translateY)}px) scale(${numberValue(player.scale, 1)})`,
             }}
           />
-          <div id="jersey-wrapper">
-            {jerseyImage && (
-              <img id="jersey" src={jerseyImage} alt="Jersey Overlay" />
-            )}
-          </div>
         </div>
         <div id="playerDetails" className="player-details">
           <div>

--- a/apps/web/src/components/players/PlayerImage.tsx
+++ b/apps/web/src/components/players/PlayerImage.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties } from "react";
+import { playerImageUrl, playerJerseyUrl } from "./playerImageUrls";
+
+type PlayerRecord = Record<string, unknown>;
+
+export function PlayerImage({
+  player,
+  alt = "",
+  className = "",
+  fallback,
+  style,
+}: {
+  player?: PlayerRecord;
+  alt?: string;
+  className?: string;
+  fallback?: React.ReactNode;
+  style?: CSSProperties;
+}) {
+  const image = playerImageUrl(player);
+  const jersey = playerJerseyUrl(player);
+
+  if (!image && !jersey) return fallback ?? null;
+
+  return (
+    <span className={`player-image-layers ${className}`.trim()} style={style}>
+      {jersey && <img className="player-image-layer player-image-layer--jersey" src={jersey} alt="" />}
+      {image && <img className="player-image-layer player-image-layer--player" src={image} alt={alt} />}
+    </span>
+  );
+}

--- a/apps/web/src/components/players/playerImageUrls.ts
+++ b/apps/web/src/components/players/playerImageUrls.ts
@@ -1,0 +1,15 @@
+type PlayerRecord = Record<string, unknown>;
+
+const value = (player: PlayerRecord | undefined, ...keys: string[]) => {
+  for (const key of keys) {
+    const candidate = String(player?.[key] ?? "").trim();
+    if (candidate) return candidate;
+  }
+  return "";
+};
+
+export const playerImageUrl = (player?: PlayerRecord) =>
+  value(player, "image", "Image", "photo", "Photo", "Player Image from AI", "player image from ai");
+
+export const playerJerseyUrl = (player?: PlayerRecord) =>
+  value(player, "jersey", "Jersey", "Jersey Image", "jersey image");

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,3 +6,22 @@ button,
 table {
   font: inherit;
 }
+/* Team jerseys and transparent player portraits share a 1024px canvas. */
+.player-image-layers {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.player-image-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: inherit;
+  object-position: inherit;
+}
+
+.player-image-layer--jersey { z-index: 1; }
+.player-image-layer--player { z-index: 2; }


### PR DESCRIPTION
### Motivation
- Ensure every player image shown in the UI includes the player's team jersey as a background layer sourced from the Teams sheet `Jersey` column so portraits display team branding consistently.
- Make the jersey sit underneath the player portrait while keeping both assets aligned to the same natural 1024×1024 canvas so existing translations/scales continue to work.

### Description
- Hydrated backend player records with team jersey URLs by reading the `Jersey` column from the Teams sheet and matching by `Team`/`Name`/`Abbrev`, and returned players via the `/players` endpoint with a `Jersey` value when available (`apps/api/src/routes/gameRoutes.ts`).
- Added a reusable `PlayerImage` component and `playerImageUrls` helper that composes a jersey image beneath the player portrait on a shared 1024×1024-aligned layer stack (`apps/web/src/components/players/PlayerImage.tsx`, `playerImageUrls.ts`, `apps/web/src/index.css`).
- Replaced direct single-image usages with the layered `PlayerImage` across player cards, leader tables, roster controls, formations, game-field tokens, and player profiles so jerseys render behind portraits (`PlayerCard.tsx`, `LeagueStats.tsx`, `GameControls.tsx`, `GameField.tsx`, `GameCenter.tsx`, `runPlayJSONAnimationBuilder.ts` and related CSS updates).
- Kept the jersey layer lower z-index than the player portrait and preserved existing transform/translate/scale behavior by passing the player image through the `PlayerImage` stack and by adding `jerseyUrl` to animation/player objects where needed.

### Testing
- Ran frontend lint and build with `cd apps/web && npm run lint && npm run build` and the build completed successfully after iterating on type/lint issues (final status: success).
- Ran backend typecheck and tests with `cd apps/api && npm run typecheck` and `cd apps/api && npm test`, and the API typecheck and unit tests passed (3 tests OK).
- Verified `git diff --check` produced no trailing whitespace errors and inspected the modified files locally to ensure the new component is used where intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a684def45bc83248830ad1ddac5ed3c)