### PR TITLE
Add weekly and team schedule views

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -6,6 +6,7 @@ import { normalizeGames } from "./leagueMappers";
 import { LeagueHeader } from "./LeagueHeader";
 import { LeagueNews } from "./LeagueNews";
 import { LeagueSchedule } from "./LeagueSchedule";
+import { Schedules } from "./Schedules";
 import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
@@ -144,6 +145,11 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             {activeTab === "scores" && (
               <div className="league-tab-content active">
                 <LeagueSchedule games={games} onSelectGame={openGame} />
+              </div>
+            )}
+            {activeTab === "schedules" && (
+              <div className="league-tab-content active">
+                <Schedules games={games} teams={teams} />
               </div>
             )}
             {activeTab === "standings" && (

--- a/apps/web/src/components/league/Schedules.tsx
+++ b/apps/web/src/components/league/Schedules.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from "react";
+import type { LeagueGame, LeagueTeam } from "./types";
+import { parseInteger } from "./leagueMappers";
+
+const teamName = (team: LeagueTeam) => String(team.Team || team.Name || "");
+const gameWeek = (game: LeagueGame) => Math.max(1, parseInteger(game.Week) || 1);
+const isFinal = (game: LeagueGame) => String(game.Qtr).toUpperCase() === "FINAL";
+
+function TeamLogo({ src, name }: { src?: string; name: string }) {
+  return src ? <img src={src} alt="" /> : <span aria-hidden="true">{name.slice(0, 2)}</span>;
+}
+
+export function Schedules({ games, teams }: { games: LeagueGame[]; teams: LeagueTeam[] }) {
+  const [week, setWeek] = useState(1);
+  const [selectedTeam, setSelectedTeam] = useState("");
+  const currentYear = new Date().getFullYear();
+  const teamOptions = useMemo(() => {
+    const names = new Set(teams.map(teamName).filter(Boolean));
+    games.forEach((game) => { names.add(game.Home); names.add(game.Away); });
+    return [...names].sort();
+  }, [games, teams]);
+  const weeks = useMemo(() => {
+    const maximum = Math.max(4, ...games.map(gameWeek));
+    return Array.from({ length: maximum }, (_, index) => index + 1);
+  }, [games]);
+
+  if (selectedTeam) {
+    const teamGames = games.filter((game) => game.Home === selectedTeam || game.Away === selectedTeam);
+    return (
+      <section className="team-schedule-page">
+        <header className="team-schedule-hero">
+          <div className="team-schedule-monogram">{selectedTeam.slice(0, 2)}</div>
+          <div><p>TEAM</p><h2>{selectedTeam}</h2><span>Football Club</span></div>
+        </header>
+        <nav className="team-subtabs" aria-label={`${selectedTeam} sections`}>
+          <button type="button">Overview</button><button type="button">Roster</button>
+          <button type="button" className="active">Schedule</button><button type="button">Stats</button>
+        </nav>
+        <div className="schedule-surface team-surface">
+          <div className="schedule-title-row">
+            <div><span className="schedule-eyebrow">{currentYear} SEASON</span><h1>{selectedTeam} Schedule</h1></div>
+            <select value={selectedTeam} onChange={(event) => setSelectedTeam(event.target.value)} aria-label="Choose another team">
+              <option value="">All weekly schedules</option>
+              {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+            </select>
+          </div>
+          <h3 className="schedule-section-title">Regular Season</h3>
+          <div className="schedule-table-scroll"><table className="schedule-table team-schedule-table">
+            <thead><tr><th>WK</th><th>DATE</th><th>OPPONENT</th><th>{teamGames.some(isFinal) ? "RESULT" : "TIME"}</th><th>STATUS</th></tr></thead>
+            <tbody>{teamGames.length ? teamGames.map((game) => {
+              const home = game.Home === selectedTeam;
+              const opponent = home ? game.Away : game.Home;
+              const ownScore = parseInteger(home ? game.HomeScore : game.AwayScore);
+              const opponentScore = parseInteger(home ? game.AwayScore : game.HomeScore);
+              const final = isFinal(game);
+              return <tr key={String(game.GameId)}><td>{gameWeek(game)}</td><td>{game.Date || "Date TBD"}</td>
+                <td><span className="venue-mark">{home ? "vs" : "@"}</span> <TeamLogo src={home ? game.AwayLogo : game.HomeLogo} name={opponent} /> <strong>{opponent}</strong></td>
+                <td>{final ? <><b className={ownScore > opponentScore ? "result-win" : "result-loss"}>{ownScore > opponentScore ? "W" : "L"}</b> {ownScore}-{opponentScore}</> : String(game.Time || "TBD")}</td>
+                <td>{final ? "Final" : `Week ${gameWeek(game)}`}</td></tr>;
+            }) : <tr><td colSpan={5} className="schedule-empty">No games are scheduled for this team yet.</td></tr>}</tbody>
+          </table></div>
+          <button className="all-schedules-link" type="button" onClick={() => setSelectedTeam("")}>← Back to all schedules</button>
+        </div>
+      </section>
+    );
+  }
+
+  const weeklyGames = games.filter((game) => gameWeek(game) === week);
+  return <section className="schedule-page"><div className="schedule-surface">
+    <div className="schedule-title-row"><div><span className="schedule-eyebrow">LEAGUE</span><h1>Weekly Schedule</h1></div>
+      <select value={selectedTeam} onChange={(event) => setSelectedTeam(event.target.value)} aria-label="Team schedules">
+        <option value="">All Team Schedules</option>{teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+      </select>
+    </div>
+    <div className="week-picker" aria-label="Select schedule week">
+      {weeks.map((item) => <button key={item} type="button" className={week === item ? "active" : ""} onClick={() => setWeek(item)}><span>WEEK</span><strong>{item}</strong></button>)}
+    </div>
+    <div className="week-heading"><div><span>WEEK {week}</span><h2>League Matchups</h2></div><strong>{weeklyGames.length} {weeklyGames.length === 1 ? "GAME" : "GAMES"}</strong></div>
+    <div className="weekly-games">{weeklyGames.length ? weeklyGames.map((game) => {
+      const final = isFinal(game); return <article className="weekly-game" key={String(game.GameId)}>
+        <div className="game-date"><span>{game.Date || `WEEK ${week}`}</span><b>{final ? "FINAL" : String(game.Time || "TBD")}</b></div>
+        <div className="matchup-team"><TeamLogo src={game.AwayLogo} name={game.Away}/><strong>{game.Away}</strong><b>{final ? game.AwayScore : ""}</b></div>
+        <div className="matchup-team"><TeamLogo src={game.HomeLogo} name={game.Home}/><strong>{game.Home}</strong><b>{final ? game.HomeScore : ""}</b></div>
+        <button type="button" onClick={() => setSelectedTeam(game.Home)}>View team schedule <span>→</span></button>
+      </article>;
+    }) : <div className="schedule-empty">No games have been scheduled for Week {week}.</div>}</div>
+  </div></section>;
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -224,6 +224,89 @@
 .game-list {
   padding: 2.5vw;
 }
+.schedule-page,
+.team-schedule-page {
+  min-height: calc(100vh - 120px);
+  padding: clamp(16px, 3vw, 42px);
+  background: #eef0f3;
+  color: #20242b;
+}
+.schedule-surface {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(22px, 3.5vw, 48px);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 12px 40px #1b24300d;
+}
+.schedule-title-row,
+.week-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.schedule-title-row h1 { margin: 4px 0 0; font-size: clamp(30px, 4vw, 48px); letter-spacing: -.035em; }
+.schedule-eyebrow { color: #c10206; font-size: 12px; font-weight: 800; letter-spacing: .18em; }
+.schedule-title-row select {
+  min-width: 210px;
+  padding: 13px 42px 13px 18px;
+  border: 1px solid #d7dbe0;
+  border-radius: 999px;
+  background: #fff;
+  color: #20242b;
+  font-weight: 700;
+}
+.week-picker { display: flex; gap: 8px; margin: 34px 0; overflow-x: auto; padding-bottom: 7px; }
+.week-picker button {
+  min-width: 92px; padding: 12px 22px; border: 0; border-radius: 10px; background: #f1f3f5; color: #6e747c; cursor: pointer;
+}
+.week-picker button span { display: block; font-size: 10px; font-weight: 800; letter-spacing: .12em; }
+.week-picker button strong { display: block; margin-top: 3px; font-size: 23px; }
+.week-picker button.active { background: #c10206; color: #fff; box-shadow: 0 7px 18px #c1020640; }
+.week-heading { margin: 8px 0 18px; padding-bottom: 18px; border-bottom: 1px solid #e5e7ea; }
+.week-heading span { color: #c10206; font-size: 12px; font-weight: 800; letter-spacing: .14em; }
+.week-heading h2 { margin: 4px 0 0; font-size: 24px; }
+.week-heading > strong { color: #777d85; font-size: 12px; letter-spacing: .1em; }
+.weekly-games { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.weekly-game { padding: 20px; border: 1px solid #e1e4e8; border-radius: 12px; box-shadow: 0 4px 12px #1d27330a; }
+.game-date { display: flex; justify-content: space-between; margin-bottom: 18px; color: #717780; font-size: 12px; font-weight: 700; }
+.game-date b { color: #c10206; }
+.matchup-team { display: grid; grid-template-columns: 38px 1fr auto; align-items: center; gap: 12px; min-height: 48px; font-size: 18px; }
+.matchup-team img, .matchup-team > span, .team-schedule-table img, .team-schedule-table td span:not(.venue-mark) {
+  display: inline-grid; place-items: center; width: 34px; height: 34px; border-radius: 50%; background: #20242b; color: #fff; object-fit: contain; font-size: 10px;
+}
+.matchup-team > b { font-size: 22px; }
+.weekly-game > button, .all-schedules-link { margin-top: 15px; padding: 12px 0 0; width: 100%; border: 0; border-top: 1px solid #eceef0; background: transparent; color: #1267ba; text-align: left; font-weight: 700; cursor: pointer; }
+.weekly-game > button span { float: right; }
+.schedule-empty { grid-column: 1 / -1; padding: 56px 20px !important; color: #777d85; text-align: center !important; background: #f7f8f9; border-radius: 10px; }
+.team-schedule-page { padding-top: 0; }
+.team-schedule-hero { display: flex; align-items: center; gap: 20px; max-width: 1280px; margin: 0 auto; padding: 28px 10px; }
+.team-schedule-monogram { display: grid; place-items: center; width: 70px; height: 70px; border-radius: 50%; background: #c10206; color: #fff; font-size: 24px; font-weight: 900; }
+.team-schedule-hero p { margin: 0; color: #c10206; font-size: 10px; font-weight: 900; letter-spacing: .15em; }
+.team-schedule-hero h2 { margin: 2px 0; font-size: 30px; }
+.team-schedule-hero span { color: #777d85; }
+.team-subtabs { display: flex; max-width: 1280px; margin: 0 auto 18px; border-bottom: 1px solid #d8dce1; }
+.team-subtabs button { padding: 14px 20px; border: 0; border-bottom: 3px solid transparent; background: transparent; color: #656b73; cursor: pointer; }
+.team-subtabs button.active { border-bottom-color: #c10206; color: #20242b; font-weight: 800; }
+.schedule-section-title { margin: 34px 0 8px; padding-bottom: 12px; border-bottom: 1px solid #e3e6e9; }
+.schedule-table-scroll { overflow-x: auto; }
+.schedule-table { width: 100%; border-collapse: collapse; }
+.schedule-table th, .schedule-table td { padding: 14px 12px; border-bottom: 1px solid #e9ebee; text-align: left; white-space: nowrap; }
+.schedule-table th { color: #6d737a; font-size: 11px; letter-spacing: .08em; }
+.schedule-table tbody tr:nth-child(even) { background: #f7f8f9; }
+.team-schedule-table td:nth-child(3) { display: flex; align-items: center; gap: 8px; }
+.venue-mark { width: 24px; color: #747a82; }
+.result-win { color: #008f4c; }.result-loss { color: #d1121b; }
+.all-schedules-link { width: auto; border: 0; }
+@media (max-width: 700px) {
+  .schedule-page, .team-schedule-page { padding: 12px; }
+  .schedule-surface { padding: 20px 14px; border-radius: 12px; }
+  .schedule-title-row { align-items: flex-start; flex-direction: column; }
+  .schedule-title-row select { width: 100%; }
+  .weekly-games { grid-template-columns: 1fr; }
+  .team-subtabs { overflow-x: auto; }
+}
 .game-card {
   display: block;
   width: 100%;

--- a/apps/web/src/components/league/leagueConstants.ts
+++ b/apps/web/src/components/league/leagueConstants.ts
@@ -3,6 +3,7 @@ import type { LeagueTab } from "./types";
 export const LEAGUE_TABS: Array<{ id: LeagueTab; label: string }> = [
   { id: "news", label: "NEWS" },
   { id: "scores", label: "SCORES" },
+  { id: "schedules", label: "SCHEDULES" },
   { id: "standings", label: "STANDINGS" },
   { id: "stats", label: "STATS" },
   { id: "draft", label: "DRAFT" },

--- a/apps/web/src/components/league/leagueMockData.ts
+++ b/apps/web/src/components/league/leagueMockData.ts
@@ -14,6 +14,8 @@ export const mockGames: LeagueGame[] = [
     Distance: 7,
     BallOn: 64,
     Possession: "Home",
+    Week: 1,
+    Date: "Sun, Sep 13",
   },
   {
     GameId: 2,
@@ -27,6 +29,28 @@ export const mockGames: LeagueGame[] = [
     Distance: 10,
     BallOn: 50,
     Possession: "Away",
+    Week: 1,
+    Date: "Sun, Sep 13",
+  },
+  {
+    GameId: 3, Home: "Denver", Away: "Green Bay", HomeScore: 0, AwayScore: 0,
+    Qtr: 1, Time: "4:25 PM", Down: 1, Distance: 10, BallOn: 50, Possession: "Home",
+    Week: 2, Date: "Sun, Sep 20",
+  },
+  {
+    GameId: 4, Home: "Las Vegas", Away: "Chicago", HomeScore: 0, AwayScore: 0,
+    Qtr: 1, Time: "8:20 PM", Down: 1, Distance: 10, BallOn: 50, Possession: "Away",
+    Week: 2, Date: "Sun, Sep 20",
+  },
+  {
+    GameId: 5, Home: "Chicago", Away: "Denver", HomeScore: 20, AwayScore: 27,
+    Qtr: "FINAL", Time: "0:00", Down: 1, Distance: 10, BallOn: 50, Possession: "Home",
+    Week: 3, Date: "Sun, Sep 27",
+  },
+  {
+    GameId: 6, Home: "Green Bay", Away: "Las Vegas", HomeScore: 31, AwayScore: 16,
+    Qtr: "FINAL", Time: "0:00", Down: 1, Distance: 10, BallOn: 50, Possession: "Home",
+    Week: 4, Date: "Sun, Oct 4",
   },
 ];
 

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -1,4 +1,4 @@
-export type LeagueTab = "news" | "scores" | "standings" | "stats" | "draft";
+export type LeagueTab = "news" | "scores" | "schedules" | "standings" | "stats" | "draft";
 export type GameTab = "gamecast" | "playbyplay" | "boxscore" | "teamstats";
 
 export type LeagueGame = {
@@ -15,6 +15,9 @@ export type LeagueGame = {
   Possession: "Home" | "Away" | string;
   HomeLogo?: string;
   AwayLogo?: string;
+  Week?: string | number;
+  Date?: string;
+  Season?: string | number;
 };
 
 export type LeagueTeam = Record<string, string | number | undefined> & {


### PR DESCRIPTION
### Motivation
- Provide a dedicated Schedules area so users can browse the league schedule by week and inspect individual team schedules.
- Allow navigating from a league-wide weekly view into a team-specific schedule page with the team "Schedule" subtab pre-selected.
- Surface completed-game results (W/L + score) in schedule lists for past games.

### Description
- Add a new `Schedules` component and page at `apps/web/src/components/league/Schedules.tsx` that renders weekly matchups, a week picker, and a team selector that opens a team schedule with an active `Schedule` subtab.
- Wire the new tab into the app by adding `schedules` to `LeagueTab` in `apps/web/src/components/league/types.ts`, registering the tab in `apps/web/src/components/league/leagueConstants.ts`, and mounting `Schedules` from `apps/web/src/components/league/LeagueAppScreen.tsx`.
- Add responsive, schedule-focused styles in `apps/web/src/components/league/league.css` for weekly cards, week picker, team hero, subtabs and schedule tables.
- Populate representative fallback data and week/date fields in `apps/web/src/components/league/leagueMockData.ts` to demonstrate weekly and team views.

### Testing
- Ran `npm run build` against the web app and the build succeeded.
- Ran `npm run lint` and it completed; one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` was observed but unrelated to the new schedules work.
- Executed Playwright smoke tests that open the app, navigate to the League, select the `SCHEDULES` tab, verify weekly schedule rendering, select a team from the dropdown, and confirm the team schedule page loads with the `Schedule` subtab active; all checks passed.
- Captured a desktop viewport screenshot to visually verify the weekly schedule surface and team schedule transition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d1b155d7483249f47d81bd714444d)