### PR TITLE
Update schedules and scores from Games sheet

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -27,12 +27,14 @@ function objectFrom(headers: string[], row: Row) {
 async function getGamesList() {
   const { headers, rows } = await sheetRows("Games");
   const idx = (h: string) => headers.indexOf(h);
-  return rows.map((row) => ({
-    GameId: cell(row, idx("Id")), Home: cell(row, idx("Home")), Away: cell(row, idx("Away")),
-    HomeScore: cell(row, idx("HomeScore")), AwayScore: cell(row, idx("AwayScore")), Qtr: cell(row, idx("Qtr")),
-    Time: cell(row, idx("Time")), Down: cell(row, idx("Down")), Distance: cell(row, idx("Distance")),
-    BallOn: cell(row, idx("BallOn")), Possession: cell(row, idx("Possession")), HomeLogo: cell(row, idx("HomeLogo")), AwayLogo: cell(row, idx("AwayLogo")),
-  }));
+  return rows
+    .filter((row) => cell(row, idx("Id")) !== "")
+    .map((row) => ({
+      ...objectFrom(headers, row),
+      // The UI historically called this value GameId. Keep the alias while also
+      // returning every Games sheet column under its workbook header.
+      GameId: cell(row, idx("Id")),
+    }));
 }
 async function getGameState(gameId: string) {
   const { headers, rows } = await sheetRows("Games");

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -28,13 +28,11 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
   const gameLoadTimeout = useRef<number | null>(null);
   useEffect(() => {
-    getGames()
-      .then(({ games }) => setGames(normalizeGames(games)))
-      .catch(() => setGames(mockGames));
-    Promise.all([getStandings(), getTeams()])
-      .then(([standingsResponse, teamsResponse]) => {
+    Promise.all([getGames(), getStandings(), getTeams()])
+      .then(([gamesResponse, standingsResponse, teamsResponse]) => {
         const sheetTeams = teamsResponse.teams as LeagueTeam[];
         setTeams(sheetTeams);
+        setGames(normalizeGames(gamesResponse.games, sheetTeams));
         setStandings(
           mergeStandingsWithTeams(
             standingsResponse.standings as LeagueTeam[],
@@ -43,6 +41,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
         );
       })
       .catch(() => {
+        setGames(normalizeGames(mockGames, mockTeams));
         setTeams(mockTeams);
         setStandings(mockTeams);
       });

--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -1,10 +1,22 @@
 import { useMemo, useState } from "react";
 import type { LeagueGame } from "./types";
 
-const WEEKS = [1, 2, 3, 4, 5];
+const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
 
 const gameWeek = (game: LeagueGame, index: number) =>
   Number(game.Week ?? (index % WEEKS.length) + 1);
+
+function kickoffParts(game: LeagueGame) {
+  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
+  const parsed = new Date(raw);
+  if (!raw || Number.isNaN(parsed.getTime())) {
+    return { date: game.Date || `Week ${game.Week || "—"}`, time: raw || "Time TBD" };
+  }
+  return {
+    date: new Intl.DateTimeFormat("en-US", { weekday: "long", month: "long", day: "numeric" }).format(parsed),
+    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
+  };
+}
 
 export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; onSelectGame: (game: LeagueGame) => void }) {
   const [activeWeek, setActiveWeek] = useState(1);
@@ -12,32 +24,44 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
     () => games.filter((game, index) => gameWeek(game, index) === activeWeek),
     [activeWeek, games],
   );
+  const finalGames = weekGames.filter((game) => String(game.Qtr).toUpperCase() === "FINAL").length;
+  const weekLabel = (week: number) => {
+    const game = games.find((item, index) => gameWeek(item, index) === week);
+    if (!game) return `WEEK ${week}`;
+    const parsed = new Date(String(game["Kickoff Time"] ?? game.Kickoff ?? ""));
+    return Number.isNaN(parsed.getTime())
+      ? `WEEK ${week}`
+      : new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(parsed).toUpperCase();
+  };
 
   return (
     <div className="scores-screen">
       <header className="scores-heading">
         <div><span className="scores-heading__eyebrow">2026 SEASON</span><h1>AFL Scoreboard</h1></div>
-        <div className="scores-heading__status"><i /> Games have not started</div>
+        <div className="scores-heading__status"><i /> {finalGames ? `${finalGames} final` : "Games scheduled"}</div>
       </header>
       <nav className="week-tabs" aria-label="Scoreboard weeks">
         {WEEKS.map((week) => (
           <button key={week} type="button" className={activeWeek === week ? "active" : ""} onClick={() => setActiveWeek(week)}>
-            <span>WEEK {week}</span><small>{week === 1 ? "SEP 6" : `WEEK ${week}`}</small>
+            <span>WEEK {week}</span><small>{weekLabel(week)}</small>
           </button>
         ))}
       </nav>
       <section className="week-scoreboard">
-        <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>Upcoming Games</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
-        {weekGames.length ? weekGames.map((game) => (
+        <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>{finalGames ? "Scores & Results" : "Upcoming Games"}</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
+        {weekGames.length ? weekGames.map((game) => {
+          const kickoff = kickoffParts(game);
+          const final = String(game.Qtr).toUpperCase() === "FINAL";
+          return (
           <article className="schedule-game" key={String(game.GameId)}>
-            <div className="schedule-game__date"><strong>{game.Date || `Week ${activeWeek}`}</strong><span>{game.Kickoff || "Time TBD"} · {game.Network || "AFL Network"}</span></div>
+            <div className="schedule-game__date"><strong>{kickoff.date}</strong><span>{kickoff.time} · {game.Network || "Network TBD"}</span>{game.Weather && <small>{game.Weather}</small>}</div>
             <div className="schedule-game__teams">
-              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.Away}</strong><small>AWAY · 0-0</small></span><b>0</b></div>
-              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.Home}</strong><small>HOME · 0-0</small></span><b>0</b></div>
+              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
+              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
             </div>
-            <div className="schedule-game__action"><span>PRE-GAME</span><button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button></div>
+            <div className="schedule-game__action"><span>{final ? "FINAL" : `Q${game.Qtr} · ${game.Time}`}</span><button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button></div>
           </article>
-        )) : <div className="schedule-empty"><strong>No games scheduled yet</strong><span>Check back for the Week {activeWeek} matchup announcement.</span></div>}
+        );}) : <div className="schedule-empty"><strong>No games scheduled yet</strong><span>Check back for the Week {activeWeek} matchup announcement.</span></div>}
       </section>
     </div>
   );

--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -6,6 +6,18 @@ const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
 const getWeek = (game: LeagueGame, index: number) => Number(game.Week ?? index + 1);
 const isFinal = (game: LeagueGame) => String(game.Qtr).toUpperCase() === "FINAL";
 const teamName = (team: LeagueTeam) => String(team.Team || team.Name || team.Abbrev || "Team");
+const teamAbbrev = (team: LeagueTeam) => String(team.Abbrev || team.Team || "");
+function kickoffParts(game: LeagueGame) {
+  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
+  const parsed = new Date(raw);
+  if (!raw || Number.isNaN(parsed.getTime())) {
+    return { date: game.Date || `Week ${game.Week || "—"}`, time: raw || "TBD" };
+  }
+  return {
+    date: new Intl.DateTimeFormat("en-US", { weekday: "short", month: "short", day: "numeric" }).format(parsed),
+    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
+  };
+}
 
 export function LeagueSchedules({
   games,
@@ -23,7 +35,7 @@ export function LeagueSchedules({
   const teamOptions = useMemo(() => {
     const labels = new Map<string, string>();
     teams.forEach((team) => {
-      const abbreviation = String(team.Abbrev || team.Team || "");
+      const abbreviation = teamAbbrev(team);
       if (abbreviation) labels.set(abbreviation, teamName(team));
     });
     games.forEach((game) => {
@@ -40,12 +52,13 @@ export function LeagueSchedules({
     [games, selectedTeam, week],
   );
   const selectedLabel = teamOptions.find(([id]) => id === selectedTeam)?.[1] || selectedTeam;
+  const selectedTeamDetails = teams.find((team) => teamAbbrev(team) === selectedTeam);
 
   return (
     <main className="schedule-center">
       {selectedTeam && (
         <header className="team-schedule-hero">
-          <div className="team-schedule-crest">{selectedTeam.slice(0, 2)}</div>
+          <div className="team-schedule-crest">{selectedTeamDetails?.Logo ? <img src={String(selectedTeamDetails.Logo)} alt="" /> : selectedTeam.slice(0, 2)}</div>
           <div><span>AFL TEAM</span><h1>{selectedLabel}</h1><small>2026 season</small></div>
         </header>
       )}
@@ -58,7 +71,7 @@ export function LeagueSchedules({
             <select value={selectedTeam} onChange={(event) => {
               const id = event.target.value;
               setSelectedTeam(id);
-              const team = teams.find((item) => String(item.Abbrev || item.Team || "") === id);
+              const team = teams.find((item) => teamAbbrev(item) === id);
               if (team) onSelectTeam?.(team);
             }}>
               <option value="">All weekly schedules</option>
@@ -76,16 +89,17 @@ export function LeagueSchedules({
           <table className="schedule-table">
             <thead><tr>{selectedTeam && <th>WK</th>}<th>Date</th><th>Matchup</th><th>{visibleGames.some(isFinal) ? "Result / Time" : "Time"}</th><th>TV</th><th>Game</th></tr></thead>
             <tbody>
-              {visibleGames.map((game, index) => {
+              {visibleGames.map((game) => {
                 const final = isFinal(game);
                 const homeWon = Number(game.HomeScore) > Number(game.AwayScore);
                 const chosenIsHome = selectedTeam === game.Home;
                 const won = chosenIsHome ? homeWon : !homeWon;
+                const kickoff = kickoffParts(game);
                 return <tr key={String(game.GameId)}>
                   {selectedTeam && <td>{getWeek(game, games.indexOf(game))}</td>}
-                  <td>{game.Date || `Week ${getWeek(game, index)}`}</td>
-                  <td><div className="schedule-matchup"><span><b>{game.Away}</b><small>Away</small></span><em>at</em><span><b>{game.Home}</b><small>Home</small></span></div></td>
-                  <td>{final ? <span className={`game-result ${won ? "win" : "loss"}`}><b>{selectedTeam ? (won ? "W" : "L") : "FINAL"}</b> {game.AwayScore}–{game.HomeScore}</span> : <strong className="kickoff-time">{game.Kickoff || "TBD"}</strong>}</td>
+                  <td>{kickoff.date}</td>
+                  <td><div className="schedule-matchup"><span><b>{game.AwayName || game.Away}</b><small>{game.Away} · Away</small></span><em>at</em><span><b>{game.HomeName || game.Home}</b><small>{game.Home} · Home</small></span></div></td>
+                  <td>{final ? <span className={`game-result ${won ? "win" : "loss"}`}><b>{selectedTeam ? (won ? "W" : "L") : "FINAL"}</b> {game.AwayScore}–{game.HomeScore}</span> : <strong className="kickoff-time">{kickoff.time}</strong>}</td>
                   <td>{game.Network || "AFL Network"}</td>
                   <td><button className="schedule-game-link" type="button" onClick={() => onSelectGame(game)}>Gamecast ›</button></td>
                 </tr>;

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -283,6 +283,7 @@
 .schedule-game__date { border-right: 1px solid #292e35; }
 .schedule-game__date strong { margin-bottom: 8px; font-size: .88rem; }
 .schedule-game__date span { color: #929ba7; font-size: .72rem; }
+.schedule-game__date small { margin-top: 9px; color: #737e8b; font-size: .66rem; }
 .schedule-game__teams { display: grid; align-content: center; padding: 18px 34px; }
 .schedule-game__teams > div { display: grid; grid-template-columns: 42px 1fr auto; align-items: center; gap: 16px; min-height: 64px; }
 .schedule-game__teams img { width: 38px; height: 38px; object-fit: contain; }
@@ -333,6 +334,7 @@
 .team-schedule-hero h1 { margin: 2px 0; font-size: clamp(1.65rem, 3vw, 2.35rem); text-transform: uppercase; }
 .team-schedule-hero span, .team-schedule-hero small { color: #747d87; font-size: .68rem; letter-spacing: .1em; text-transform: uppercase; }
 .team-schedule-crest { display: grid; place-items: center; width: 74px; height: 74px; color: #fff; border-radius: 50%; background: linear-gradient(135deg, #ba0714, #171a20); font-size: 1.25rem; font-weight: 900; }
+.team-schedule-crest img { width: 58px; height: 58px; object-fit: contain; }
 .team-subtabs { display: flex; gap: 30px; max-width: 1240px; margin: 0 auto 16px; padding: 0 8px; border-bottom: 1px solid #d0d5db; }
 .team-subtabs span, .team-subtabs strong { padding: 10px 2px 13px; font-size: .82rem; }
 .team-subtabs strong { margin-bottom: -1px; border-bottom: 3px solid var(--accent-red); }

--- a/apps/web/src/components/league/leagueMappers.ts
+++ b/apps/web/src/components/league/leagueMappers.ts
@@ -97,6 +97,34 @@ export function mergeStandingsWithTeams(
   });
 }
 
-export function normalizeGames(rows: unknown[]): LeagueGame[] {
-  return rows.filter(Boolean).map((row) => row as LeagueGame);
+function teamKey(value: unknown): string {
+  return String(value ?? "").trim().toUpperCase();
+}
+
+function teamDisplayName(team: LeagueTeam | undefined, fallback: string): string {
+  if (!team) return fallback;
+  const city = String(team.City ?? "").trim();
+  const nickname = String(team.Nickname ?? "").trim();
+  return String(team.Team ?? team.Name ?? `${city} ${nickname}`.trim() ?? fallback) || fallback;
+}
+
+export function normalizeGames(rows: unknown[], teams: LeagueTeam[] = []): LeagueGame[] {
+  const teamsByAbbrev = new Map(
+    teams.map((team) => [teamKey(team.Abbrev ?? team.Team), team]),
+  );
+
+  return rows.filter(Boolean).map((row) => {
+    const game = row as LeagueGame & { Id?: string | number };
+    const home = teamsByAbbrev.get(teamKey(game.Home));
+    const away = teamsByAbbrev.get(teamKey(game.Away));
+    return {
+      ...game,
+      GameId: game.GameId ?? game.Id ?? "",
+      Kickoff: game.Kickoff ?? game["Kickoff Time"],
+      HomeLogo: String(home?.Logo ?? ""),
+      AwayLogo: String(away?.Logo ?? ""),
+      HomeName: teamDisplayName(home, game.Home),
+      AwayName: teamDisplayName(away, game.Away),
+    };
+  });
 }

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -14,11 +14,15 @@ export type LeagueGame = {
   BallOn: string | number;
   Possession: "Home" | "Away" | string;
   Week?: string | number;
+  "Kickoff Time"?: string;
   Date?: string;
   Kickoff?: string;
   Network?: string;
+  Weather?: string;
   HomeLogo?: string;
   AwayLogo?: string;
+  HomeName?: string;
+  AwayName?: string;
 };
 
 export type LeagueTeam = Record<string, string | number | undefined> & {


### PR DESCRIPTION
### Motivation
- Surface all populated columns from the workbook `Games` sheet in the API and use Teams sheet data so the app can display accurate kickoff times, weather, team names, logos, and sheet-based scores in the Schedules and Scores tabs.
- Keep backwards-compatible behavior by preserving the historical `GameId` alias while returning the full row object for future UI use.
- Improve the Scores and Schedules UX to show real kickoff dates/times, 18 weeks, game status (final/Qtr/clock), and enriched team presentation.

### Description
- API: changed `getGamesList` to return every populated `Games` sheet column via `objectFrom(headers, row)` and preserve `GameId` as an alias while filtering out empty Id rows (`apps/api/src/routes/gameRoutes.ts`).
- Data mapping: extended `normalizeGames` to accept `teams` and resolve team display names and logos (adds `HomeName`, `AwayName`, `HomeLogo`, `AwayLogo` mapping), and to map `Kickoff` from `Kickoff Time` when present (`apps/web/src/components/league/leagueMappers.ts`, `apps/web/src/components/league/types.ts`).
- App load: fetch `getGames()`, `getStandings()`, and `getTeams()` together and normalize games with the teams data before rendering (`apps/web/src/components/league/LeagueAppScreen.tsx`).
- UI: updated Scores and Schedules components to show all 18 weeks, parse and format kickoff timestamps, display weather/network, show team logos and enriched team names, and display actual sheet scores/status (Q/FINAL/clock) (`apps/web/src/components/league/LeagueSchedule.tsx`, `apps/web/src/components/league/LeagueSchedules.tsx`).
- Styling: small CSS additions to support displaying team crest images and weather text (`apps/web/src/components/league/league.css`).

### Testing
- Built the web app with `cd apps/web && npm run build` and the build completed successfully.
- Ran lint with `cd apps/web && npm run lint` which completed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (no new lint errors).
- Ran API checks with `cd apps/api && npm run typecheck && npm test` and all automated tests passed (`3` tests OK).
- Ran `git diff --check` to validate whitespace/diff issues; no blocking problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d5a3b39cc8324b23abb4ebf6cc033)