### PR TITLE
Make player yardline positioning clear

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -165,6 +165,62 @@ body {
   pointer-events: none;
 }
 
+/* A permanent coordinate grid stays visible while editing a formation, while
+   waiting at the line, and while the play camera follows an animation. */
+.yard-grid {
+  position: absolute;
+  inset: 0;
+  z-index: 19;
+  pointer-events: none;
+}
+
+.yard-guide {
+  position: absolute;
+  left: 7%;
+  width: 86%;
+  height: 1px;
+  border-top: 1px solid rgba(255, 255, 255, 0.34);
+  transform: translateY(-50%);
+}
+
+.yard-guide.major {
+  height: 2px;
+  border-top: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 1px 0 rgba(2, 6, 23, 0.5);
+}
+
+.yard-guide.midfield {
+  border-top-color: rgba(255, 255, 255, 0.95);
+}
+
+.yard-guide-label {
+  position: absolute;
+  top: 50%;
+  min-width: 58px;
+  padding: 3px 5px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 5px;
+  background: rgba(2, 6, 23, 0.82);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 1000;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  transform: translateY(-50%);
+}
+
+.yard-guide-label--left { right: calc(100% + 4px); }
+.yard-guide-label--right { left: calc(100% + 4px); }
+
+.yard-guide.minor .yard-guide-label {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(2, 6, 23, 0.68);
+  color: #e2e8f0;
+  font-size: 9px;
+}
+
 
 .field-midfield-logo {
   position: absolute;
@@ -357,6 +413,17 @@ body {
   font-weight: 900;
   white-space: nowrap;
   pointer-events: none;
+}
+
+.player-yard {
+  display: block;
+  margin-top: 2px;
+  color: #fde047;
+  font-size: 8px;
+  font-weight: 1000;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-align: center;
 }
 
 .token.defense .name {

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -288,6 +288,13 @@ const normalizeYard = (yard: string | number) =>
 const normalizeDistance = (distance: string | number) =>
   Number.isFinite(Number(distance)) ? Number(distance) : 10;
 const clampYard = (yard: number) => Math.max(0, Math.min(100, yard));
+const formatFieldPosition = (yard: number) => {
+  const roundedYard = Math.round(clampYard(yard));
+  if (roundedYard === 50) return "50";
+  return roundedYard < 50
+    ? `HOME ${roundedYard}`
+    : `AWAY ${100 - roundedYard}`;
+};
 const possessionDirection = (possession?: string) =>
   String(possession ?? "Home").toLowerCase() === "away" ? -1 : 1;
 
@@ -685,6 +692,8 @@ export default function GameField({
     Object.values(playersRef.current).forEach((player) => {
       player.el.style.top = `${yardToYPct(player.yard)}%`;
       player.el.style.zIndex = String(playerDepthZIndex(player.yard));
+      const yardLabel = player.el.querySelector<HTMLElement>(".player-yard");
+      if (yardLabel) yardLabel.textContent = formatFieldPosition(player.yard);
     });
     Object.values(labelsRef.current).forEach((labelEl) => {
       const yard = Number(labelEl.dataset.yard);
@@ -824,14 +833,6 @@ export default function GameField({
           hash.style.top = `${yardToYPct(yard)}%`;
           field.appendChild(hash);
         });
-      for (let yard = 10; yard <= 90; yard += 5) {
-        const el = document.createElement("div");
-        el.className = "yard-number";
-        el.dataset.yard = String(yard);
-        el.textContent = yard >= 50 ? `AWAY ${100 - yard}` : `HOME ${yard}`;
-        el.style.top = `${yardToYPct(yard)}%`;
-        field.appendChild(el);
-      }
       const homeTeam = plan.meta?.homeTeam;
       const homePlayers = plan.players.filter((player) =>
         homeTeam
@@ -978,10 +979,13 @@ export default function GameField({
         const labelName = document.createElement("span");
         labelName.className = "player-name";
         labelName.textContent = player.name;
+        const yardLabel = document.createElement("span");
+        yardLabel.className = "player-yard";
+        yardLabel.textContent = formatFieldPosition(player.yard);
         const possessionDot = document.createElement("span");
         possessionDot.className = "possession-dot";
         possessionDot.setAttribute("aria-hidden", "true");
-        label.append(labelName, possessionDot);
+        label.append(labelName, yardLabel, possessionDot);
         el.appendChild(portrait);
         el.appendChild(label);
         el.dataset.action = playerActionForStep(player);
@@ -1374,6 +1378,24 @@ export default function GameField({
               alt="Home team logo at midfield"
             />
           )}
+          <div className="yard-grid" aria-hidden="true">
+            {Array.from({ length: 21 }, (_, index) => index * 5).map(
+              (yard) => (
+                <div
+                  key={yard}
+                  className={`yard-guide ${yard % 10 === 0 ? "major" : "minor"} ${yard === 50 ? "midfield" : ""}`}
+                  style={{ top: `${yardToYPct(yard)}%` }}
+                >
+                  <span className="yard-guide-label yard-guide-label--left">
+                    {formatFieldPosition(yard)}
+                  </span>
+                  <span className="yard-guide-label yard-guide-label--right">
+                    {formatFieldPosition(yard)}
+                  </span>
+                </div>
+              ),
+            )}
+          </div>
           <div className="field-line los-line" id="losLine" />
           <div className="field-line first-down-line" id="firstDownLine" />
           <div className="field-line end-line" id="endLine" />
@@ -1430,7 +1452,7 @@ export default function GameField({
                     <span className="field-formation-label">{slot}</span>
                   )}
                   {playerName && (
-                    <span className="field-formation-name"><span className="player-number">{slot}</span><span className="player-name">{playerName}</span></span>
+                    <span className="field-formation-name"><span className="player-number">{slot}</span><span className="player-name">{playerName}</span><span className="player-yard">{formatFieldPosition(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}</span></span>
                   )}
                 </button>
               );


### PR DESCRIPTION
### Motivation
- Yardline and player-depth information was difficult to read during formation setup, pre-play positioning, and while plays animate, so the UI needs clearer field coordinates and per-player position labels.

### Description
- Add a `formatFieldPosition` helper that formats yards as `HOME <n>`, `50`, or `AWAY <n>` and use it to render per-player yard badges under each player name in formation and animation views.
- Render a permanent five-yard vertical grid across the field with emphasized ten-yard guides and mirrored labels on both sidelines, and style the grid in `GameField.css` for visibility during setup and playback.
- Update the animation/positioning code so yard badges are created for tokens, injected into formation slots, and updated by `updateScreenPositionsWithoutFootball` and reset/scene builders as players move.
- Add accompanying CSS (`.yard-grid`, `.yard-guide`, `.player-yard`) and remove the old ad-hoc numeric element generation in favor of the consistent grid+badge approach.

### Testing
- Built the web app with `npm run build` and the build completed successfully.
- Ran `npm run lint` and there were no lint errors reported.
- Performed a visual smoke check by capturing a local Playwright screenshot of the running dev server to verify the app served and the field UI rendered (the game field requires navigating into a league/game to show populated tokens).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6abdc7f560832494e4be90174e7d18)