### PR TITLE
Update scores UI with weekly schedule navigation

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -9,11 +9,13 @@ import { LeagueSchedule } from "./LeagueSchedule";
 import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
+import { WeeklyGamesBanner } from "./WeeklyGamesBanner";
 import "./league.css";
 export function LeagueAppScreen() {
   const [activeTab, setActiveTab] = useState<LeagueTab>("scores");
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
+  const [selectedWeek, setSelectedWeek] = useState(1);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
@@ -122,6 +124,7 @@ export function LeagueAppScreen() {
       {!loadingGame && (
         <>
           <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
+          <WeeklyGamesBanner games={games} weeks={[1, 2, 3, 4]} selectedWeek={selectedWeek} onWeekChange={setSelectedWeek} />
           <div id="tabContents">
             {activeTab === "news" && (
               <div className="league-tab-content active">
@@ -130,7 +133,7 @@ export function LeagueAppScreen() {
             )}
             {activeTab === "scores" && (
               <div className="league-tab-content active">
-                <LeagueSchedule games={games} onSelectGame={openGame} />
+                <LeagueSchedule games={games} weeks={[1, 2, 3, 4]} selectedWeek={selectedWeek} onWeekChange={setSelectedWeek} onSelectGame={openGame} />
               </div>
             )}
             {activeTab === "standings" && (

--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -1,81 +1,45 @@
 import type { LeagueGame } from "./types";
-import {
-  formatBallOnForPoss,
-  formatClock,
-  formatDownDistance,
-  formatQuarter,
-  parseInteger,
-} from "./leagueMappers";
-
 export function LeagueSchedule({
   games,
+  weeks,
+  selectedWeek,
+  onWeekChange,
   onSelectGame,
 }: {
   games: LeagueGame[];
+  weeks: number[];
+  selectedWeek: number;
+  onWeekChange: (week: number) => void;
   onSelectGame: (game: LeagueGame) => void;
 }) {
+  const weekGames = games.filter((game) => Number(game.Week ?? 1) === selectedWeek);
+
   return (
-    <div className="game-list">
-      {games.map((g) => {
-        const final = String(g.Qtr).toUpperCase() === "FINAL";
-        const hs = parseInteger(g.HomeScore);
-        const as = parseInteger(g.AwayScore);
-        const rowClass = (score: number, other: number) =>
-          `team-row ${score > other ? "winner" : score < other ? "loser" : ""}`;
-        return (
+    <div className="scores-page">
+      <header className="scores-heading">
+        <div><span className="eyebrow">Regular season</span><h1>League Scores</h1></div>
+        <span className="scores-heading__week">Week {selectedWeek}</span>
+      </header>
+      <div className="week-tabs" role="tablist" aria-label="Score weeks">
+        {weeks.map((week) => <button key={week} type="button" role="tab" aria-selected={week === selectedWeek} className={week === selectedWeek ? "active" : ""} onClick={() => onWeekChange(week)}>Week {week}</button>)}
+      </div>
+      <div className="game-list">
+      {weekGames.map((g) => (
           <button
             key={String(g.GameId)}
             type="button"
-            className={`game-card ${final ? "final" : ""}`}
+            className="game-card game-card--scheduled"
             onClick={() => onSelectGame(g)}
           >
-            <div className={rowClass(hs, as)}>
-              <img
-                className="team-logo"
-                src={g.HomeLogo || "https://via.placeholder.com/24"}
-                alt="Home Logo"
-              />
-              <div className="team-name-wrap">
-                <span className="team-name">{g.Home}</span>
-                <span className="poss-indicator">
-                  {g.Possession === "Home" ? "🏈" : ""}
-                </span>
-              </div>
-              <span className="team-score">{g.HomeScore}</span>
-              {!final && (
-                <>
-                  <span className="team-time">{formatClock(g.Time)}</span>
-                  <span className="team-down">
-                    {formatDownDistance(g.Down, g.Distance)}
-                  </span>
-                </>
-              )}
-            </div>
-            <div className={rowClass(as, hs)}>
-              <img
-                className="team-logo"
-                src={g.AwayLogo || "https://via.placeholder.com/24"}
-                alt="Away Logo"
-              />
-              <div className="team-name-wrap">
-                <span className="team-name">{g.Away}</span>
-                <span className="poss-indicator">
-                  {g.Possession === "Away" ? "🏈" : ""}
-                </span>
-              </div>
-              <span className="team-score">{g.AwayScore}</span>
-              {!final && (
-                <>
-                  <span className="team-qtr">{formatQuarter(g.Qtr)}</span>
-                  <span className="team-ball">
-                    {formatBallOnForPoss(g.BallOn, g.Possession)}
-                  </span>
-                </>
-              )}
+            <div className="game-card__topline"><span>{g.Date || `Week ${selectedWeek}`}</span><span>Scheduled</span></div>
+            <div className="scheduled-matchup">
+              <div className="scheduled-team"><span className="team-mark-fallback">{g.Away.slice(0, 3)}</span><strong>{g.Away}</strong><span className="record">0-0</span></div>
+              <div className="scheduled-kickoff"><strong>{g.StartTime || "TBD"}</strong><span>Kickoff</span><small>Game preview →</small></div>
+              <div className="scheduled-team"><span className="team-mark-fallback">{g.Home.slice(0, 3)}</span><strong>{g.Home}</strong><span className="record">0-0</span></div>
             </div>
           </button>
-        );
-      })}
+      ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/league/WeeklyGamesBanner.tsx
+++ b/apps/web/src/components/league/WeeklyGamesBanner.tsx
@@ -1,0 +1,62 @@
+import type { LeagueGame } from "./types";
+
+function teamMark(name: string, logo?: string) {
+  return logo ? (
+    <img src={logo} alt="" />
+  ) : (
+    <span className="team-mark-fallback">{name.slice(0, 3).toUpperCase()}</span>
+  );
+}
+
+export function WeeklyGamesBanner({
+  games,
+  weeks,
+  selectedWeek,
+  onWeekChange,
+}: {
+  games: LeagueGame[];
+  weeks: number[];
+  selectedWeek: number;
+  onWeekChange: (week: number) => void;
+}) {
+  const weekGames = games.filter((game) => Number(game.Week ?? 1) === selectedWeek);
+
+  return (
+    <section className="games-banner" aria-label="This week's games">
+      <div className="games-banner__weeks" role="tablist" aria-label="Game week">
+        {weeks.map((week) => (
+          <button
+            key={week}
+            type="button"
+            role="tab"
+            aria-selected={selectedWeek === week}
+            className={selectedWeek === week ? "active" : ""}
+            onClick={() => onWeekChange(week)}
+          >
+            Week {week}
+          </button>
+        ))}
+      </div>
+      <div className="games-banner__rail">
+        {weekGames.map((game) => (
+          <article className="banner-game" key={String(game.GameId)}>
+            <div className="banner-game__meta">
+              <span>{game.Date || "Upcoming"}</span>
+              <strong>{game.StartTime || "TBD"}</strong>
+            </div>
+            <div className="banner-game__team">
+              {teamMark(game.Away, game.AwayLogo)}
+              <strong>{game.Away}</strong>
+              <span>–</span>
+            </div>
+            <div className="banner-game__team">
+              {teamMark(game.Home, game.HomeLogo)}
+              <strong>{game.Home}</strong>
+              <span>–</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -221,26 +221,102 @@
     grid-column: 1/-1;
   }
 }
-.game-list {
-  padding: 2.5vw;
+.games-banner {
+  position: sticky;
+  top: clamp(92px, 14vw, 150px);
+  z-index: 80;
+  background: #0b0d10;
+  border-bottom: 1px solid #34383f;
+  box-shadow: 0 8px 24px #0008;
 }
+.games-banner__weeks,
+.week-tabs {
+  display: flex;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.games-banner__weeks {
+  padding: 0 clamp(16px, 3vw, 48px);
+  border-bottom: 1px solid #292d33;
+}
+.games-banner__weeks button,
+.week-tabs button {
+  flex: 0 0 auto;
+  border: 0;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+  color: #9298a2;
+  font-weight: 700;
+  cursor: pointer;
+}
+.games-banner__weeks button { padding: 12px 20px 10px; font-size: 13px; }
+.games-banner__weeks button.active,
+.week-tabs button.active { color: white; border-bottom-color: var(--accent-red); }
+.games-banner__rail {
+  display: flex;
+  overflow-x: auto;
+  padding: 10px clamp(16px, 3vw, 48px) 12px;
+  scrollbar-color: #444 transparent;
+}
+.banner-game {
+  flex: 0 0 clamp(220px, 25vw, 310px);
+  padding: 0 20px;
+  border-right: 1px solid #30343a;
+}
+.banner-game:first-child { padding-left: 0; }
+.banner-game__meta,
+.banner-game__team { display: flex; align-items: center; }
+.banner-game__meta { justify-content: space-between; color: #9298a2; font-size: 11px; margin-bottom: 6px; text-transform: uppercase; letter-spacing: .06em; }
+.banner-game__meta strong { color: #dce0e7; }
+.banner-game__team { gap: 8px; min-height: 26px; font-size: 13px; }
+.banner-game__team img,
+.team-mark-fallback { width: 26px; height: 26px; object-fit: contain; }
+.team-mark-fallback { display: inline-grid; place-items: center; flex: 0 0 auto; border-radius: 50%; background: linear-gradient(145deg, #3e454f, #171a1f); border: 1px solid #58606b; color: white; font-size: 8px; font-weight: 800; }
+.banner-game__team strong { flex: 1; }
+.banner-game__team > span:last-child { color: #79808a; font-weight: 800; }
+.scores-page { max-width: 1180px; margin: 0 auto; padding: clamp(28px, 5vw, 64px) clamp(16px, 3vw, 36px); }
+.scores-heading { display: flex; justify-content: space-between; align-items: end; margin-bottom: 24px; }
+.scores-heading h1 { margin: 4px 0 0; font-size: clamp(30px, 4vw, 48px); letter-spacing: -.04em; }
+.eyebrow { color: var(--accent-red); text-transform: uppercase; font-size: 12px; font-weight: 800; letter-spacing: .16em; }
+.scores-heading__week { color: #aeb4bd; font-weight: 700; }
+.week-tabs { gap: 8px; margin-bottom: 24px; border-bottom: 1px solid #34383f; }
+.week-tabs button { padding: 14px clamp(16px, 3vw, 28px); font-size: 14px; }
+.game-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
 .game-card {
-  display: block;
   width: 100%;
   text-align: left;
-  background: var(--gray-medium);
-  border: 1px solid var(--gray-light);
-  border-radius: 4px;
-  margin-bottom: 3vw;
+  background: linear-gradient(145deg, #202329, #181a1f);
+  border: 1px solid #363b43;
+  border-radius: 10px;
   cursor: pointer;
-  padding: 2.5vw;
+  padding: 0;
   color: inherit;
+  overflow: hidden;
+  transition: transform .18s ease, border-color .18s ease;
 }
+.game-card:hover { transform: translateY(-2px); border-color: #626a76; }
+.game-card__topline { display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #333840; color: #aeb4bd; font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; }
+.game-card__topline span:last-child { color: #dfe3e8; }
+.scheduled-matchup { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; padding: clamp(20px, 3vw, 32px) 16px; }
+.scheduled-team,
+.scheduled-kickoff { display: flex; flex-direction: column; align-items: center; text-align: center; }
+.scheduled-team .team-mark-fallback { width: 54px; height: 54px; margin-bottom: 10px; font-size: 13px; }
+.scheduled-team strong { font-size: clamp(16px, 2vw, 22px); }
+.record { color: #8f96a0; font-size: 12px; margin-top: 3px; }
+.scheduled-kickoff { padding: 0 12px; }
+.scheduled-kickoff strong { font-size: clamp(16px, 2vw, 21px); }
+.scheduled-kickoff span { color: #9298a2; font-size: 11px; text-transform: uppercase; letter-spacing: .12em; margin-top: 3px; }
+.scheduled-kickoff small { color: #e16d70; margin-top: 14px; }
 .game-card .team-row {
   display: flex;
   align-items: center;
   font-size: 4vw;
   gap: 0;
+}
+@media (max-width: 700px) {
+  .games-banner { top: 132px; }
+  .game-list { grid-template-columns: 1fr; }
+  .league-name { padding-bottom: 1vw; }
 }
 .game-card .team-row + .team-row {
   margin-top: 1vw;

--- a/apps/web/src/components/league/leagueMockData.ts
+++ b/apps/web/src/components/league/leagueMockData.ts
@@ -14,6 +14,9 @@ export const mockGames: LeagueGame[] = [
     Distance: 7,
     BallOn: 64,
     Possession: "Home",
+    Week: 1,
+    Date: "Sun, Sep 7",
+    StartTime: "1:00 PM",
   },
   {
     GameId: 2,
@@ -27,7 +30,14 @@ export const mockGames: LeagueGame[] = [
     Distance: 10,
     BallOn: 50,
     Possession: "Away",
+    Week: 1,
+    Date: "Sun, Sep 7",
+    StartTime: "4:25 PM",
   },
+  { GameId: 3, Home: "MIA", Away: "BUF", HomeScore: 0, AwayScore: 0, Qtr: 1, Time: "15:00", Down: 1, Distance: 10, BallOn: 25, Possession: "Away", Week: 2, Date: "Sun, Sep 14", StartTime: "1:00 PM" },
+  { GameId: 4, Home: "DAL", Away: "NYG", HomeScore: 0, AwayScore: 0, Qtr: 1, Time: "15:00", Down: 1, Distance: 10, BallOn: 25, Possession: "Away", Week: 2, Date: "Sun, Sep 14", StartTime: "8:20 PM" },
+  { GameId: 5, Home: "SF", Away: "SEA", HomeScore: 0, AwayScore: 0, Qtr: 1, Time: "15:00", Down: 1, Distance: 10, BallOn: 25, Possession: "Away", Week: 3, Date: "Sun, Sep 21", StartTime: "4:05 PM" },
+  { GameId: 6, Home: "KC", Away: "LAC", HomeScore: 0, AwayScore: 0, Qtr: 1, Time: "15:00", Down: 1, Distance: 10, BallOn: 25, Possession: "Away", Week: 4, Date: "Mon, Sep 29", StartTime: "8:15 PM" },
 ];
 
 // TODO: Replace fallback standings with the Teams sheet through /api/teams in production-like local runs.

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -15,6 +15,9 @@ export type LeagueGame = {
   Possession: "Home" | "Away" | string;
   HomeLogo?: string;
   AwayLogo?: string;
+  Week?: string | number;
+  Date?: string;
+  StartTime?: string;
 };
 
 export type LeagueTeam = Record<string, string | number | undefined> & {


### PR DESCRIPTION
### Motivation

- Provide a week-oriented Scores UI where each week is a sub-tab and only that week's games show when selected.
- Add a persistent, horizontally-scrollable games banner with selectable weeks and compact kickoff/team info above the Scores content.
- Show all upcoming matchups as unstarted/scheduled cards until week-start tracking is implemented.

### Description

- Added a new `WeeklyGamesBanner` component that renders selectable week tabs and a horizontal rail of compact matchup cards, and integrated it into `LeagueAppScreen` via `selectedWeek` state.
- Extended `LeagueSchedule` to accept `weeks`, `selectedWeek`, and `onWeekChange` props, and to render only `Week`-filtered matchups as scheduled matchup cards instead of the previous live-score row layout.
- Extended `LeagueGame` type with `Week`, `Date`, and `StartTime` fields and populated `mockGames` with multi-week fallback data so the new week navigation can be exercised locally.
- Added styles in `league.css` for the sticky banner, week tabs, scheduled matchup cards, two-column scores grid, and responsive behavior for mobile and desktop.

### Testing

- Ran `npx eslint src/components/league/LeagueAppScreen.tsx src/components/league/LeagueSchedule.tsx src/components/league/WeeklyGamesBanner.tsx src/components/league/leagueMockData.ts src/components/league/types.ts` which completed successfully for the changed files.
- Ran `git diff --check` which reported no whitespace/merge errors in the changes.
- Attempted `npm run build`, which failed due to pre-existing TypeScript errors in unrelated files (`GameCenter.tsx` and `gameplay/engine/runEngine.ts`) and did not block merging these UI changes.
- Running the workspace-wide `npm run lint` surfaced pre-existing lint errors in unrelated files (`GameControls.tsx` and `gameplay/engine/runEngine.ts`) unrelated to this UI update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6cc1e256e483248b0d6f80fa2a80e2)