### PR TITLE
Hide player name tags until selection

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -343,28 +343,6 @@ body {
   transform: translateX(-50%) scaleX(var(--facing));
 }
 
-.token .name {
-  position: absolute;
-  left: 50%;
-  top: 100%;
-  transform: translateX(-50%);
-  margin-top: 3px;
-  padding: 2px 5px;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.84);
-  color: #f8fafc;
-  font-size: 10px;
-  font-weight: 900;
-  white-space: nowrap;
-  pointer-events: none;
-}
-
-.token.defense .name {
-  top: auto;
-  margin-top: 0;
-  margin-bottom: 3px;
-}
-
 .token.active-runner .player-sprite,
 .token.ball-carrier .player-sprite {
   box-shadow:
@@ -852,7 +830,7 @@ textarea {
   display: none;
 }
 
-.token .name, .field-formation-name {
+.field-formation-name {
   top: auto;
   bottom: -20px;
   display: flex;
@@ -871,8 +849,6 @@ textarea {
 .player-number { padding: 5px 6px; color: #12100a; background: #ffd45a; font-size: 1.05em; }
 .player-name { padding: 5px 7px; }
 .token.defense .player-number, .field-formation-slot.defense .player-number { color: white; background: #c62828; }
-.possession-dot { width: 7px; height: 7px; margin: 0 6px 0 auto; border-radius: 50%; opacity: 0; background: #ffd45a; box-shadow: 0 0 8px #ffd45a; }
-.token.active-runner .possession-dot, .token.ball-carrier .possession-dot { opacity: 1; }
 .token.active-runner > .player-sprite::before, .token.ball-carrier > .player-sprite::before { content: none; }
 
 .motion-swipe, .action-burst { position: absolute; opacity: 0; pointer-events: none; }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -469,6 +469,8 @@ export default function GameField({
     leftPct: number;
     topPct: number;
   } | null>(null);
+  const [revealedFormationSlot, setRevealedFormationSlot] =
+    useState<FormationSlot | null>(null);
   const findFormationPlayer = useCallback(
     (playerName?: string) =>
       players.find((player) => nameOf(player) === playerName),
@@ -989,20 +991,7 @@ export default function GameField({
           indicator.setAttribute("aria-hidden", "true");
           el.appendChild(indicator);
         }
-        const label = document.createElement("div");
-        label.className = "name";
-        // const number = document.createElement("span");
-        // number.className = "player-number";
-        // number.textContent = player.role || player.position || "--";
-        const labelName = document.createElement("span");
-        labelName.className = "player-name";
-        labelName.textContent = player.name;
-        const possessionDot = document.createElement("span");
-        possessionDot.className = "possession-dot";
-        possessionDot.setAttribute("aria-hidden", "true");
-        label.append(labelName, possessionDot);
         el.appendChild(portrait);
-        el.appendChild(label);
         el.dataset.action = playerActionForStep(player);
         // The field runs vertically, so team/possession must not imply a
         // horizontal facing. Unspecified sprites keep their source artwork's
@@ -1360,7 +1349,10 @@ export default function GameField({
           className="field-wrap"
           id="field"
           ref={fieldRef}
-          onClick={() => setSelectedPlayerMenu(null)}
+          onClick={() => {
+            setSelectedPlayerMenu(null);
+            setRevealedFormationSlot(null);
+          }}
         >
           <div className="field-title">Dynamic Football Animation View</div>
           <div
@@ -1424,6 +1416,9 @@ export default function GameField({
                   }
                   onClick={(event) => {
                     event.stopPropagation();
+                    setRevealedFormationSlot((current) =>
+                      playerName && current !== slot ? slot : null,
+                    );
                     onFormationSlotClick?.(slot);
                   }}
                 >
@@ -1439,8 +1434,11 @@ export default function GameField({
                   ) : (
                     <span className="field-formation-label">{slot}</span>
                   )}
-                  {playerName && (
-                    <span className="field-formation-name"><span className="player-number">{slot}</span><span className="player-name">{playerName}</span></span>
+                  {playerName && revealedFormationSlot === slot && (
+                    <span className="field-formation-name">
+                      <span className="player-number">{slot}</span>
+                      <span className="player-name">{playerName}</span>
+                    </span>
                   )}
                 </button>
               );


### PR DESCRIPTION
### Motivation
- Players in live gameplay currently display persistent name tags which clutter the view, so names should be hidden until a player is explicitly selected. 
- Formation setup names should only be revealed on demand to reduce visual noise and avoid exposing player labels by default.

### Description
- Stop creating and appending the always-visible live player name DOM node by removing the label element creation in `GameField.tsx` and corresponding `.token .name` styles in `GameField.css`.
- Add a `revealedFormationSlot` React state and toggle it when a formation slot is clicked so formation player names are shown only while that slot is revealed, and collapse the reveal when clicking the field background. 
- Wire the field `onClick` to dismiss both the open player action menu and any revealed formation slot name, and conditionally render `.field-formation-name` only when its slot is revealed.
- Remove obsolete `.possession-dot` and related always-visible name/tag styling while preserving formation-name styling and selection visuals.

### Testing
- Built the web app with `npm run build` which completed successfully including the TypeScript build and Vite bundle. 
- Ran the linter with `npm run lint` which returned no blocking errors. 
- Verified there are no style/diff errors with `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6ac81ef9b8832486cfd3fe4e032712)