### PR TITLE
Add current-season individual team stats view

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -11,6 +11,7 @@ import { LeagueStandings } from "./LeagueStandings";
 import { LeagueStats } from "./LeagueStats";
 import { GameCenter } from "./GameCenter";
 import { GamesBanner } from "./GamesBanner";
+import { TeamDetail } from "./TeamDetail";
 import "./league.css";
 type LeagueAppScreenProps = {
   onBack?: () => void;
@@ -21,6 +22,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
+  const [selectedTeam, setSelectedTeam] = useState<LeagueTeam | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
   const gameLoadTimeout = useRef<number | null>(null);
@@ -78,6 +80,13 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
       <section className="league-app">
         <GamesBanner games={games} />
         <GameCenter game={selectedGame} onBack={() => setSelectedGame(null)} />
+      </section>
+    );
+  if (selectedTeam)
+    return (
+      <section className="league-app">
+        <GamesBanner games={games} />
+        <TeamDetail team={selectedTeam} games={games} onBack={() => setSelectedTeam(null)} onGame={openGame} />
       </section>
     );
   return (
@@ -152,12 +161,12 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             )}
             {activeTab === "schedules" && (
               <div className="league-tab-content active">
-                <LeagueSchedules games={games} teams={teams} onSelectGame={openGame} />
+                <LeagueSchedules games={games} teams={teams} onSelectGame={openGame} onSelectTeam={setSelectedTeam} />
               </div>
             )}
             {activeTab === "standings" && (
               <div className="league-tab-content active">
-                <LeagueStandings teams={teams} />
+                <LeagueStandings teams={teams} onSelectTeam={setSelectedTeam} />
               </div>
             )}
             {activeTab === "stats" && (

--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -11,10 +11,12 @@ export function LeagueSchedules({
   games,
   teams,
   onSelectGame,
+  onSelectTeam,
 }: {
   games: LeagueGame[];
   teams: LeagueTeam[];
   onSelectGame: (game: LeagueGame) => void;
+  onSelectTeam?: (team: LeagueTeam) => void;
 }) {
   const [week, setWeek] = useState(1);
   const [selectedTeam, setSelectedTeam] = useState("");
@@ -53,7 +55,12 @@ export function LeagueSchedules({
           <div><span className="schedule-kicker">2026 SEASON</span><h1>{selectedTeam ? `${selectedLabel} Schedule` : "AFL Schedule"}</h1></div>
           <label className="team-schedule-picker">
             <span className="sr-only">Choose a team schedule</span>
-            <select value={selectedTeam} onChange={(event) => setSelectedTeam(event.target.value)}>
+            <select value={selectedTeam} onChange={(event) => {
+              const id = event.target.value;
+              setSelectedTeam(id);
+              const team = teams.find((item) => String(item.Abbrev || item.Team || "") === id);
+              if (team) onSelectTeam?.(team);
+            }}>
               <option value="">All weekly schedules</option>
               {teamOptions.map(([id, label]) => <option value={id} key={id}>{label}</option>)}
             </select>

--- a/apps/web/src/components/league/LeagueStandings.tsx
+++ b/apps/web/src/components/league/LeagueStandings.tsx
@@ -13,14 +13,14 @@ function value(team: LeagueTeam, ...keys: string[]): string {
   return match ? String(team[match]) : "";
 }
 
-function TeamIdentity({ team }: { team: LeagueTeam }) {
+function TeamIdentity({ team, onSelect }: { team: LeagueTeam; onSelect?: (team: LeagueTeam) => void }) {
   const [logoFailed, setLogoFailed] = useState(false);
   const name = value(team, "City", "Location", "TeamName") || teamName(team);
   const nickname = value(team, "Nickname", "NickName", "Name", "Mascot");
   const logo = value(team, "Logo", "LogoUrl", "LogoURL");
 
   return (
-    <div className="standings-team">
+    <button className="standings-team standings-team-button" type="button" onClick={() => onSelect?.(team)}>
       {logo && !logoFailed ? (
         <img
           className="standings-team-logo"
@@ -39,11 +39,11 @@ function TeamIdentity({ team }: { team: LeagueTeam }) {
           <span className="standings-team-nickname">{nickname}</span>
         )}
       </span>
-    </div>
+    </button>
   );
 }
 
-function StandingsTable({ teams }: { teams: LeagueTeam[] }) {
+function StandingsTable({ teams, onSelectTeam }: { teams: LeagueTeam[]; onSelectTeam?: (team: LeagueTeam) => void }) {
   return (
     <div className="standings-table-scroll">
       <table className="standings-table">
@@ -68,7 +68,7 @@ function StandingsTable({ teams }: { teams: LeagueTeam[] }) {
         <tbody>
           {teams.map((team, index) => (
             <tr key={`${teamName(team)}-${index}`}>
-              <td className="team-col"><TeamIdentity team={team} /></td>
+              <td className="team-col"><TeamIdentity team={team} onSelect={onSelectTeam} /></td>
               <td>{parseInteger(team.Wins ?? team.W)}</td>
               <td>{parseInteger(team.Losses ?? team.L)}</td>
               <td>{parseInteger(team.Ties ?? team.T)}</td>
@@ -90,7 +90,7 @@ function StandingsTable({ teams }: { teams: LeagueTeam[] }) {
   );
 }
 
-export function LeagueStandings({ teams }: { teams: LeagueTeam[] }) {
+export function LeagueStandings({ teams, onSelectTeam }: { teams: LeagueTeam[]; onSelectTeam?: (team: LeagueTeam) => void }) {
   const [view, setView] = useState<StandingsView>("league");
   const divisions = Object.entries(
     teams.reduce<Record<string, LeagueTeam[]>>((groups, team) => {
@@ -117,14 +117,14 @@ export function LeagueStandings({ teams }: { teams: LeagueTeam[] }) {
         {view === "league" ? (
           <section className="standings-panel">
             <header className="standings-panel-header">League</header>
-            <StandingsTable teams={teams} />
+            <StandingsTable teams={teams} onSelectTeam={onSelectTeam} />
           </section>
         ) : (
           <div className="standings-division-list">
             {divisions.map(([division, divisionTeams]) => (
               <section className="standings-panel" key={division}>
                 <header className="standings-panel-header">{division} Division</header>
-                <StandingsTable teams={divisionTeams} />
+                <StandingsTable teams={divisionTeams} onSelectTeam={onSelectTeam} />
               </section>
             ))}
           </div>

--- a/apps/web/src/components/league/TeamDetail.tsx
+++ b/apps/web/src/components/league/TeamDetail.tsx
@@ -1,0 +1,65 @@
+import { useMemo, useState } from "react";
+import type { LeagueGame, LeagueTeam } from "./types";
+
+type TeamSection = "overview" | "stats" | "schedule" | "roster";
+type StatRow = { name: string; pos: string; values: (string | number)[] };
+
+const statGroups: { title: string; columns: string[]; rows: StatRow[] }[] = [
+  { title: "Passing", columns: ["GP", "CMP", "ATT", "CMP%", "YDS", "AVG", "YDS/G", "LNG", "TD", "INT", "RTG"], rows: [
+    { name: "Marcus Cole", pos: "QB", values: [17, 356, 521, "68.3", "4,218", "8.1", "248.1", 72, 31, 9, "106.4"] },
+    { name: "Evan Brooks", pos: "QB", values: [6, 42, 68, "61.8", 487, "7.2", "81.2", 44, 3, 2, "88.7"] },
+  ]},
+  { title: "Rushing", columns: ["GP", "CAR", "YDS", "AVG", "LNG", "BIG", "TD", "YDS/G", "FUM", "FD"], rows: [
+    { name: "Darius King", pos: "RB", values: [17, 284, "1,426", "5.0", 61, 14, 13, "83.9", 2, 72] },
+    { name: "Marcus Cole", pos: "QB", values: [17, 82, 476, "5.8", 29, 5, 6, "28.0", 3, 31] },
+    { name: "Jaylen Price", pos: "RB", values: [15, 96, 421, "4.4", 38, 4, 3, "28.1", 1, 22] },
+    { name: "Andre Bell", pos: "WR", values: [17, 12, 91, "7.6", 24, 1, 1, "5.4", 0, 6] },
+  ]},
+  { title: "Receiving", columns: ["GP", "REC", "TGTS", "YDS", "AVG", "TD", "LNG", "BIG", "YDS/G", "YAC", "FD"], rows: [
+    { name: "Andre Bell", pos: "WR", values: [17, 94, 132, "1,287", "13.7", 9, 58, 18, "75.7", 486, 61] },
+    { name: "Malik Reed", pos: "WR", values: [16, 72, 103, 978, "13.6", 7, 49, 12, "61.1", 312, 45] },
+    { name: "Noah Grant", pos: "TE", values: [17, 58, 76, 681, "11.7", 6, 37, 7, "40.1", 223, 38] },
+  ]},
+  { title: "Defense", columns: ["GP", "SOLO", "AST", "TOT", "SACK", "TFL", "PD", "INT", "YDS", "FF", "FR"], rows: [
+    { name: "Isaiah Ward", pos: "LB", values: [17, 79, 54, 133, "4.5", 11, 6, 1, 18, 2, 1] },
+    { name: "Cam Turner", pos: "S", values: [17, 64, 39, 103, "1.0", 5, 10, 4, 76, 2, 0] },
+    { name: "Dante Lewis", pos: "CB", values: [16, 52, 21, 73, 0, 2, 17, 5, 112, 1, 1] },
+    { name: "Bryce Stone", pos: "DE", values: [17, 39, 24, 63, "10.5", 14, 3, 0, 0, 3, 2] },
+  ]},
+  { title: "Scoring", columns: ["GP", "RUSH", "REC", "RET", "TD", "FG", "PAT", "2PT", "PTS", "PTS/G"], rows: [
+    { name: "Luke Mason", pos: "K", values: [17, 0, 0, 0, 0, 29, 46, 0, 133, "7.8"] },
+    { name: "Darius King", pos: "RB", values: [17, 13, 1, 0, 14, 0, 0, 0, 84, "4.9"] },
+    { name: "Andre Bell", pos: "WR", values: [17, 1, 9, 0, 10, 0, 0, 0, 60, "3.5"] },
+  ]},
+];
+
+function teamLabel(team: LeagueTeam) { return String(team.Name || team.Team || team.Nickname || team.Abbrev || "AFL Team"); }
+
+export function TeamDetail({ team, games, onBack, onGame }: { team: LeagueTeam; games: LeagueGame[]; onBack: () => void; onGame: (game: LeagueGame) => void }) {
+  const [section, setSection] = useState<TeamSection>("stats");
+  const id = String(team.Abbrev || team.Team || team.Name || "AFL");
+  const name = teamLabel(team);
+  const teamGames = useMemo(() => games.filter((game) => game.Home === id || game.Away === id), [games, id]);
+  const leaders = [statGroups[0].rows[0], statGroups[1].rows[0], statGroups[2].rows[0], statGroups[3].rows[0]];
+  const leaderLabels = ["Passing Yards", "Rushing Yards", "Receiving Yards", "Tackles"];
+  const leaderValues = ["4,218", "1,426", "1,287", "133"];
+
+  return <main className="team-page">
+    <button className="team-page-back" type="button" onClick={onBack}>← All teams</button>
+    <header className="team-page-hero">
+      {team.Logo ? <img src={String(team.Logo)} alt="" /> : <div className="team-page-crest">{id.slice(0, 2)}</div>}
+      <div><span>AFL TEAM</span><h1>{name}</h1><p>{team.Wins ?? 0}-{team.Losses ?? 0} · 2026 Regular Season</p></div>
+    </header>
+    <nav className="team-page-nav" aria-label={`${name} sections`}>
+      {(["overview", "stats", "schedule", "roster"] as TeamSection[]).map((item) => <button type="button" className={section === item ? "active" : ""} onClick={() => setSection(item)} key={item}>{item}</button>)}
+    </nav>
+    {section === "stats" ? <section className="team-stats-shell">
+      <header className="team-stats-heading"><div><span>2026 REGULAR SEASON</span><h2>{name} Player Stats</h2></div><button type="button">2026 Regular Season⌄</button></header>
+      <div className="team-stats-mode"><strong>Players</strong><span>Team</span></div>
+      <h3>Team Leaders</h3>
+      <div className="team-leaders">{leaders.map((leader, index) => <article key={leader.name}><small>{leaderLabels[index]}</small><div className="leader-avatar">{leader.name.split(" ").map((part) => part[0]).join("")}</div><p><b>{leader.name}</b> <em>{leader.pos}</em></p><strong>{leaderValues[index]}</strong></article>)}</div>
+      {statGroups.map((group) => <section className="team-stat-group" key={group.title}><h3>{group.title}</h3><div className="team-stat-scroll"><table><thead><tr><th>NAME</th>{group.columns.map((column) => <th className={column === "YDS" || column === "TOT" || column === "PTS" ? "sorted" : ""} key={column}>{column}</th>)}</tr></thead><tbody>{group.rows.map((row) => <tr key={row.name}><td><a>{row.name}</a> <small>{row.pos}</small></td>{row.values.map((value, index) => <td className={group.columns[index] === "YDS" || group.columns[index] === "TOT" || group.columns[index] === "PTS" ? "sorted" : ""} key={index}>{value}</td>)}</tr>)}</tbody></table></div></section>)}
+      <p className="stats-updated">Statistics are updated after every game</p>
+    </section> : section === "schedule" ? <section className="team-simple-panel"><h2>{name} Schedule</h2>{teamGames.length ? teamGames.map((game) => <button type="button" key={game.GameId} onClick={() => onGame(game)}>{game.Away} at {game.Home}<span>{game.Date || `Week ${game.Week || "—"}`} · Gamecast ›</span></button>) : <p>No games have been scheduled.</p>}</section> : <section className="team-simple-panel"><h2>{name} {section === "roster" ? "Roster" : "Overview"}</h2><p>This section will be available during the 2026 season.</p></section>}
+  </main>;
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -511,6 +511,51 @@
   align-items: center;
   gap: 12px;
 }
+.standings-team-button { width: 100%; padding: 0; color: inherit; border: 0; background: transparent; font: inherit; text-align: left; cursor: pointer; }
+.standings-team-button:hover .standings-team-name { color: #72b7ff; text-decoration: underline; }
+
+/* Individual team hub */
+.team-page { min-height: calc(100vh - 96px); padding: clamp(22px, 3vw, 46px); color: #292d32; background: #eceeef; }
+.team-page-back { margin: 0 auto 18px; display: block; width: min(1240px, 100%); padding: 0; color: #52606d; border: 0; background: none; text-align: left; font-weight: 700; cursor: pointer; }
+.team-page-hero { display: flex; align-items: center; gap: 20px; width: min(1240px, 100%); margin: auto; }
+.team-page-hero img, .team-page-crest { width: 78px; height: 78px; object-fit: contain; }
+.team-page-crest { display: grid; place-items: center; color: #fff; border-radius: 50%; background: linear-gradient(135deg, var(--accent-red), #16191e); font-weight: 900; }
+.team-page-hero span { color: #7f8790; font-size: .65rem; font-weight: 800; letter-spacing: .14em; }
+.team-page-hero h1 { margin: 2px 0; font-size: clamp(1.8rem, 4vw, 2.8rem); text-transform: uppercase; }
+.team-page-hero p { margin: 0; color: #6c737b; font-size: .82rem; }
+.team-page-nav { display: flex; gap: 28px; width: min(1240px, 100%); margin: 24px auto 14px; border-bottom: 1px solid #cdd1d5; }
+.team-page-nav button { padding: 12px 2px; color: #51565d; border: 0; border-bottom: 3px solid transparent; background: none; text-transform: capitalize; font-weight: 700; cursor: pointer; }
+.team-page-nav button.active { color: #17191c; border-bottom-color: var(--accent-red); }
+.team-stats-shell, .team-simple-panel { width: min(1240px, 100%); margin: auto; padding: clamp(18px, 2.5vw, 34px); box-sizing: border-box; border-radius: 12px; background: #fff; box-shadow: 0 2px 10px #1d283312; }
+.team-stats-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.team-stats-heading span { color: var(--accent-red); font-size: .65rem; font-weight: 900; letter-spacing: .14em; }
+.team-stats-heading h2 { margin: 5px 0 0; font-size: clamp(1.7rem, 3vw, 2.35rem); }
+.team-stats-heading button { padding: 11px 17px; color: #555d65; border: 1px solid #d7dade; border-radius: 22px; background: #fff; }
+.team-stats-mode { display: grid; grid-template-columns: 1fr 1fr; margin: 20px 0 24px; border-bottom: 1px solid #ddd; text-align: center; }
+.team-stats-mode > * { padding: 13px; color: #9a9ea3; }
+.team-stats-mode strong { color: #25282c; border-bottom: 3px solid var(--accent-red); }
+.team-stats-shell h3 { margin: 20px 0 10px; font-size: 1.1rem; }
+.team-leaders { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid #dadddf; }
+.team-leaders article { display: grid; grid-template-columns: 44px 1fr; grid-template-rows: auto auto auto; column-gap: 10px; padding: 14px; border-right: 1px solid #dadddf; }
+.team-leaders article:last-child { border: 0; }
+.team-leaders small { grid-column: 1/-1; color: #555b61; font-weight: 800; }
+.leader-avatar { grid-row: 2/4; align-self: center; display: grid; place-items: center; width: 40px; height: 40px; color: #fff; border-radius: 50%; background: linear-gradient(145deg, #34495e, var(--accent-red)); font-size: .7rem; font-weight: 900; }
+.team-leaders p { margin: 10px 0 0; white-space: nowrap; font-size: .78rem; }
+.team-leaders p em { color: #8c9196; font-style: normal; }
+.team-leaders article > strong { font-size: 1.65rem; }
+.team-stat-scroll { overflow-x: auto; }
+.team-stat-group table { width: 100%; min-width: 850px; border-collapse: collapse; color: #646a70; font-size: .76rem; }
+.team-stat-group th, .team-stat-group td { padding: 9px 7px; border: 1px solid #e1e3e5; text-align: right; }
+.team-stat-group th:first-child, .team-stat-group td:first-child { min-width: 150px; text-align: left; }
+.team-stat-group th { color: #565b60; font-size: .67rem; text-decoration: underline; }
+.team-stat-group tbody tr:nth-child(even) { background: #f7f7f8; }
+.team-stat-group .sorted { background: #e1edf8; }
+.team-stat-group a { color: #0874d1; font-size: .82rem; }
+.team-stat-group td small { color: #898e93; }
+.stats-updated { margin: 34px 0 0; color: #999ea3; font-size: .75rem; }
+.team-simple-panel > button { display: flex; justify-content: space-between; width: 100%; padding: 16px; color: #222; border: 0; border-top: 1px solid #e1e3e5; background: #fff; cursor: pointer; text-align: left; }
+.team-simple-panel > button span { color: #647381; }
+@media (max-width: 760px) { .team-page { padding: 16px; } .team-leaders { grid-template-columns: 1fr 1fr; } .team-leaders article:nth-child(2) { border-right: 0; } .team-stats-heading { align-items: flex-start; flex-direction: column; } .team-page-nav { gap: 12px; overflow-x: auto; } }
 .standings-team-logo,
 .standings-team-logo-fallback {
   width: 38px;


### PR DESCRIPTION
### Motivation
- Provide a dedicated individual team hub that surfaces current-season stats when a user drills into a team and selects the `stats` subtab. 
- Make teams in the standings and schedule picker navigable so users can jump from league lists to a team-specific view.

### Description
- Add a new `TeamDetail` component at `apps/web/src/components/league/TeamDetail.tsx` that implements an Overview/Stats/Schedule/Roster hub with tables for passing, rushing, receiving, defense, and scoring. 
- Integrate the team hub into the main flow by adding `selectedTeam` state and rendering `TeamDetail` from `apps/web/src/components/league/LeagueAppScreen.tsx`. 
- Make teams clickable by converting the standings row identity into a button and threading an `onSelectTeam` handler through `apps/web/src/components/league/LeagueStandings.tsx` and `apps/web/src/components/league/LeagueSchedules.tsx`. 
- Add responsive styling for the team page and related UI in `apps/web/src/components/league/league.css` and include placeholder/sample stat rows for the current-season presentation.

### Testing
- Ran `npm run build` in `apps/web` which completed successfully and produced production assets. 
- Ran `npm run lint` in `apps/web` which completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`. 
- Ran `git diff --check` which returned no check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d586b745483248512a17942ede226)