### PR TITLE
Build current-season stats view for individual teams

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -9,6 +9,7 @@ import { LeagueSchedule } from "./LeagueSchedule";
 import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
+import { TeamScreen } from "./TeamScreen";
 import "./league.css";
 type LeagueAppScreenProps = {
   onBack?: () => void;
@@ -19,6 +20,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<LeagueTeam | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
   const gameLoadTimeout = useRef<number | null>(null);
@@ -75,6 +77,12 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
     return (
       <section className="league-app">
         <GameCenter game={selectedGame} onBack={() => setSelectedGame(null)} />
+      </section>
+    );
+  if (selectedTeam)
+    return (
+      <section className="league-app">
+        <TeamScreen team={selectedTeam} onBack={() => setSelectedTeam(null)} />
       </section>
     );
   return (
@@ -148,7 +156,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             )}
             {activeTab === "standings" && (
               <div className="league-tab-content active">
-                <LeagueStandings teams={teams} />
+                <LeagueStandings teams={teams} onSelectTeam={setSelectedTeam} />
               </div>
             )}
             {activeTab === "stats" && (

--- a/apps/web/src/components/league/LeagueStandings.tsx
+++ b/apps/web/src/components/league/LeagueStandings.tsx
@@ -5,7 +5,13 @@ import {
   parseInteger,
   teamName,
 } from "./leagueMappers";
-export function LeagueStandings({ teams }: { teams: LeagueTeam[] }) {
+export function LeagueStandings({
+  teams,
+  onSelectTeam,
+}: {
+  teams: LeagueTeam[];
+  onSelectTeam?: (team: LeagueTeam) => void;
+}) {
   return (
     <div className="standings-wrapper">
       <div className="standings-header">
@@ -47,7 +53,13 @@ export function LeagueStandings({ teams }: { teams: LeagueTeam[] }) {
                   <tr key={`${teamName(t)}-${i}`}>
                     <td className="team-col">
                       <span className="team-rank">{i + 1}</span>
-                      {teamName(t)}
+                      <button
+                        className="standings-team-link"
+                        type="button"
+                        onClick={() => onSelectTeam?.(t)}
+                      >
+                        {teamName(t)}
+                      </button>
                     </td>
                     <td>{parseInteger(t.Wins ?? t.W)}</td>
                     <td>{parseInteger(t.Losses ?? t.L)}</td>

--- a/apps/web/src/components/league/TeamScreen.tsx
+++ b/apps/web/src/components/league/TeamScreen.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useMemo, useState } from "react";
+import { getPlayers, getPlayerStats, type PlayerStats } from "../../api/client";
+import type { Player } from "../players/types";
+import { PlayerImage } from "../players/PlayerImage";
+import { PLACEHOLDER_LOGOS } from "./leagueConstants";
+import { parseInteger, teamName } from "./leagueMappers";
+import type { LeagueTeam } from "./types";
+
+type TeamTab = "Overview" | "Stats" | "Schedule" | "Roster";
+
+const number = (value: unknown) => Number(value) || 0;
+
+function matchesTeam(playerTeam: string | undefined, selectedTeam: string) {
+  if (!playerTeam) return false;
+  const player = playerTeam.trim().toLowerCase();
+  const selected = selectedTeam.trim().toLowerCase();
+  return player === selected || player.includes(selected) || selected.includes(player);
+}
+
+export function TeamScreen({ team, onBack }: { team: LeagueTeam; onBack: () => void }) {
+  const [activeTab, setActiveTab] = useState<TeamTab>("Stats");
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [stats, setStats] = useState<PlayerStats[]>([]);
+  const [loading, setLoading] = useState(true);
+  const selectedName = teamName(team);
+
+  useEffect(() => {
+    Promise.all([getPlayers(), getPlayerStats()])
+      .then(([playerResult, statResult]) => {
+        setPlayers(playerResult.players);
+        setStats(statResult.playerStats);
+      })
+      .catch(() => {
+        setPlayers([]);
+        setStats([]);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const roster = useMemo(
+    () => players.filter((player) => matchesTeam(player.Team, selectedName)),
+    [players, selectedName],
+  );
+  const playerByName = useMemo(
+    () => new Map(roster.map((player) => [player.Name?.trim().toLowerCase(), player])),
+    [roster],
+  );
+  const rushing = useMemo(
+    () =>
+      stats
+        .filter((row) => playerByName.has(row.Player?.trim().toLowerCase()))
+        .filter((row) => number(row.Carries) > 0)
+        .sort((a, b) => number(b.Yards) - number(a.Yards)),
+    [playerByName, stats],
+  );
+  const leaders = rushing.slice(0, 3);
+  const totalCarries = rushing.reduce((sum, row) => sum + number(row.Carries), 0);
+  const totalYards = rushing.reduce((sum, row) => sum + number(row.Yards), 0);
+  const logo = String(team.Logo || PLACEHOLDER_LOGOS.team);
+
+  return (
+    <div className="team-page">
+      <button className="team-page-back" type="button" onClick={onBack}>← All teams</button>
+      <header className="team-page-hero">
+        <img src={logo} alt="" />
+        <div>
+          <p>{String(team.Division || "AFL")} Division</p>
+          <h1>{selectedName}</h1>
+          <span>{parseInteger(team.Wins ?? team.W)}-{parseInteger(team.Losses ?? team.L)} · Current season</span>
+        </div>
+      </header>
+      <nav className="team-page-tabs" aria-label={`${selectedName} sections`}>
+        {(["Overview", "Stats", "Schedule", "Roster"] as TeamTab[]).map((tab) => (
+          <button key={tab} type="button" className={activeTab === tab ? "active" : ""} onClick={() => setActiveTab(tab)}>{tab}</button>
+        ))}
+      </nav>
+
+      {activeTab === "Stats" ? (
+        <main className="team-stats-page">
+          <div className="team-stats-heading">
+            <div><p>Current season</p><h2>{selectedName} Player Stats</h2></div>
+            <button type="button">Regular Season <span>⌄</span></button>
+          </div>
+          {loading ? <div className="team-stats-state">Loading team statistics…</div> : (
+            <>
+              <section>
+                <h3>Team leaders</h3>
+                <div className="team-leader-grid">
+                  {leaders.length ? leaders.map((row) => {
+                    const player = playerByName.get(row.Player.trim().toLowerCase());
+                    return <article key={row.Player}><span>Rushing yards</span><div><PlayerImage player={player || { Image: logo }} /><p><b>{row.Player}</b><small>{player?.Pos || "RB"}</small><strong>{number(row.Yards).toLocaleString()}</strong></p></div></article>;
+                  }) : <p className="team-empty">No player statistics have been recorded for this team yet.</p>}
+                </div>
+              </section>
+              <section className="team-stat-section">
+                <h3>Rushing</h3>
+                <div className="team-stat-scroll"><table><thead><tr><th>PLAYER</th><th>GP</th><th>CAR</th><th className="sorted">YDS ↓</th><th>AVG</th><th>TD</th><th>FUM</th><th>LONG</th></tr></thead><tbody>
+                  {rushing.map((row) => { const carries = number(row.Carries); return <tr key={row.Player}><td><b>{row.Player}</b><small>{playerByName.get(row.Player.trim().toLowerCase())?.Pos || "—"}</small></td><td>{row.GP || "—"}</td><td>{carries}</td><td className="sorted">{number(row.Yards).toLocaleString()}</td><td>{carries ? (number(row.Yards) / carries).toFixed(1) : "0.0"}</td><td>{row.TD || 0}</td><td>{row.Fum || 0}</td><td>{row.Long || 0}</td></tr>; })}
+                  {rushing.length > 0 && <tr className="total"><td>Total</td><td>—</td><td>{totalCarries}</td><td className="sorted">{totalYards.toLocaleString()}</td><td>{totalCarries ? (totalYards / totalCarries).toFixed(1) : "0.0"}</td><td>{rushing.reduce((s, r) => s + number(r.TD), 0)}</td><td>{rushing.reduce((s, r) => s + number(r.Fum), 0)}</td><td>{Math.max(...rushing.map((r) => number(r.Long)))}</td></tr>}
+                </tbody></table></div>
+              </section>
+              <p className="team-stats-note">Statistics are updated after every game.</p>
+            </>
+          )}
+        </main>
+      ) : <div className="team-stats-state">{activeTab} content is coming soon.</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -342,6 +342,16 @@
 .standings-table .team-col {
   text-align: left;
 }
+.standings-team-link {
+  border: 0;
+  padding: .35rem 0;
+  background: none;
+  color: #7cb7ff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.standings-team-link:hover { text-decoration: underline; }
 .team-rank,
 .rank {
   display: inline-block;
@@ -457,6 +467,58 @@
   text-decoration: underline;
   text-underline-offset: 3px;
   cursor: pointer;
+}
+
+/* Individual team hub */
+.team-page { min-height: 100vh; background: #eef0f2; color: #24272b; }
+.team-page-back { margin: 1rem max(1rem, calc((100% - 1180px) / 2)); border: 0; background: transparent; color: #53606e; font-weight: 700; cursor: pointer; }
+.team-page-hero { display: flex; align-items: center; gap: 1.25rem; max-width: 1180px; margin: 0 auto; padding: 1.5rem 1.25rem 1.25rem; background: #fff; }
+.team-page-hero img { width: 82px; height: 82px; object-fit: contain; }
+.team-page-hero p, .team-stats-heading p { margin: 0 0 .3rem; color: #737b84; font-size: .78rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.team-page-hero h1 { margin: 0 0 .4rem; font-size: clamp(1.8rem, 4vw, 2.8rem); }
+.team-page-hero span { color: #636b74; }
+.team-page-tabs { display: flex; max-width: 1180px; margin: 0 auto; padding: 0 1.25rem; overflow-x: auto; background: #fff; border-top: 1px solid #e5e7e9; }
+.team-page-tabs button { padding: 1rem 1.4rem .85rem; border: 0; border-bottom: 4px solid transparent; background: none; color: #5d646c; font-weight: 700; cursor: pointer; }
+.team-page-tabs button.active { border-bottom-color: var(--accent-red); color: #17191c; }
+.team-stats-page { max-width: 1180px; margin: 1rem auto 3rem; padding: 1.4rem; background: #fff; border-radius: 12px; box-shadow: 0 1px 3px #18202a16; }
+.team-stats-heading { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding-bottom: 1.2rem; border-bottom: 1px solid #e1e4e7; }
+.team-stats-heading h2 { margin: 0; font-size: clamp(1.5rem, 3vw, 2.15rem); }
+.team-stats-heading button { flex: 0 0 auto; padding: .7rem 1rem; border: 1px solid #d5d9dd; border-radius: 999px; background: white; color: #454b52; }
+.team-stats-heading button span { margin-left: .65rem; color: #1e73d8; }
+.team-stats-page section { margin-top: 1.65rem; }
+.team-stats-page h3 { margin: 0 0 .75rem; font-size: 1.15rem; }
+.team-leader-grid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid #dfe2e5; }
+.team-leader-grid article { padding: .85rem 1rem; border-right: 1px solid #dfe2e5; }
+.team-leader-grid article:last-child { border-right: 0; }
+.team-leader-grid article > span { color: #646c74; font-size: .75rem; font-weight: 800; text-transform: uppercase; }
+.team-leader-grid article > div { display: flex; align-items: flex-end; gap: .8rem; margin-top: .55rem; }
+.team-leader-grid img { width: 58px; height: 58px; object-fit: contain; }
+.team-leader-grid p { display: grid; grid-template-columns: auto auto; gap: 0 .3rem; margin: 0; }
+.team-leader-grid b { font-size: .95rem; }
+.team-leader-grid small { align-self: center; color: #777f87; }
+.team-leader-grid strong { grid-column: 1 / -1; font-size: 1.7rem; line-height: 1.15; }
+.team-empty { grid-column: 1 / -1; margin: 0; padding: 1.5rem; color: #737b84; }
+.team-stat-scroll { overflow-x: auto; }
+.team-stat-section table { width: 100%; min-width: 720px; border-collapse: collapse; color: #555d65; font-size: .9rem; }
+.team-stat-section th, .team-stat-section td { padding: .7rem .55rem; border-top: 1px solid #e0e3e6; text-align: right; }
+.team-stat-section th { color: #555b61; font-size: .72rem; text-decoration: underline; }
+.team-stat-section th:first-child, .team-stat-section td:first-child { width: 28%; text-align: left; }
+.team-stat-section tbody tr:nth-child(even) { background: #f7f7f8; }
+.team-stat-section td:first-child b { color: #086dcc; }
+.team-stat-section td:first-child small { margin-left: .3rem; color: #7e858c; }
+.team-stat-section .sorted { background: #e3edf8; }
+.team-stat-section .total { background: #fff !important; font-weight: 800; }
+.team-stats-note { margin: 2rem 0 0; color: #92989e; font-size: .85rem; }
+.team-stats-state { max-width: 1180px; margin: 1rem auto; padding: 3rem; border-radius: 12px; background: #fff; color: #727980; text-align: center; }
+@media (max-width: 700px) {
+  .team-page-back { margin-left: 1rem; }
+  .team-page-hero { padding-top: .75rem; }
+  .team-page-hero img { width: 64px; height: 64px; }
+  .team-stats-page { margin-top: .6rem; padding: 1rem; border-radius: 0; }
+  .team-stats-heading { align-items: flex-end; }
+  .team-stats-heading button { font-size: .78rem; }
+  .team-leader-grid { grid-template-columns: 1fr; }
+  .team-leader-grid article { border-right: 0; border-bottom: 1px solid #dfe2e5; }
 }
 .player-name-button:hover,
 .player-name-button:focus-visible { color: #fff; }


### PR DESCRIPTION
### Motivation
- Provide an individual team hub when clicking a team in the standings so users can inspect the current season’s team-level and player-level stats. 
- Surface team-specific leaders, totals, and a dense, responsive stats table matching the supplied season view layout.

### Description
- Make team names in the standings interactive by adding an optional `onSelectTeam` prop to `LeagueStandings` and rendering the team name as a button in `apps/web/src/components/league/LeagueStandings.tsx`.
- Integrate a selected-team route into league navigation by adding `selectedTeam` state and rendering `TeamScreen` from `apps/web/src/components/league/LeagueAppScreen.tsx` when a team is selected.
- Add a new `TeamScreen` component at `apps/web/src/components/league/TeamScreen.tsx` that loads players and player-stats via `getPlayers()` and `getPlayerStats()`, computes a team roster, derives rushing leaders and totals, and renders Overview/Stats/Schedule/Roster tabs with the `Stats` tab selected by default.
- Add styles in `apps/web/src/components/league/league.css` to support the standings link and a polished responsive individual-team hub (desktop and mobile table/layout rules).

### Testing
- Ran `npm run build` in `apps/web` which completed successfully and produced the production build.
- Ran `npm run lint` which completed with no new errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (unchanged by this work).
- Ran `git diff --check` to validate diffs (no check failures reported).
- Attempted automated Playwright/browser tooling; the browser install was attempted but end-to-end screenshot verification was unavailable because the container lacks required Playwright browser system libraries, so visual regression automation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d1b33b63c83248f758dbb6183ea1b)