### PR TITLE
Group league schedules by Week and redesign team schedule view

### DIFF
--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -1,8 +1,6 @@
 import { useMemo, useState } from "react";
 import type { LeagueGame, LeagueTeam } from "./types";
 
-const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
-
 const getWeek = (game: LeagueGame, index: number) => Number(game.Week ?? index + 1);
 const isFinal = (game: LeagueGame) => String(game.Qtr).toUpperCase() === "FINAL";
 const teamName = (team: LeagueTeam) => String(team.Team || team.Name || team.Abbrev || "Team");
@@ -30,7 +28,6 @@ export function LeagueSchedules({
   onSelectGame: (game: LeagueGame) => void;
   onSelectTeam?: (team: LeagueTeam) => void;
 }) {
-  const [week, setWeek] = useState(1);
   const [selectedTeam, setSelectedTeam] = useState("");
   const teamOptions = useMemo(() => {
     const labels = new Map<string, string>();
@@ -45,12 +42,17 @@ export function LeagueSchedules({
     return [...labels].sort((a, b) => a[1].localeCompare(b[1]));
   }, [games, teams]);
 
-  const visibleGames = useMemo(
-    () => selectedTeam
-      ? games.filter((game) => game.Home === selectedTeam || game.Away === selectedTeam)
-      : games.filter((game, index) => getWeek(game, index) === week),
-    [games, selectedTeam, week],
-  );
+  const visibleGames = useMemo(() => selectedTeam
+    ? games.filter((game) => game.Home === selectedTeam || game.Away === selectedTeam)
+    : games, [games, selectedTeam]);
+  const gamesByWeek = useMemo(() => {
+    const grouped = new Map<number, LeagueGame[]>();
+    visibleGames.forEach((game, index) => {
+      const gameWeek = getWeek(game, index);
+      grouped.set(gameWeek, [...(grouped.get(gameWeek) ?? []), game]);
+    });
+    return [...grouped.entries()].sort(([a], [b]) => a - b);
+  }, [visibleGames]);
   const selectedLabel = teamOptions.find(([id]) => id === selectedTeam)?.[1] || selectedTeam;
   const selectedTeamDetails = teams.find((team) => teamAbbrev(team) === selectedTeam);
 
@@ -80,16 +82,14 @@ export function LeagueSchedules({
           </label>
         </header>
 
-        {!selectedTeam && <nav className="schedule-weeks" aria-label="Schedule weeks">
-          {WEEKS.map((item) => <button type="button" key={item} className={week === item ? "active" : ""} onClick={() => setWeek(item)}><b>WEEK {item}</b><small>{item === 1 ? "SEP 6–12" : `2026 · WK ${item}`}</small></button>)}
-        </nav>}
-
         <div className="schedule-table-wrap">
-          <div className="schedule-section-title"><h2>{selectedTeam ? "Regular Season" : `Week ${week}`}</h2><span>{visibleGames.length} {visibleGames.length === 1 ? "game" : "games"}</span></div>
+          {selectedTeam && <div className="schedule-section-title"><h2>Regular Season</h2><span>{visibleGames.length} {visibleGames.length === 1 ? "game" : "games"}</span></div>}
           <table className="schedule-table">
             <thead><tr>{selectedTeam && <th>WK</th>}<th>Date</th><th>Matchup</th><th>{visibleGames.some(isFinal) ? "Result / Time" : "Time"}</th><th>TV</th><th>Game</th></tr></thead>
             <tbody>
-              {visibleGames.map((game) => {
+              {gamesByWeek.flatMap(([gameWeek, weekGames]) => [
+                !selectedTeam && <tr className="schedule-week-row" key={`week-${gameWeek}`}><th colSpan={5}><span>Week {gameWeek}</span><small>{weekGames.length} {weekGames.length === 1 ? "game" : "games"}</small></th></tr>,
+                ...weekGames.map((game) => {
                 const final = isFinal(game);
                 const homeWon = Number(game.HomeScore) > Number(game.AwayScore);
                 const chosenIsHome = selectedTeam === game.Home;
@@ -103,10 +103,10 @@ export function LeagueSchedules({
                   <td>{game.Network || "AFL Network"}</td>
                   <td><button className="schedule-game-link" type="button" onClick={() => onSelectGame(game)}>Gamecast ›</button></td>
                 </tr>;
-              })}
+              })])}
             </tbody>
           </table>
-          {!visibleGames.length && <div className="schedule-no-games"><strong>No games scheduled</strong><span>The Week {week} schedule has not been announced yet.</span></div>}
+          {!visibleGames.length && <div className="schedule-no-games"><strong>No games scheduled</strong><span>The 2026 schedule has not been announced yet.</span></div>}
         </div>
       </section>
     </main>

--- a/apps/web/src/components/league/TeamDetail.tsx
+++ b/apps/web/src/components/league/TeamDetail.tsx
@@ -20,6 +20,15 @@ function numericStat(stats: PlayerStats | null | undefined, names: string[]) {
 function stars(player: TeamPlayer, side: "off" | "def") {
   return Number(player[side === "off" ? "Off Stars" : "Def Stars"]) || 0;
 }
+function kickoffParts(game: LeagueGame) {
+  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
+  const parsed = new Date(raw);
+  if (!raw || Number.isNaN(parsed.getTime())) return { date: game.Date || "TBD", time: raw || "TBD" };
+  return {
+    date: new Intl.DateTimeFormat("en-US", { weekday: "short", month: "short", day: "numeric" }).format(parsed),
+    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
+  };
+}
 
 export function TeamDetail({ team, standings, games, onBack, onGame }: { team: LeagueTeam; standings: LeagueTeam[]; games: LeagueGame[]; onBack: () => void; onGame: (game: LeagueGame) => void }) {
   const [section, setSection] = useState<TeamSection>("stats");
@@ -64,6 +73,14 @@ export function TeamDetail({ team, standings, games, onBack, onGame }: { team: L
       <h3>Team Leaders</h3>
       {rosterError ? <p className="players-message players-message--error">{rosterError}</p> : <div className="team-leaders">{leaders.map((leader, index) => leader && <article key={`${leader.Name}-${index}`}><small>{leaderSpecs[index].label}</small><PlayerImage player={leader} className="leader-avatar" /><p><b>{leader.Name}</b> <em>{leader.Pos || leader.DefPos}</em></p><strong>{hasStats ? numericStat(leader.Stats, leaderSpecs[index].fields) : `${stars(leader, leaderSpecs[index].side)}★`}</strong></article>)}</div>}
       <section className="team-stat-group"><h3>Season Stats</h3><div className="team-stat-scroll"><table><thead><tr><th>NAME</th>{statColumns.map((column) => <th key={column}>{column}</th>)}</tr></thead><tbody>{players.map((player) => <tr key={String(player.Name)}><td><a>{player.Name}</a> <small>{player.Pos || player.DefPos}</small></td>{statColumns.map((column) => <td key={column}>{player.Stats?.[column] || "—"}</td>)}</tr>)}</tbody></table></div>{!players.length && !rosterError && <p>Loading roster…</p>}{players.length > 0 && !statColumns.length && <p>No season statistics have been recorded yet. Leaders are based on player star ratings.</p>}</section>
-    </section> : section === "schedule" ? <section className="team-simple-panel"><h2>{name} Schedule</h2>{teamGames.length ? teamGames.map((game) => <button type="button" key={game.GameId} onClick={() => onGame(game)}>{game.Away} at {game.Home}<span>{game.Date || `Week ${game.Week || "—"}`} · Gamecast ›</span></button>) : <p>No games have been scheduled.</p>}</section> : section === "roster" ? <section className="team-simple-panel"><h2>{name} Roster</h2>{players.map((player) => <p key={String(player.Name)}><b>{player.Name}</b> · {player.Pos || player.DefPos || "Player"}</p>)}</section> : <section className="team-simple-panel"><h2>{name} Overview</h2><p>{record} · {divisionPlace >= 0 ? `${ordinal(divisionPlace + 1)} in ${division}` : division}</p></section>}
+    </section> : section === "schedule" ? <section className="team-schedule-panel"><header><span>2026 SEASON</span><h2>{name} Schedule 2026</h2></header>{teamGames.length ? <><h3>Regular Season</h3><div className="team-schedule-scroll"><table><thead><tr><th>WK</th><th>DATE</th><th>OPPONENT</th><th>TIME</th><th>TV</th></tr></thead><tbody>{teamGames.map((game, index) => {
+      const isHome = key(game.Home) === key(id);
+      const opponent = isHome ? game.Away : game.Home;
+      const opponentName = isHome ? game.AwayName : game.HomeName;
+      const opponentLogo = isHome ? game.AwayLogo : game.HomeLogo;
+      const kickoff = kickoffParts(game);
+      const final = String(game.Qtr).toUpperCase() === "FINAL";
+      return <tr key={game.GameId} onClick={() => onGame(game)}><td>{game.Week || index + 1}</td><td>{kickoff.date}</td><td><span className="team-schedule-opponent"><em>{isHome ? "vs" : "@"}</em>{opponentLogo ? <img src={opponentLogo} alt="" /> : <i>{opponent.slice(0, 2)}</i>}<strong>{opponentName || opponent}</strong></span></td><td><button type="button" onClick={() => onGame(game)}>{final ? `${Number(game.HomeScore) === Number(game.AwayScore) ? "T" : (isHome ? Number(game.HomeScore) > Number(game.AwayScore) : Number(game.AwayScore) > Number(game.HomeScore)) ? "W" : "L"} ${game.AwayScore}-${game.HomeScore}` : kickoff.time}</button></td><td>{game.Network || "AFL Network"}</td></tr>;
+    })}</tbody></table></div></> : <p>No games have been scheduled.</p>}</section> : section === "roster" ? <section className="team-simple-panel"><h2>{name} Roster</h2>{players.map((player) => <p key={String(player.Name)}><b>{player.Name}</b> · {player.Pos || player.DefPos || "Player"}</p>)}</section> : <section className="team-simple-panel"><h2>{name} Overview</h2><p>{record} · {divisionPlace >= 0 ? `${ordinal(divisionPlace + 1)} in ${division}` : division}</p></section>}
   </main>;
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -318,6 +318,10 @@
 .schedule-table th { padding: 11px 8px; color: #69717a; text-align: left; text-transform: uppercase; font-size: .66rem; letter-spacing: .05em; }
 .schedule-table td { padding: 13px 8px; border-top: 1px solid #e6e8eb; color: #606871; font-size: .8rem; }
 .schedule-table tbody tr:nth-child(even) { background: #f7f8f9; }
+.schedule-table .schedule-week-row { background: #eef1f4; }
+.schedule-table .schedule-week-row th { padding: 17px 10px 9px; border-bottom: 2px solid #cfd4da; color: #242b33; }
+.schedule-week-row th span { font-size: .9rem; font-weight: 900; }
+.schedule-week-row th small { margin-left: 12px; color: #7a838d; font-size: .62rem; font-weight: 700; }
 .schedule-matchup { display: flex; align-items: center; gap: 14px; color: #1e252d; }
 .schedule-matchup span { display: grid; min-width: 58px; }
 .schedule-matchup small { color: #89919a; font-size: .6rem; text-transform: uppercase; }
@@ -335,6 +339,21 @@
 .team-schedule-hero span, .team-schedule-hero small { color: #747d87; font-size: .68rem; letter-spacing: .1em; text-transform: uppercase; }
 .team-schedule-crest { display: grid; place-items: center; width: 74px; height: 74px; color: #fff; border-radius: 50%; background: linear-gradient(135deg, #ba0714, #171a20); font-size: 1.25rem; font-weight: 900; }
 .team-schedule-crest img { width: 58px; height: 58px; object-fit: contain; }
+.team-schedule-panel { max-width: 1120px; margin: 28px auto; padding: 28px 32px 36px; border: 1px solid #dce0e4; border-radius: 12px; background: #fff; box-shadow: 0 7px 24px #17202c0c; }
+.team-schedule-panel header span { color: var(--accent-red); font-size: .66rem; font-weight: 900; letter-spacing: .14em; }
+.team-schedule-panel header h2 { margin: 5px 0 30px; font-size: clamp(1.7rem, 3vw, 2.25rem); }
+.team-schedule-panel h3 { margin: 0; padding: 0 4px 9px; color: #606a75; border-bottom: 2px solid #d8dce0; font-size: 1rem; }
+.team-schedule-panel table { width: 100%; border-collapse: collapse; }
+.team-schedule-panel th { padding: 10px 6px; color: #68717c; text-align: left; font-size: .65rem; }
+.team-schedule-panel td { padding: 10px 6px; border-top: 1px solid #e4e7ea; color: #59636e; font-size: .8rem; }
+.team-schedule-panel tbody tr:nth-child(even) { background: #f7f8f9; }
+.team-schedule-panel tbody tr { cursor: pointer; }
+.team-schedule-panel tbody tr:hover { background: #edf4fb; }
+.team-schedule-opponent { display: flex; align-items: center; gap: 8px; color: #086bc1; }
+.team-schedule-opponent em { width: 18px; color: #606a75; font-style: normal; }
+.team-schedule-opponent img, .team-schedule-opponent i { width: 25px; height: 25px; object-fit: contain; }
+.team-schedule-opponent i { display: grid; place-items: center; color: #fff; border-radius: 50%; background: #2c3845; font-size: .55rem; font-style: normal; font-weight: 800; }
+.team-schedule-panel td button { padding: 0; color: #076dcc; border: 0; background: transparent; cursor: pointer; font-weight: 700; }
 .team-subtabs { display: flex; gap: 30px; max-width: 1240px; margin: 0 auto 16px; padding: 0 8px; border-bottom: 1px solid #d0d5db; }
 .team-subtabs span, .team-subtabs strong { padding: 10px 2px 13px; font-size: .82rem; }
 .team-subtabs strong { margin-bottom: -1px; border-bottom: 3px solid var(--accent-red); }
@@ -355,6 +374,9 @@
   .team-schedule-picker select { width: 100%; }
   .schedule-table-wrap { padding: 18px 14px 28px; overflow-x: auto; }
   .schedule-table { min-width: 680px; }
+  .team-schedule-panel { margin: 14px; padding: 22px 16px 28px; }
+  .team-schedule-scroll { overflow-x: auto; }
+  .team-schedule-panel table { min-width: 650px; }
   .team-subtabs { gap: 18px; overflow-x: auto; }
 }
 .game-card {


### PR DESCRIPTION
### Motivation
- Ensure the League Schedules view is grouped and presented by the `Week` column so games are organized per-week. 
- Replace the minimal team schedule list with a richer team-specific schedule UI matching the requested columns: WK, Date, Opponent (with @/vs and logo), Time, and TV.

### Description
- Group the league schedule into ordered week sections and render week header rows with per-week game counts in `LeagueSchedules.tsx` using a `gamesByWeek` map and `getWeek(game)` logic.
- Replace the team schedule subtab in `TeamDetail.tsx` with a regular-season table showing `WK`, formatted `Date`, `Opponent` (home/away marker, logo fallback, and name), `Time` (formatted kickoff or final/result), and `TV`, and make rows clickable to open the gamecast.
- Add a `kickoffParts` helper for consistent date/time formatting and derive final/result badges for completed games.
- Add CSS for visual week separators and a responsive `team-schedule-panel` (styles in `league.css`) including alternating rows, hover states, opponent logo handling, and mobile horizontal scrolling.

### Testing
- Ran `npm run build` successfully (production build completed).
- Ran `npm run lint` which completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (unrelated to these changes).
- Verified `git diff --check` / repository status and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d5d8c091483249871aa5e7190994c)