### PR TITLE
Update scores UI with weekly scoreboard

### DIFF
--- a/apps/web/src/components/league/GamesBanner.tsx
+++ b/apps/web/src/components/league/GamesBanner.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import type { LeagueGame } from "./types";
+
+const WEEKS = [1, 2, 3, 4, 5];
+
+const gameWeek = (game: LeagueGame, index: number) =>
+  Number(game.Week ?? (index % WEEKS.length) + 1);
+
+export function GamesBanner({ games }: { games: LeagueGame[] }) {
+  const [week, setWeek] = useState(1);
+  const weekGames = games.filter((game, index) => gameWeek(game, index) === week);
+
+  return (
+    <aside className="games-banner" aria-label="Games this week">
+      <div className="games-banner__brand">AFL</div>
+      <label className="games-banner__picker">
+        <span>Week</span>
+        <select value={week} onChange={(event) => setWeek(Number(event.target.value))}>
+          {WEEKS.map((item) => <option key={item} value={item}>Week {item}</option>)}
+        </select>
+      </label>
+      <div className="games-banner__rail">
+        {weekGames.length ? weekGames.map((game) => (
+          <article className="banner-game" key={String(game.GameId)}>
+            <div className="banner-game__meta">{game.Kickoff || "TBD"} <span>{game.Network || "AFL Network"}</span></div>
+            <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /> <strong>{game.Away}</strong><b>0-0</b></div>
+            <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /> <strong>{game.Home}</strong><b>0-0</b></div>
+          </article>
+        )) : <p className="games-banner__empty">Week {week} matchups are coming soon</p>}
+      </div>
+      <div className="games-banner__all">Full Scoreboard <span aria-hidden="true">›</span></div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -9,6 +9,7 @@ import { LeagueSchedule } from "./LeagueSchedule";
 import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
+import { GamesBanner } from "./GamesBanner";
 import "./league.css";
 type LeagueAppScreenProps = {
   onBack?: () => void;
@@ -74,6 +75,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   if (selectedGame)
     return (
       <section className="league-app">
+        <GamesBanner games={games} />
         <GameCenter game={selectedGame} onBack={() => setSelectedGame(null)} />
       </section>
     );
@@ -134,6 +136,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
               ← Back
             </button>
           )}
+          <GamesBanner games={games} />
           <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
           <div id="tabContents">
             {activeTab === "news" && (

--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -1,81 +1,44 @@
+import { useMemo, useState } from "react";
 import type { LeagueGame } from "./types";
-import {
-  formatBallOnForPoss,
-  formatClock,
-  formatDownDistance,
-  formatQuarter,
-  parseInteger,
-} from "./leagueMappers";
 
-export function LeagueSchedule({
-  games,
-  onSelectGame,
-}: {
-  games: LeagueGame[];
-  onSelectGame: (game: LeagueGame) => void;
-}) {
+const WEEKS = [1, 2, 3, 4, 5];
+
+const gameWeek = (game: LeagueGame, index: number) =>
+  Number(game.Week ?? (index % WEEKS.length) + 1);
+
+export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; onSelectGame: (game: LeagueGame) => void }) {
+  const [activeWeek, setActiveWeek] = useState(1);
+  const weekGames = useMemo(
+    () => games.filter((game, index) => gameWeek(game, index) === activeWeek),
+    [activeWeek, games],
+  );
+
   return (
-    <div className="game-list">
-      {games.map((g) => {
-        const final = String(g.Qtr).toUpperCase() === "FINAL";
-        const hs = parseInteger(g.HomeScore);
-        const as = parseInteger(g.AwayScore);
-        const rowClass = (score: number, other: number) =>
-          `team-row ${score > other ? "winner" : score < other ? "loser" : ""}`;
-        return (
-          <button
-            key={String(g.GameId)}
-            type="button"
-            className={`game-card ${final ? "final" : ""}`}
-            onClick={() => onSelectGame(g)}
-          >
-            <div className={rowClass(hs, as)}>
-              <img
-                className="team-logo"
-                src={g.HomeLogo || "https://via.placeholder.com/24"}
-                alt="Home Logo"
-              />
-              <div className="team-name-wrap">
-                <span className="team-name">{g.Home}</span>
-                <span className="poss-indicator">
-                  {g.Possession === "Home" ? "🏈" : ""}
-                </span>
-              </div>
-              <span className="team-score">{g.HomeScore}</span>
-              {!final && (
-                <>
-                  <span className="team-time">{formatClock(g.Time)}</span>
-                  <span className="team-down">
-                    {formatDownDistance(g.Down, g.Distance)}
-                  </span>
-                </>
-              )}
-            </div>
-            <div className={rowClass(as, hs)}>
-              <img
-                className="team-logo"
-                src={g.AwayLogo || "https://via.placeholder.com/24"}
-                alt="Away Logo"
-              />
-              <div className="team-name-wrap">
-                <span className="team-name">{g.Away}</span>
-                <span className="poss-indicator">
-                  {g.Possession === "Away" ? "🏈" : ""}
-                </span>
-              </div>
-              <span className="team-score">{g.AwayScore}</span>
-              {!final && (
-                <>
-                  <span className="team-qtr">{formatQuarter(g.Qtr)}</span>
-                  <span className="team-ball">
-                    {formatBallOnForPoss(g.BallOn, g.Possession)}
-                  </span>
-                </>
-              )}
-            </div>
+    <div className="scores-screen">
+      <header className="scores-heading">
+        <div><span className="scores-heading__eyebrow">2026 SEASON</span><h1>AFL Scoreboard</h1></div>
+        <div className="scores-heading__status"><i /> Games have not started</div>
+      </header>
+      <nav className="week-tabs" aria-label="Scoreboard weeks">
+        {WEEKS.map((week) => (
+          <button key={week} type="button" className={activeWeek === week ? "active" : ""} onClick={() => setActiveWeek(week)}>
+            <span>WEEK {week}</span><small>{week === 1 ? "SEP 6" : `WEEK ${week}`}</small>
           </button>
-        );
-      })}
+        ))}
+      </nav>
+      <section className="week-scoreboard">
+        <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>Upcoming Games</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
+        {weekGames.length ? weekGames.map((game) => (
+          <article className="schedule-game" key={String(game.GameId)}>
+            <div className="schedule-game__date"><strong>{game.Date || `Week ${activeWeek}`}</strong><span>{game.Kickoff || "Time TBD"} · {game.Network || "AFL Network"}</span></div>
+            <div className="schedule-game__teams">
+              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.Away}</strong><small>AWAY · 0-0</small></span><b>0</b></div>
+              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.Home}</strong><small>HOME · 0-0</small></span><b>0</b></div>
+            </div>
+            <div className="schedule-game__action"><span>PRE-GAME</span><button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button></div>
+          </article>
+        )) : <div className="schedule-empty"><strong>No games scheduled yet</strong><span>Check back for the Week {activeWeek} matchup announcement.</span></div>}
+      </section>
     </div>
   );
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -19,9 +19,45 @@
 .league-app * {
   box-sizing: border-box;
 }
-.league-header {
+.games-banner {
   position: sticky;
   top: 0;
+  z-index: 120;
+  height: 88px;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  color: #17202b;
+  background: #f8fafc;
+  border-bottom: 1px solid #cbd2da;
+  box-shadow: 0 3px 12px #0006;
+}
+.games-banner__brand {
+  display: grid;
+  place-items: center;
+  width: 98px;
+  flex: 0 0 auto;
+  color: #fff;
+  background: linear-gradient(125deg, #99000b 0 70%, #c10206 70%);
+  font: italic 900 1.55rem/1 Arial, sans-serif;
+  letter-spacing: .08em;
+}
+.games-banner__picker { display: grid; align-content: center; gap: 4px; flex: 0 0 135px; padding: 10px 18px; border-right: 1px solid #d9dee4; }
+.games-banner__picker span { color: #6a7480; font-size: .64rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+.games-banner__picker select { border: 0; background: transparent; color: #17202b; font-weight: 800; cursor: pointer; outline-offset: 4px; }
+.games-banner__rail { display: flex; flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+.banner-game { flex: 0 0 210px; padding: 10px 16px; border-right: 1px solid #d9dee4; }
+.banner-game__meta { display: flex; justify-content: space-between; margin-bottom: 6px; font-size: .68rem; font-weight: 800; }
+.banner-game__meta span { color: #68727f; font-weight: 500; }
+.banner-game > div:not(.banner-game__meta) { display: grid; grid-template-columns: 20px 1fr auto; gap: 7px; align-items: center; min-height: 24px; font-size: .75rem; }
+.banner-game img { width: 18px; height: 18px; object-fit: contain; }
+.banner-game b { font-size: .68rem; }
+.games-banner__empty { margin: auto 24px; color: #78828e; font-size: .8rem; }
+.games-banner__all { display: grid; place-items: center; grid-auto-flow: column; gap: 14px; flex: 0 0 145px; padding: 12px; color: #52606e; border-left: 1px solid #d9dee4; font-size: .74rem; }
+.games-banner__all span { color: var(--accent-red); font-size: 1.7rem; }
+.league-header {
+  position: sticky;
+  top: 88px;
   z-index: 100;
   display: flex;
   flex-direction: column;
@@ -223,6 +259,55 @@
 }
 .game-list {
   padding: 2.5vw;
+}
+.scores-screen { min-height: calc(100vh - 170px); padding: clamp(20px, 3vw, 46px); background: #111419; }
+.scores-heading { display: flex; align-items: end; justify-content: space-between; max-width: 1180px; margin: 0 auto 24px; }
+.scores-heading h1 { margin: 3px 0 0; font-size: clamp(2rem, 4vw, 3.4rem); letter-spacing: -.04em; }
+.scores-heading__eyebrow { color: #e84b50; font-size: .7rem; font-weight: 800; letter-spacing: .18em; }
+.scores-heading__status { padding-bottom: 8px; color: #aeb5bf; font-size: .78rem; }
+.scores-heading__status i { display: inline-block; width: 7px; height: 7px; margin-right: 7px; border-radius: 50%; background: #828b97; }
+.week-tabs { display: flex; max-width: 1180px; margin: 0 auto; overflow-x: auto; border: 1px solid #30353d; border-bottom: 0; background: #191d23; }
+.week-tabs button { min-width: 120px; flex: 1; padding: 16px 12px 13px; color: #8f98a4; background: transparent; border: 0; border-right: 1px solid #30353d; border-bottom: 3px solid transparent; cursor: pointer; }
+.week-tabs button:last-child { border-right: 0; }
+.week-tabs button span, .week-tabs button small { display: block; }
+.week-tabs button span { margin-bottom: 5px; font-size: .76rem; font-weight: 800; letter-spacing: .08em; }
+.week-tabs button small { font-size: .62rem; }
+.week-tabs button.active { color: #fff; background: #232830; border-bottom-color: var(--accent-red); }
+.week-scoreboard { max-width: 1180px; margin: 0 auto; border: 1px solid #30353d; background: #191d23; }
+.week-scoreboard__title { display: flex; justify-content: space-between; align-items: center; padding: 22px 26px; border-bottom: 1px solid #30353d; }
+.week-scoreboard__title span { color: #929ba7; font-size: .66rem; font-weight: 800; letter-spacing: .12em; }
+.week-scoreboard__title h2 { margin: 3px 0 0; font-size: 1.25rem; }
+.schedule-game { display: grid; grid-template-columns: minmax(190px, .85fr) minmax(300px, 1.5fr) 160px; min-height: 176px; border-bottom: 1px solid #30353d; }
+.schedule-game:last-child { border-bottom: 0; }
+.schedule-game__date, .schedule-game__action { display: flex; flex-direction: column; justify-content: center; padding: 24px 26px; }
+.schedule-game__date { border-right: 1px solid #292e35; }
+.schedule-game__date strong { margin-bottom: 8px; font-size: .88rem; }
+.schedule-game__date span { color: #929ba7; font-size: .72rem; }
+.schedule-game__teams { display: grid; align-content: center; padding: 18px 34px; }
+.schedule-game__teams > div { display: grid; grid-template-columns: 42px 1fr auto; align-items: center; gap: 16px; min-height: 64px; }
+.schedule-game__teams img { width: 38px; height: 38px; object-fit: contain; }
+.schedule-game__teams span { display: grid; gap: 3px; }
+.schedule-game__teams strong { font-size: 1.05rem; }
+.schedule-game__teams small { color: #7f8995; font-size: .65rem; letter-spacing: .06em; }
+.schedule-game__teams b { font-size: 1.55rem; }
+.schedule-game__action { align-items: stretch; gap: 13px; border-left: 1px solid #292e35; }
+.schedule-game__action > span { color: #7f8995; text-align: center; font-size: .62rem; font-weight: 800; letter-spacing: .12em; }
+.schedule-game__action button { display: flex; justify-content: space-between; padding: 11px 14px; color: #fff; border: 1px solid #59616c; border-radius: 3px; background: transparent; cursor: pointer; font-size: .74rem; font-weight: 700; }
+.schedule-game__action button:hover { border-color: #e84b50; background: #c102061f; }
+.schedule-game__action button b { color: #e84b50; }
+.schedule-empty { display: grid; gap: 8px; place-items: center; min-height: 190px; color: #9aa3ae; }
+.schedule-empty strong { color: #fff; }
+@media (max-width: 720px) {
+  .games-banner { height: 76px; }
+  .games-banner__brand, .games-banner__all { display: none; }
+  .games-banner__picker { flex-basis: 108px; padding: 8px 12px; }
+  .banner-game { flex-basis: 180px; padding: 8px 12px; }
+  .league-header { top: 76px; }
+  .scores-heading { align-items: start; flex-direction: column; gap: 10px; }
+  .schedule-game { grid-template-columns: 1fr 105px; }
+  .schedule-game__date { grid-column: 1 / -1; padding: 15px 20px; border-right: 0; border-bottom: 1px solid #292e35; }
+  .schedule-game__teams { padding: 12px 18px; }
+  .schedule-game__action { padding: 16px 12px; }
 }
 .game-card {
   display: block;

--- a/apps/web/src/components/league/leagueMockData.ts
+++ b/apps/web/src/components/league/leagueMockData.ts
@@ -4,6 +4,10 @@ import type { LeagueGame, LeagueTeam } from "./types";
 export const mockGames: LeagueGame[] = [
   {
     GameId: 1,
+    Week: 1,
+    Date: "Sunday, September 6",
+    Kickoff: "1:00 PM",
+    Network: "AFL Network",
     Home: "LV",
     Away: "DEN",
     HomeScore: 14,
@@ -17,6 +21,10 @@ export const mockGames: LeagueGame[] = [
   },
   {
     GameId: 2,
+    Week: 2,
+    Date: "Sunday, September 13",
+    Kickoff: "4:25 PM",
+    Network: "AFL Network",
     Home: "CHI",
     Away: "GB",
     HomeScore: 24,

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -13,6 +13,10 @@ export type LeagueGame = {
   Distance: string | number;
   BallOn: string | number;
   Possession: "Home" | "Away" | string;
+  Week?: string | number;
+  Date?: string;
+  Kickoff?: string;
+  Network?: string;
   HomeLogo?: string;
   AwayLogo?: string;
 };


### PR DESCRIPTION
### Motivation
- Provide a week-focused Scores experience where each week is its own sub-tab and only that week’s games are shown.
- Surface upcoming matchups in a persistent, selectable games banner for quick navigation and at-a-glance kickoff/network info. 
- Prepare the data model for future scheduling and API integration by adding basic scheduling fields to game objects.

### Description
- Replaced the previous scoreboard list with a new `LeagueSchedule` that renders week tabs, filters games by week, and shows pre-game cards that display unstarted games with `0-0` placeholder scores and kickoff/network metadata. (new/modified: `LeagueSchedule.tsx`)
- Added a persistent `GamesBanner` component that is sticky at the top, allows week selection, and shows compact game tiles for the selected week. (added: `GamesBanner.tsx`, updated: `LeagueAppScreen.tsx` to include the banner)
- Extended the `LeagueGame` type with optional `Week`, `Date`, `Kickoff`, and `Network` fields and updated fallback mock fixtures to include those values. (modified: `types.ts`, `leagueMockData.ts`)
- Added responsive and desktop CSS for the games banner, week tabs, and schedule layout and adjusted header positioning to accommodate the sticky banner. (modified: `league.css`)

### Testing
- Built the web app with `npm run build` which completed successfully and produced the production bundle. 
- Ran `npm run lint` which completed with no errors; one pre-existing `react-hooks/exhaustive-deps` warning remained in `GameField.tsx`. 
- Ran `git diff --check` to verify diffs; no blocking issues were reported. 
- Attempted to install Playwright and capture a screenshot, but the Chromium download failed with an HTTP 403 from the CDN, so automated screenshot verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d1ad32f1483249caaba75cc335ac4)