### PR TITLE
Add Schedules tab with weekly and team-specific schedule views

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -6,6 +6,7 @@ import { normalizeGames } from "./leagueMappers";
 import { LeagueHeader } from "./LeagueHeader";
 import { LeagueNews } from "./LeagueNews";
 import { LeagueSchedule } from "./LeagueSchedule";
+import { LeagueSchedules } from "./LeagueSchedules";
 import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
@@ -147,6 +148,11 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             {activeTab === "scores" && (
               <div className="league-tab-content active">
                 <LeagueSchedule games={games} onSelectGame={openGame} />
+              </div>
+            )}
+            {activeTab === "schedules" && (
+              <div className="league-tab-content active">
+                <LeagueSchedules games={games} teams={teams} onSelectGame={openGame} />
               </div>
             )}
             {activeTab === "standings" && (

--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from "react";
+import type { LeagueGame, LeagueTeam } from "./types";
+
+const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
+
+const getWeek = (game: LeagueGame, index: number) => Number(game.Week ?? index + 1);
+const isFinal = (game: LeagueGame) => String(game.Qtr).toUpperCase() === "FINAL";
+const teamName = (team: LeagueTeam) => String(team.Team || team.Name || team.Abbrev || "Team");
+
+export function LeagueSchedules({
+  games,
+  teams,
+  onSelectGame,
+}: {
+  games: LeagueGame[];
+  teams: LeagueTeam[];
+  onSelectGame: (game: LeagueGame) => void;
+}) {
+  const [week, setWeek] = useState(1);
+  const [selectedTeam, setSelectedTeam] = useState("");
+  const teamOptions = useMemo(() => {
+    const labels = new Map<string, string>();
+    teams.forEach((team) => {
+      const abbreviation = String(team.Abbrev || team.Team || "");
+      if (abbreviation) labels.set(abbreviation, teamName(team));
+    });
+    games.forEach((game) => {
+      if (!labels.has(game.Home)) labels.set(game.Home, game.Home);
+      if (!labels.has(game.Away)) labels.set(game.Away, game.Away);
+    });
+    return [...labels].sort((a, b) => a[1].localeCompare(b[1]));
+  }, [games, teams]);
+
+  const visibleGames = useMemo(
+    () => selectedTeam
+      ? games.filter((game) => game.Home === selectedTeam || game.Away === selectedTeam)
+      : games.filter((game, index) => getWeek(game, index) === week),
+    [games, selectedTeam, week],
+  );
+  const selectedLabel = teamOptions.find(([id]) => id === selectedTeam)?.[1] || selectedTeam;
+
+  return (
+    <main className="schedule-center">
+      {selectedTeam && (
+        <header className="team-schedule-hero">
+          <div className="team-schedule-crest">{selectedTeam.slice(0, 2)}</div>
+          <div><span>AFL TEAM</span><h1>{selectedLabel}</h1><small>2026 season</small></div>
+        </header>
+      )}
+      {selectedTeam && <nav className="team-subtabs" aria-label={`${selectedLabel} sections`}><span>Overview</span><span>Stats</span><strong>Schedule</strong><span>Roster</span></nav>}
+      <section className="schedule-card">
+        <header className="schedule-card__heading">
+          <div><span className="schedule-kicker">2026 SEASON</span><h1>{selectedTeam ? `${selectedLabel} Schedule` : "AFL Schedule"}</h1></div>
+          <label className="team-schedule-picker">
+            <span className="sr-only">Choose a team schedule</span>
+            <select value={selectedTeam} onChange={(event) => setSelectedTeam(event.target.value)}>
+              <option value="">All weekly schedules</option>
+              {teamOptions.map(([id, label]) => <option value={id} key={id}>{label}</option>)}
+            </select>
+          </label>
+        </header>
+
+        {!selectedTeam && <nav className="schedule-weeks" aria-label="Schedule weeks">
+          {WEEKS.map((item) => <button type="button" key={item} className={week === item ? "active" : ""} onClick={() => setWeek(item)}><b>WEEK {item}</b><small>{item === 1 ? "SEP 6–12" : `2026 · WK ${item}`}</small></button>)}
+        </nav>}
+
+        <div className="schedule-table-wrap">
+          <div className="schedule-section-title"><h2>{selectedTeam ? "Regular Season" : `Week ${week}`}</h2><span>{visibleGames.length} {visibleGames.length === 1 ? "game" : "games"}</span></div>
+          <table className="schedule-table">
+            <thead><tr>{selectedTeam && <th>WK</th>}<th>Date</th><th>Matchup</th><th>{visibleGames.some(isFinal) ? "Result / Time" : "Time"}</th><th>TV</th><th>Game</th></tr></thead>
+            <tbody>
+              {visibleGames.map((game, index) => {
+                const final = isFinal(game);
+                const homeWon = Number(game.HomeScore) > Number(game.AwayScore);
+                const chosenIsHome = selectedTeam === game.Home;
+                const won = chosenIsHome ? homeWon : !homeWon;
+                return <tr key={String(game.GameId)}>
+                  {selectedTeam && <td>{getWeek(game, games.indexOf(game))}</td>}
+                  <td>{game.Date || `Week ${getWeek(game, index)}`}</td>
+                  <td><div className="schedule-matchup"><span><b>{game.Away}</b><small>Away</small></span><em>at</em><span><b>{game.Home}</b><small>Home</small></span></div></td>
+                  <td>{final ? <span className={`game-result ${won ? "win" : "loss"}`}><b>{selectedTeam ? (won ? "W" : "L") : "FINAL"}</b> {game.AwayScore}–{game.HomeScore}</span> : <strong className="kickoff-time">{game.Kickoff || "TBD"}</strong>}</td>
+                  <td>{game.Network || "AFL Network"}</td>
+                  <td><button className="schedule-game-link" type="button" onClick={() => onSelectGame(game)}>Gamecast ›</button></td>
+                </tr>;
+              })}
+            </tbody>
+          </table>
+          {!visibleGames.length && <div className="schedule-no-games"><strong>No games scheduled</strong><span>The Week {week} schedule has not been announced yet.</span></div>}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -297,6 +297,46 @@
 .schedule-game__action button b { color: #e84b50; }
 .schedule-empty { display: grid; gap: 8px; place-items: center; min-height: 190px; color: #9aa3ae; }
 .schedule-empty strong { color: #fff; }
+.schedule-center { min-height: calc(100vh - 170px); padding: clamp(22px, 3vw, 48px); background: #eef0f3; color: #20252b; }
+.schedule-card { max-width: 1240px; margin: 0 auto; overflow: hidden; border: 1px solid #d9dde2; border-radius: 12px; background: #fff; box-shadow: 0 8px 28px #14203314; }
+.schedule-card__heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 30px 34px 24px; }
+.schedule-card__heading h1 { margin: 4px 0 0; font-size: clamp(1.8rem, 3vw, 2.55rem); letter-spacing: -.035em; }
+.schedule-kicker { color: var(--accent-red); font-size: .68rem; font-weight: 900; letter-spacing: .16em; }
+.team-schedule-picker select { min-width: 220px; padding: 12px 38px 12px 16px; color: #26303a; border: 1px solid #cbd1d8; border-radius: 22px; background: #fff; cursor: pointer; font-weight: 700; }
+.schedule-weeks { display: flex; margin: 0 24px; overflow-x: auto; border-block: 1px solid #e0e3e7; scrollbar-width: thin; }
+.schedule-weeks button { flex: 0 0 130px; padding: 16px 10px 13px; color: #737b84; border: 0; border-bottom: 4px solid transparent; background: transparent; cursor: pointer; }
+.schedule-weeks b, .schedule-weeks small { display: block; }
+.schedule-weeks b { font-size: .72rem; letter-spacing: .08em; }
+.schedule-weeks small { margin-top: 5px; font-size: .62rem; }
+.schedule-weeks button.active { color: #171b20; border-bottom-color: var(--accent-red); }
+.schedule-table-wrap { padding: 24px 34px 38px; }
+.schedule-section-title { display: flex; align-items: end; justify-content: space-between; padding-bottom: 10px; border-bottom: 2px solid #d6d9dd; }
+.schedule-section-title h2 { margin: 0; font-size: 1.15rem; }
+.schedule-section-title span { color: #737b84; font-size: .72rem; text-transform: uppercase; }
+.schedule-table { width: 100%; border-collapse: collapse; }
+.schedule-table th { padding: 11px 8px; color: #69717a; text-align: left; text-transform: uppercase; font-size: .66rem; letter-spacing: .05em; }
+.schedule-table td { padding: 13px 8px; border-top: 1px solid #e6e8eb; color: #606871; font-size: .8rem; }
+.schedule-table tbody tr:nth-child(even) { background: #f7f8f9; }
+.schedule-matchup { display: flex; align-items: center; gap: 14px; color: #1e252d; }
+.schedule-matchup span { display: grid; min-width: 58px; }
+.schedule-matchup small { color: #89919a; font-size: .6rem; text-transform: uppercase; }
+.schedule-matchup em { color: #9299a1; font-style: normal; }
+.kickoff-time, .schedule-game-link { color: #076dcc; }
+.schedule-game-link { padding: 0; border: 0; background: transparent; cursor: pointer; font-weight: 700; }
+.game-result { white-space: nowrap; color: #076dcc; }
+.game-result b { display: inline-grid; place-items: center; width: 24px; height: 24px; margin-right: 7px; color: #fff; border-radius: 50%; font-size: .67rem; }
+.game-result.win b { background: #05884e; }
+.game-result.loss b { background: #c52931; }
+.schedule-no-games { display: grid; place-items: center; gap: 8px; min-height: 170px; color: #78818b; }
+.schedule-no-games strong { color: #29313a; }
+.team-schedule-hero { display: flex; align-items: center; gap: 20px; max-width: 1240px; margin: 0 auto; padding: 5px 8px 22px; }
+.team-schedule-hero h1 { margin: 2px 0; font-size: clamp(1.65rem, 3vw, 2.35rem); text-transform: uppercase; }
+.team-schedule-hero span, .team-schedule-hero small { color: #747d87; font-size: .68rem; letter-spacing: .1em; text-transform: uppercase; }
+.team-schedule-crest { display: grid; place-items: center; width: 74px; height: 74px; color: #fff; border-radius: 50%; background: linear-gradient(135deg, #ba0714, #171a20); font-size: 1.25rem; font-weight: 900; }
+.team-subtabs { display: flex; gap: 30px; max-width: 1240px; margin: 0 auto 16px; padding: 0 8px; border-bottom: 1px solid #d0d5db; }
+.team-subtabs span, .team-subtabs strong { padding: 10px 2px 13px; font-size: .82rem; }
+.team-subtabs strong { margin-bottom: -1px; border-bottom: 3px solid var(--accent-red); }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 @media (max-width: 720px) {
   .games-banner { height: 76px; }
   .games-banner__brand, .games-banner__all { display: none; }
@@ -308,6 +348,12 @@
   .schedule-game__date { grid-column: 1 / -1; padding: 15px 20px; border-right: 0; border-bottom: 1px solid #292e35; }
   .schedule-game__teams { padding: 12px 18px; }
   .schedule-game__action { padding: 16px 12px; }
+  .schedule-center { padding: 14px; }
+  .schedule-card__heading { align-items: stretch; flex-direction: column; padding: 22px 18px; }
+  .team-schedule-picker select { width: 100%; }
+  .schedule-table-wrap { padding: 18px 14px 28px; overflow-x: auto; }
+  .schedule-table { min-width: 680px; }
+  .team-subtabs { gap: 18px; overflow-x: auto; }
 }
 .game-card {
   display: block;

--- a/apps/web/src/components/league/leagueConstants.ts
+++ b/apps/web/src/components/league/leagueConstants.ts
@@ -3,6 +3,7 @@ import type { LeagueTab } from "./types";
 export const LEAGUE_TABS: Array<{ id: LeagueTab; label: string }> = [
   { id: "news", label: "NEWS" },
   { id: "scores", label: "SCORES" },
+  { id: "schedules", label: "SCHEDULES" },
   { id: "standings", label: "STANDINGS" },
   { id: "stats", label: "STATS" },
   { id: "draft", label: "DRAFT" },

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -1,4 +1,4 @@
-export type LeagueTab = "news" | "scores" | "standings" | "stats" | "draft";
+export type LeagueTab = "news" | "scores" | "schedules" | "standings" | "stats" | "draft";
 export type GameTab = "gamecast" | "playbyplay" | "boxscore" | "teamstats";
 
 export type LeagueGame = {


### PR DESCRIPTION
### Motivation
- Provide a dedicated Schedules view so users can browse week-by-week matchups and quickly switch to a team-specific schedule page with the Schedule subtab selected.
- Show completed game results inline (final scores and win/loss badges) for past games and allow launching the Gamecast from schedule rows.
- Offer a responsive desktop and mobile layout for an 18-week season and a team selector that lists all teams plus an "All weekly schedules" option.

### Description
- Add a new `LeagueSchedules` React component to render an 18-week browser, a team selector, week navigation, schedule tables, result badges, and Gamecast actions (new file `LeagueSchedules.tsx`).
- Add `schedules` to the `LeagueTab` union in `types.ts` and include a `SCHEDULES` tab in `leagueConstants.ts` so the tab appears in the league navigation.
- Wire the new component into `LeagueAppScreen.tsx` so selecting the Schedules tab shows the weekly/team schedule view and `onSelectGame` still opens the GameCenter flow.
- Add CSS styles in `league.css` for `.schedule-center`, `.schedule-card`, week navigation, schedule table, team hero, result badges, and responsive rules for mobile.

### Testing
- Ran `npm run build` which completed successfully and produced the production build artifacts.
- Ran `npm run lint` which completed successfully with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (no new lint errors introduced).
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d1d9fa7b483248c02ff61a6c064d2)