### PR TITLE
Load league standings directly from workbook standings data

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -44,23 +44,15 @@ async function getTeamsFromSheet() {
   return rows.filter((r) => r?.[0] !== "" && r?.[0] != null).slice(0, 10).map((r) => objectFrom(headers, r));
 }
 async function getStandingsFromSheet() {
-  const [standings, teams] = await Promise.all([
-    readSheetObjects("standings!A1:Z"),
-    getTeamsFromSheet(),
-  ]);
-  const teamsByAbbrev = new Map(
-    teams.map((team) => [String(team.Abbrev ?? "").trim().toUpperCase(), team]),
-  );
-
+  const standings = await readSheetObjects("standings!A1:Z");
   const standingsAbbrev = (row: Record<string, string>) =>
     String(row.Abbrev ?? row.Team ?? row[""] ?? "").trim().toUpperCase();
 
+  // The first standings column is intentionally unlabeled in the workbook.
+  // Expose it as Abbrev while otherwise returning the sheet columns verbatim.
   return standings
     .filter((row) => standingsAbbrev(row) !== "")
-    .map((row) => {
-      const abbrev = standingsAbbrev(row);
-      return { ...teamsByAbbrev.get(abbrev), ...row, Abbrev: abbrev };
-    });
+    .map((row) => ({ ...row, Abbrev: standingsAbbrev(row) }));
 }
 async function getTeamJerseys() {
   const teams = await getTeamsFromSheet();

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { getGames, getStandings } from "../../api/client";
+import { getGames, getStandings, getTeams } from "../../api/client";
 import type { LeagueGame, LeagueTab, LeagueTeam } from "./types";
 import { mockGames, mockTeams } from "./leagueMockData";
-import { normalizeGames } from "./leagueMappers";
+import { mergeStandingsWithTeams, normalizeGames } from "./leagueMappers";
 import { LeagueHeader } from "./LeagueHeader";
 import { LeagueNews } from "./LeagueNews";
 import { LeagueSchedule } from "./LeagueSchedule";
@@ -20,6 +20,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [activeTab, setActiveTab] = useState<LeagueTab>("scores");
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
+  const [standings, setStandings] = useState<LeagueTeam[]>(mockTeams);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
@@ -28,9 +29,21 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
     getGames()
       .then(({ games }) => setGames(normalizeGames(games)))
       .catch(() => setGames(mockGames));
-    getStandings()
-      .then(({ standings }) => setTeams(standings as LeagueTeam[]))
-      .catch(() => setTeams(mockTeams));
+    Promise.all([getStandings(), getTeams()])
+      .then(([standingsResponse, teamsResponse]) => {
+        const sheetTeams = teamsResponse.teams as LeagueTeam[];
+        setTeams(sheetTeams);
+        setStandings(
+          mergeStandingsWithTeams(
+            standingsResponse.standings as LeagueTeam[],
+            sheetTeams,
+          ),
+        );
+      })
+      .catch(() => {
+        setTeams(mockTeams);
+        setStandings(mockTeams);
+      });
   }, []);
 
   useEffect(() => {
@@ -157,7 +170,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             )}
             {activeTab === "standings" && (
               <div className="league-tab-content active">
-                <LeagueStandings teams={teams} />
+                <LeagueStandings teams={standings} />
               </div>
             )}
             {activeTab === "stats" && (

--- a/apps/web/src/components/league/LeagueStandings.tsx
+++ b/apps/web/src/components/league/LeagueStandings.tsx
@@ -80,8 +80,8 @@ function StandingsTable({ teams }: { teams: LeagueTeam[] }) {
               <td>{parseInteger(team["Div L"] ?? team.DivisionLosses)}</td>
               <td>{parseInteger(team.PF ?? team.PointsFor)}</td>
               <td>{parseInteger(team.PA ?? team.PointsAgainst)}</td>
-              <td>{computeDiff(team)}</td>
-              <td>{value(team, "Streak") || "—"}</td>
+              <td>{value(team, "DIFF", "Diff") || computeDiff(team)}</td>
+              <td>{value(team, "STRK", "Streak") || "—"}</td>
             </tr>
           ))}
         </tbody>

--- a/apps/web/src/components/league/leagueMappers.ts
+++ b/apps/web/src/components/league/leagueMappers.ts
@@ -80,6 +80,23 @@ export function computeDiff(team: LeagueTeam): number {
   );
 }
 
+export function mergeStandingsWithTeams(
+  standings: LeagueTeam[],
+  teams: LeagueTeam[],
+): LeagueTeam[] {
+  const teamsByAbbrev = new Map(
+    teams.map((team) => [String(team.Abbrev ?? "").trim().toUpperCase(), team]),
+  );
+
+  return standings.map((standing) => {
+    const abbrev = String(
+      standing.Abbrev ?? standing.Team ?? standing[""] ?? "",
+    ).trim().toUpperCase();
+
+    return { ...teamsByAbbrev.get(abbrev), ...standing, Abbrev: abbrev };
+  });
+}
+
 export function normalizeGames(rows: unknown[]): LeagueGame[] {
   return rows.filter(Boolean).map((row) => row as LeagueGame);
 }

--- a/apps/web/src/components/league/leagueMockData.ts
+++ b/apps/web/src/components/league/leagueMockData.ts
@@ -38,7 +38,7 @@ export const mockGames: LeagueGame[] = [
   },
 ];
 
-// TODO: Replace fallback standings with the Teams sheet through /api/teams in production-like local runs.
+// Used only when the Standings or Teams sheet cannot be reached.
 export const mockTeams: LeagueTeam[] = [
   {
     Abbrev: "POR",

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -34,6 +34,8 @@ export type LeagueTeam = Record<string, string | number | undefined> & {
   Ties?: string | number;
   PF?: string | number;
   PA?: string | number;
+  DIFF?: string | number;
+  STRK?: string;
   Streak?: string;
   "Home W"?: string | number;
   "Home L"?: string | number;


### PR DESCRIPTION
### Motivation
- The standings tab should display authoritative rows from the workbook `standings` sheet while preserving the sheet's unlabeled abbreviation column. 
- Team identity, logo, and division metadata should come from the `Teams` sheet and be joined to the standings by abbreviation.

### Description
- Updated the API `getStandingsFromSheet` to return the `standings` sheet rows verbatim while normalizing the unlabeled abbreviation column to `Abbrev`. (`apps/api/src/routes/gameRoutes.ts`)
- Frontend now fetches both `getStandings()` and `getTeams()` and stores a dedicated `standings` state while keeping `teams` for schedules. (`apps/web/src/components/league/LeagueAppScreen.tsx`)
- Added `mergeStandingsWithTeams` to join standings rows with team metadata by abbreviation, and wired it into the app load flow. (`apps/web/src/components/league/leagueMappers.ts`)
- The standings table now prefers the sheet-provided `DIFF` and `STRK` columns with fallbacks to computed values, and the `LeagueTeam` type was extended to include `DIFF` and `STRK`. (`apps/web/src/components/league/LeagueStandings.tsx`, `apps/web/src/components/league/types.ts`)

### Testing
- Ran backend tests and typecheck with `cd apps/api && npm test && npm run typecheck`, and all tests and the typecheck completed successfully. 
- Built the frontend with `cd apps/web && npm run build`, which completed successfully. 
- Ran frontend lint with `cd apps/web && npm run lint`, which succeeded but reported a pre-existing React hook warning in `GameField.tsx`. 
- Verified diffs with `git diff --check` and inspected modified files to ensure the new join logic and fallbacks are applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d590d13788324a2d48ea854adeccb)