### PR TITLE
Improve player scale, alignment, and depth stacking

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -778,11 +778,12 @@ textarea {
 
 /* Full-body player presentation shared by formation setup and live plays. */
 .token {
-  --player-size: clamp(68px, 8vw, 96px);
+  --player-size: clamp(46px, 5.5vw, 64px);
   width: var(--player-size);
   height: calc(var(--player-size) * 1.28);
   border-radius: 0;
-  transform: translate(-50%, -72%);
+  /* The yard coordinate represents the player's feet, not their center. */
+  transform: translate(-50%, -92%);
   transform-origin: 50% 82%;
 }
 
@@ -850,6 +851,12 @@ textarea {
 .token.active-runner .player-aura, .token.ball-carrier .player-aura, .field-formation-slot.selected .player-aura { opacity: 1; }
 .token.defense .player-marker, .field-formation-slot.defense .player-marker { border-color: #ff5555b8; }
 
+/* Live players use clean character art without selection/highlight rings. */
+.token .player-marker,
+.token .player-aura {
+  display: none;
+}
+
 .token .name, .field-formation-name {
   top: auto;
   bottom: -20px;
@@ -880,7 +887,7 @@ textarea {
 .token[data-action="stiff-arm"] .action-burst { animation: action-burst 420ms 210ms ease-out; }
 .token[data-action="celebration"] .player-aura { opacity: 1; animation: celebration-aura 900ms ease-in-out infinite; }
 
-.field-formation-slot { width: clamp(68px, 8vw, 96px); height: calc(clamp(68px, 8vw, 96px) * 1.28); border-radius: 0; border: 0; background: transparent; transform: translate(-50%, -72%); }
+.field-formation-slot { width: clamp(46px, 5.5vw, 64px); height: calc(clamp(46px, 5.5vw, 64px) * 1.28); border-radius: 0; border: 0; background: transparent; transform: translate(-50%, -92%); }
 .field-formation-slot.filled { border: 0; }
 .field-formation-slot.open { width: 58px; height: 58px; border: 2px dashed currentColor; border-radius: 50%; background: #0f172ad1; transform: translate(-50%, -50%); }
 .field-formation-slot.targetable:not(.open) .player-marker { border-color: #facc15; box-shadow: 0 0 10px #facc15; }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -145,18 +145,18 @@ const DEFAULT_LINEUPS_BY_POSITION: Record<
   string,
   { lane: string; yardOffsetFromLos: number }
 > = {
-  WR1: { lane: "WR1", yardOffsetFromLos: -1 },
-  WR2: { lane: "WR2", yardOffsetFromLos: -1 },
-  WR3: { lane: "SLT1", yardOffsetFromLos: -1.5 },
-  WR4: { lane: "SLT2", yardOffsetFromLos: -1.5 },
-  RB1: { lane: "LG", yardOffsetFromLos: -6 },
-  RB2: { lane: "RG", yardOffsetFromLos: -6 },
-  QB: { lane: "C", yardOffsetFromLos: -3.5 },
-  LT: { lane: "LT", yardOffsetFromLos: -1 },
-  LG: { lane: "LG", yardOffsetFromLos: -0.75 },
-  C: { lane: "C", yardOffsetFromLos: -0.5 },
-  RG: { lane: "RG", yardOffsetFromLos: -0.75 },
-  RT: { lane: "RT", yardOffsetFromLos: -1 },
+  WR1: { lane: "WR1", yardOffsetFromLos: -4 },
+  WR2: { lane: "WR2", yardOffsetFromLos: -4 },
+  WR3: { lane: "SLT1", yardOffsetFromLos: -4.5 },
+  WR4: { lane: "SLT2", yardOffsetFromLos: -4.5 },
+  RB1: { lane: "LG", yardOffsetFromLos: -11 },
+  RB2: { lane: "RG", yardOffsetFromLos: -11 },
+  QB: { lane: "C", yardOffsetFromLos: -7.5 },
+  LT: { lane: "LT", yardOffsetFromLos: -4 },
+  LG: { lane: "LG", yardOffsetFromLos: -4 },
+  C: { lane: "C", yardOffsetFromLos: -4 },
+  RG: { lane: "RG", yardOffsetFromLos: -4 },
+  RT: { lane: "RT", yardOffsetFromLos: -4 },
   DB1: { lane: "LSD", yardOffsetFromLos: 1.25 },
   DB2: { lane: "RSD", yardOffsetFromLos: 1.25 },
   DB3: { lane: "RFLT", yardOffsetFromLos: 1.25 },
@@ -171,8 +171,8 @@ const DEFAULT_LINEUPS_BY_POSITION: Record<
   FS: { lane: "C", yardOffsetFromLos: 14 },
   S1: { lane: "LG", yardOffsetFromLos: 13 },
   S2: { lane: "RG", yardOffsetFromLos: 13 },
-  TE1: { lane: "RT", yardOffsetFromLos: -1 },
-  TE2: { lane: "LT", yardOffsetFromLos: -1 },
+  TE1: { lane: "RT", yardOffsetFromLos: -4 },
+  TE2: { lane: "LT", yardOffsetFromLos: -4 },
 };
 
 /**
@@ -276,6 +276,11 @@ const yardToYPct = (yard: number) => {
   const fieldYard = Math.max(-10, Math.min(110, yard));
   return 91.8 - (fieldYard / 100) * (91.8 - 8.2);
 };
+// Players nearer the bottom of the vertical field must paint over players
+// farther upfield. Deriving the layer from the same ground point used for
+// positioning keeps contact pairs correct regardless of team or play state.
+const playerDepthZIndex = (yard: number) =>
+  100 + Math.round(yardToYPct(yard) * 10);
 const normalizeYard = (yard: string | number) =>
   Number.isFinite(Number(yard)) ? Number(yard) : 55;
 const normalizeDistance = (distance: string | number) =>
@@ -676,6 +681,7 @@ export default function GameField({
   const updateScreenPositionsWithoutFootball = useCallback(() => {
     Object.values(playersRef.current).forEach((player) => {
       player.el.style.top = `${yardToYPct(player.yard)}%`;
+      player.el.style.zIndex = String(playerDepthZIndex(player.yard));
     });
     Object.values(labelsRef.current).forEach((labelEl) => {
       const yard = Number(labelEl.dataset.yard);
@@ -717,6 +723,7 @@ export default function GameField({
         if (step.yard !== undefined) player.yard = step.yard;
         player.el.style.left = `${player.x}%`;
         player.el.style.top = `${yardToYPct(player.yard)}%`;
+        player.el.style.zIndex = String(playerDepthZIndex(player.yard));
         player.el.className = `token ${player.team.toLowerCase()} ${unitClassForPlayer(player)} ${player.isRunner ? "runner" : ""} ${player.className || ""}`;
         updateScreenPositionsWithoutFootball();
         await wait(durationMs);
@@ -923,6 +930,7 @@ export default function GameField({
         el.id = `player-${player.id}`;
         el.style.left = `${player.x}%`;
         el.style.top = `${yardToYPct(player.yard)}%`;
+        el.style.zIndex = String(playerDepthZIndex(player.yard));
         const portrait = document.createElement("span");
         portrait.className = "player-sprite";
         if (player.jerseyUrl) {
@@ -1386,6 +1394,9 @@ export default function GameField({
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
                     top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
+                    zIndex: playerDepthZIndex(
+                      formationLosYard + offenseDirection * lineup.yardOffsetFromLos,
+                    ),
                   }}
                   aria-label={
                     playerName
@@ -1433,6 +1444,9 @@ export default function GameField({
                   style={{
                     left: `${LANES[lineup.lane] ?? 50}%`,
                     top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
+                    zIndex: playerDepthZIndex(
+                      formationLosYard + offenseDirection * lineup.yardOffsetFromLos,
+                    ),
                   }}
                   aria-hidden="true"
                 >


### PR DESCRIPTION
### Motivation
- Players rendered during plays were visually oversized and anchored incorrectly, causing offense to appear past the LOS and misaligned with the field.
- Live-play highlight rings/markers produced distracting outlines that should not appear during playback.
- Tokens could overlap in the wrong order during animations; a deterministic depth rule is required so lower (nearer the viewer) players always paint above higher ones.

### Description
- Reduce live and formation sprite sizes by changing `--player-size` to `clamp(46px, 5.5vw, 64px)` and move the visual anchor to player feet by updating `transform` to `translate(-50%, -92%)` in `GameField.css`.
- Remove live-play highlight rings by hiding `.token .player-marker` and `.token .player-aura` in `GameField.css` so characters render cleanly during plays.
- Shift offensive formation starting depths by updating `DEFAULT_LINEUPS_BY_POSITION` yard offsets for `WR`, `RB`, `QB`, `TE`, and OL slots in `GameField.tsx` so offensive players start behind the LOS with realistic backfield spacing.
- Add `playerDepthZIndex(yard)` in `GameField.tsx` and set `el.style.zIndex` for live tokens, formation slot elements, and during screen position updates so players at lower vertical positions consistently render on top of players higher on the field.

### Testing
- Built the web app with `cd apps/web && npm run build` and the build completed successfully.
- Ran static checks with `cd apps/web && npm run lint` and `eslint` reported no blocking errors.
- Verified simple repository checks with `git diff --check`, which reported no whitespace or obvious diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69533e77ec8324aa11893739876bc9)