### PR TITLE
Keep field players below GUI and hide formation defense

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -45,6 +45,10 @@ body {
 
 .field-viewport {
   position: relative;
+  /* Contain all field depth layers so they can never escape above sibling GUI
+     such as the sticky scoreboard, regardless of a player's inline z-index. */
+  isolation: isolate;
+  z-index: 0;
   width: 100%;
   height: 680px;
   overflow-y: auto;

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -277,10 +277,12 @@ const yardToYPct = (yard: number) => {
   return 91.8 - (fieldYard / 100) * (91.8 - 8.2);
 };
 // Players nearer the bottom of the vertical field must paint over players
-// farther upfield. Deriving the layer from the same ground point used for
-// positioning keeps contact pairs correct regardless of team or play state.
+// farther upfield. Keep that depth ordering inside the field-content range;
+// GUI overlays begin at z-index 300 and must always remain above the players.
+// A one-point step per vertical percentage still gives every contact pair a
+// stable ordering without allowing a player's field position to outrank UI.
 const playerDepthZIndex = (yard: number) =>
-  100 + Math.round(yardToYPct(yard) * 10);
+  100 + Math.round(yardToYPct(yard));
 const normalizeYard = (yard: string | number) =>
   Number.isFinite(Number(yard)) ? Number(yard) : 55;
 const normalizeDistance = (distance: string | number) =>
@@ -1434,36 +1436,8 @@ export default function GameField({
               );
             })}
 
-          {formationMode &&
-            defense.map((assignment) => {
-              const lineup = assignment.align
-                ? FORMATION_SLOT_LINEUP[assignment.align as FormationSlot]
-                : defensiveLineupForPosition(assignment.position);
-              if (!lineup) return null;
-              const player = findFormationPlayer(assignment.player);
-              const playerImage = imgOf(player);
-              return (
-                <div
-                  key={`${assignment.position}-${assignment.player}`}
-                  className="field-formation-slot defense"
-                  style={{
-                    left: `${LANES[lineup.lane] ?? 50}%`,
-                    top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
-                    zIndex: playerDepthZIndex(
-                      formationLosYard + offenseDirection * lineup.yardOffsetFromLos,
-                    ),
-                  }}
-                  aria-hidden="true"
-                >
-                  {playerImage ? (
-                    <><span className="player-shadow" aria-hidden="true" /><span className="player-marker" aria-hidden="true" /><span className="player-sprite"><PlayerImage player={player} /></span></>
-                  ) : (
-                    <span className="field-formation-avatar">👤</span>
-                  )}
-                  <span className="field-formation-name"><span className="player-number">{assignment.position}</span><span className="player-name">{assignment.player}</span></span>
-                </div>
-              );
-            })}
+          {/* The generated defense remains in the pending play data, but is
+              deliberately not previewed while the offense is being placed. */}
 
           {selectedPlayerMenu && (
             <div


### PR DESCRIPTION
### Motivation

- Prevent field player tokens from visually overlapping and blocking GUI controls by keeping their stacking context confined to the field area.
- Preserve player-to-player depth ordering so contact and overlap logic still paints correctly based on yard position.
- Remove the faded defensive token previews during offensive formation editing so defensive tokens are invisible until the user exits or saves.

### Description

- Constrain field stacking so UI overlays remain above players by adding `isolation: isolate` and `z-index: 0` to the `.field-viewport` container in `apps/web/src/components/league/GameField.css`.
- Reduce the player depth range so players remain inside the field layer by changing `playerDepthZIndex` in `apps/web/src/components/league/GameField.tsx` to use `Math.round(yardToYPct(yard))` instead of multiplying by 10.
- Stop rendering the defensive preview tokens during formation placement by removing the defense-preview JSX inside formation mode and leaving a comment noting the generated defense remains in play data (defensive assignments are retained but not previewed in the UI).

### Testing

- Ran `npm run build` in `apps/web` and the production build completed successfully.
- Ran `npm run lint` in `apps/web` and the linter passed with no blocking errors.
- Ran `git diff --check` to verify no whitespace or diff issues and it returned cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69586db08483249e3dc051ea73a269)