### PR TITLE
Revert player positioning clarity changes

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -165,62 +165,6 @@ body {
   pointer-events: none;
 }
 
-/* A permanent coordinate grid stays visible while editing a formation, while
-   waiting at the line, and while the play camera follows an animation. */
-.yard-grid {
-  position: absolute;
-  inset: 0;
-  z-index: 19;
-  pointer-events: none;
-}
-
-.yard-guide {
-  position: absolute;
-  left: 7%;
-  width: 86%;
-  height: 1px;
-  border-top: 1px solid rgba(255, 255, 255, 0.34);
-  transform: translateY(-50%);
-}
-
-.yard-guide.major {
-  height: 2px;
-  border-top: 2px solid rgba(255, 255, 255, 0.7);
-  box-shadow: 0 1px 0 rgba(2, 6, 23, 0.5);
-}
-
-.yard-guide.midfield {
-  border-top-color: rgba(255, 255, 255, 0.95);
-}
-
-.yard-guide-label {
-  position: absolute;
-  top: 50%;
-  min-width: 58px;
-  padding: 3px 5px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  border-radius: 5px;
-  background: rgba(2, 6, 23, 0.82);
-  color: #fff;
-  font-size: 10px;
-  font-weight: 1000;
-  letter-spacing: 0.03em;
-  line-height: 1;
-  text-align: center;
-  white-space: nowrap;
-  transform: translateY(-50%);
-}
-
-.yard-guide-label--left { right: calc(100% + 4px); }
-.yard-guide-label--right { left: calc(100% + 4px); }
-
-.yard-guide.minor .yard-guide-label {
-  border-color: rgba(255, 255, 255, 0.2);
-  background: rgba(2, 6, 23, 0.68);
-  color: #e2e8f0;
-  font-size: 9px;
-}
-
 
 .field-midfield-logo {
   position: absolute;
@@ -413,17 +357,6 @@ body {
   font-weight: 900;
   white-space: nowrap;
   pointer-events: none;
-}
-
-.player-yard {
-  display: block;
-  margin-top: 2px;
-  color: #fde047;
-  font-size: 8px;
-  font-weight: 1000;
-  letter-spacing: 0.04em;
-  line-height: 1;
-  text-align: center;
 }
 
 .token.defense .name {

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -288,13 +288,6 @@ const normalizeYard = (yard: string | number) =>
 const normalizeDistance = (distance: string | number) =>
   Number.isFinite(Number(distance)) ? Number(distance) : 10;
 const clampYard = (yard: number) => Math.max(0, Math.min(100, yard));
-const formatFieldPosition = (yard: number) => {
-  const roundedYard = Math.round(clampYard(yard));
-  if (roundedYard === 50) return "50";
-  return roundedYard < 50
-    ? `HOME ${roundedYard}`
-    : `AWAY ${100 - roundedYard}`;
-};
 const possessionDirection = (possession?: string) =>
   String(possession ?? "Home").toLowerCase() === "away" ? -1 : 1;
 
@@ -692,8 +685,6 @@ export default function GameField({
     Object.values(playersRef.current).forEach((player) => {
       player.el.style.top = `${yardToYPct(player.yard)}%`;
       player.el.style.zIndex = String(playerDepthZIndex(player.yard));
-      const yardLabel = player.el.querySelector<HTMLElement>(".player-yard");
-      if (yardLabel) yardLabel.textContent = formatFieldPosition(player.yard);
     });
     Object.values(labelsRef.current).forEach((labelEl) => {
       const yard = Number(labelEl.dataset.yard);
@@ -833,6 +824,14 @@ export default function GameField({
           hash.style.top = `${yardToYPct(yard)}%`;
           field.appendChild(hash);
         });
+      for (let yard = 10; yard <= 90; yard += 5) {
+        const el = document.createElement("div");
+        el.className = "yard-number";
+        el.dataset.yard = String(yard);
+        el.textContent = yard >= 50 ? `AWAY ${100 - yard}` : `HOME ${yard}`;
+        el.style.top = `${yardToYPct(yard)}%`;
+        field.appendChild(el);
+      }
       const homeTeam = plan.meta?.homeTeam;
       const homePlayers = plan.players.filter((player) =>
         homeTeam
@@ -979,13 +978,10 @@ export default function GameField({
         const labelName = document.createElement("span");
         labelName.className = "player-name";
         labelName.textContent = player.name;
-        const yardLabel = document.createElement("span");
-        yardLabel.className = "player-yard";
-        yardLabel.textContent = formatFieldPosition(player.yard);
         const possessionDot = document.createElement("span");
         possessionDot.className = "possession-dot";
         possessionDot.setAttribute("aria-hidden", "true");
-        label.append(labelName, yardLabel, possessionDot);
+        label.append(labelName, possessionDot);
         el.appendChild(portrait);
         el.appendChild(label);
         el.dataset.action = playerActionForStep(player);
@@ -1378,24 +1374,6 @@ export default function GameField({
               alt="Home team logo at midfield"
             />
           )}
-          <div className="yard-grid" aria-hidden="true">
-            {Array.from({ length: 21 }, (_, index) => index * 5).map(
-              (yard) => (
-                <div
-                  key={yard}
-                  className={`yard-guide ${yard % 10 === 0 ? "major" : "minor"} ${yard === 50 ? "midfield" : ""}`}
-                  style={{ top: `${yardToYPct(yard)}%` }}
-                >
-                  <span className="yard-guide-label yard-guide-label--left">
-                    {formatFieldPosition(yard)}
-                  </span>
-                  <span className="yard-guide-label yard-guide-label--right">
-                    {formatFieldPosition(yard)}
-                  </span>
-                </div>
-              ),
-            )}
-          </div>
           <div className="field-line los-line" id="losLine" />
           <div className="field-line first-down-line" id="firstDownLine" />
           <div className="field-line end-line" id="endLine" />
@@ -1452,7 +1430,7 @@ export default function GameField({
                     <span className="field-formation-label">{slot}</span>
                   )}
                   {playerName && (
-                    <span className="field-formation-name"><span className="player-number">{slot}</span><span className="player-name">{playerName}</span><span className="player-yard">{formatFieldPosition(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}</span></span>
+                    <span className="field-formation-name"><span className="player-number">{slot}</span><span className="player-name">{playerName}</span></span>
                   )}
                 </button>
               );


### PR DESCRIPTION
### Motivation
- Undo the merged "improve player positioning clarity" change that introduced a permanent yard-guide grid and per-player yard labels and altered the yard-number rendering. 
- Restore the prior visual presentation and label behavior so the field returns to the previous five-yard numbering and original player-name label layout.

### Description
- Removed the permanent yard grid and guide markup and styles (the `.yard-grid`, `.yard-guide`, and `.yard-guide-label` additions were reverted) from `apps/web/src/components/league/GameField.css` and `GameField.tsx`.
- Removed the per-player yard label output and associated CSS (`.player-yard`) and the `formatFieldPosition` helper in `GameField.tsx`, and restored the original player name label DOM structure.
- Restored the original generation of the five-yard `yard-number` elements in `resetAnimationScene` so yard numbers are appended to the DOM as before.
- The revert was applied to undo the merged PR and produce a single revert commit (`9228893`) on the `work` branch.

### Testing
- Ran `git diff HEAD^..HEAD --check` and it reported no issues. (passed)
- Ran `npm run lint` in `apps/web` and the linter completed successfully. (exit 0)
- Ran `npm run build` in `apps/web` and the project built successfully with Vite/TypeScript. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6abf82fe1c8324b3e0c9bb8dabdf92)