### PR TITLE
Group league schedules by week and game day

### DIFF
--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -2,19 +2,36 @@ import { useMemo, useState } from "react";
 import type { LeagueGame, LeagueTeam } from "./types";
 
 const getWeek = (game: LeagueGame, index: number) => Number(game.Week ?? index + 1);
-const isFinal = (game: LeagueGame) => String(game.Qtr).toUpperCase() === "FINAL";
 const teamName = (team: LeagueTeam) => String(team.Team || team.Name || team.Abbrev || "Team");
 const teamAbbrev = (team: LeagueTeam) => String(team.Abbrev || team.Team || "");
-function kickoffParts(game: LeagueGame) {
-  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
+
+function kickoffDate(game: LeagueGame) {
+  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? game.Date ?? "").trim();
   const parsed = new Date(raw);
-  if (!raw || Number.isNaN(parsed.getTime())) {
-    return { date: game.Date || `Week ${game.Week || "—"}`, time: raw || "TBD" };
-  }
-  return {
-    date: new Intl.DateTimeFormat("en-US", { weekday: "short", month: "short", day: "numeric" }).format(parsed),
-    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
-  };
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function kickoffTime(game: LeagueGame) {
+  const parsed = kickoffDate(game);
+  if (!parsed) return String(game["Kickoff Time"] ?? game.Kickoff ?? "TBD");
+  return new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed);
+}
+
+function dayLabel(game: LeagueGame) {
+  const parsed = kickoffDate(game);
+  if (!parsed) return game.Date || "Date TBD";
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+}
+
+function dayKey(game: LeagueGame) {
+  const parsed = kickoffDate(game);
+  if (!parsed) return game.Date || "tbd";
+  return `${parsed.getFullYear()}-${parsed.getMonth()}-${parsed.getDate()}`;
 }
 
 export function LeagueSchedules({
@@ -29,6 +46,8 @@ export function LeagueSchedules({
   onSelectTeam?: (team: LeagueTeam) => void;
 }) {
   const [selectedTeam, setSelectedTeam] = useState("");
+  const [activeWeek, setActiveWeek] = useState<number>();
+  const teamsByAbbrev = useMemo(() => new Map(teams.map((team) => [teamAbbrev(team), team])), [teams]);
   const teamOptions = useMemo(() => {
     const labels = new Map<string, string>();
     teams.forEach((team) => {
@@ -41,20 +60,24 @@ export function LeagueSchedules({
     });
     return [...labels].sort((a, b) => a[1].localeCompare(b[1]));
   }, [games, teams]);
+  const weeks = useMemo(() => [...new Set(games.map(getWeek))].sort((a, b) => a - b), [games]);
+  const displayedWeek = activeWeek ?? weeks[0];
 
-  const visibleGames = useMemo(() => selectedTeam
-    ? games.filter((game) => game.Home === selectedTeam || game.Away === selectedTeam)
-    : games, [games, selectedTeam]);
-  const gamesByWeek = useMemo(() => {
-    const grouped = new Map<number, LeagueGame[]>();
-    visibleGames.forEach((game, index) => {
-      const gameWeek = getWeek(game, index);
-      grouped.set(gameWeek, [...(grouped.get(gameWeek) ?? []), game]);
-    });
-    return [...grouped.entries()].sort(([a], [b]) => a - b);
+  const visibleGames = useMemo(() => games.filter((game, index) =>
+    getWeek(game, index) === displayedWeek
+    && (!selectedTeam || game.Home === selectedTeam || game.Away === selectedTeam)), [displayedWeek, games, selectedTeam]);
+  const gamesByDay = useMemo(() => {
+    const grouped = new Map<string, LeagueGame[]>();
+    visibleGames.forEach((game) => grouped.set(dayKey(game), [...(grouped.get(dayKey(game)) ?? []), game]));
+    return [...grouped.values()];
   }, [visibleGames]);
   const selectedLabel = teamOptions.find(([id]) => id === selectedTeam)?.[1] || selectedTeam;
-  const selectedTeamDetails = teams.find((team) => teamAbbrev(team) === selectedTeam);
+  const selectedTeamDetails = teamsByAbbrev.get(selectedTeam);
+
+  const locationFor = (game: LeagueGame) => {
+    const home = teamsByAbbrev.get(game.Home);
+    return game.Location || game.Stadium || game.Venue || String(home?.City || game.HomeName || game.Home);
+  };
 
   return (
     <main className="schedule-center">
@@ -64,7 +87,6 @@ export function LeagueSchedules({
           <div><span>AFL TEAM</span><h1>{selectedLabel}</h1><small>2026 season</small></div>
         </header>
       )}
-      {selectedTeam && <nav className="team-subtabs" aria-label={`${selectedLabel} sections`}><span>Overview</span><span>Stats</span><strong>Schedule</strong><span>Roster</span></nav>}
       <section className="schedule-card">
         <header className="schedule-card__heading">
           <div><span className="schedule-kicker">2026 SEASON</span><h1>{selectedTeam ? `${selectedLabel} Schedule` : "AFL Schedule"}</h1></div>
@@ -73,40 +95,41 @@ export function LeagueSchedules({
             <select value={selectedTeam} onChange={(event) => {
               const id = event.target.value;
               setSelectedTeam(id);
-              const team = teams.find((item) => teamAbbrev(item) === id);
+              const team = teamsByAbbrev.get(id);
               if (team) onSelectTeam?.(team);
             }}>
-              <option value="">All weekly schedules</option>
+              <option value="">Team Schedules</option>
               {teamOptions.map(([id, label]) => <option value={id} key={id}>{label}</option>)}
             </select>
           </label>
         </header>
 
+        <nav className="schedule-weeks" aria-label="Schedule weeks">
+          {weeks.map((week) => <button className={week === displayedWeek ? "active" : ""} key={week} type="button" onClick={() => setActiveWeek(week)}><b>WEEK {week}</b><small>{games.filter((game, index) => getWeek(game, index) === week).length} games</small></button>)}
+        </nav>
+
         <div className="schedule-table-wrap">
-          {selectedTeam && <div className="schedule-section-title"><h2>Regular Season</h2><span>{visibleGames.length} {visibleGames.length === 1 ? "game" : "games"}</span></div>}
-          <table className="schedule-table">
-            <thead><tr>{selectedTeam && <th>WK</th>}<th>Date</th><th>Matchup</th><th>{visibleGames.some(isFinal) ? "Result / Time" : "Time"}</th><th>TV</th><th>Game</th></tr></thead>
-            <tbody>
-              {gamesByWeek.flatMap(([gameWeek, weekGames]) => [
-                !selectedTeam && <tr className="schedule-week-row" key={`week-${gameWeek}`}><th colSpan={5}><span>Week {gameWeek}</span><small>{weekGames.length} {weekGames.length === 1 ? "game" : "games"}</small></th></tr>,
-                ...weekGames.map((game) => {
-                const final = isFinal(game);
-                const homeWon = Number(game.HomeScore) > Number(game.AwayScore);
-                const chosenIsHome = selectedTeam === game.Home;
-                const won = chosenIsHome ? homeWon : !homeWon;
-                const kickoff = kickoffParts(game);
-                return <tr key={String(game.GameId)}>
-                  {selectedTeam && <td>{getWeek(game, games.indexOf(game))}</td>}
-                  <td>{kickoff.date}</td>
-                  <td><div className="schedule-matchup"><span><b>{game.AwayName || game.Away}</b><small>{game.Away} · Away</small></span><em>at</em><span><b>{game.HomeName || game.Home}</b><small>{game.Home} · Home</small></span></div></td>
-                  <td>{final ? <span className={`game-result ${won ? "win" : "loss"}`}><b>{selectedTeam ? (won ? "W" : "L") : "FINAL"}</b> {game.AwayScore}–{game.HomeScore}</span> : <strong className="kickoff-time">{kickoff.time}</strong>}</td>
-                  <td>{game.Network || "AFL Network"}</td>
-                  <td><button className="schedule-game-link" type="button" onClick={() => onSelectGame(game)}>Gamecast ›</button></td>
-                </tr>;
-              })])}
-            </tbody>
-          </table>
-          {!visibleGames.length && <div className="schedule-no-games"><strong>No games scheduled</strong><span>The 2026 schedule has not been announced yet.</span></div>}
+          {gamesByDay.map((dayGames) => (
+            <section className="schedule-day" key={dayKey(dayGames[0])}>
+              <h2>{dayLabel(dayGames[0])}</h2>
+              <table className="schedule-table">
+                <thead><tr><th>Matchup</th><th>Time</th><th>TV</th><th>Location / Weather</th></tr></thead>
+                <tbody>{dayGames.map((game) => (
+                  <tr key={String(game.GameId)} onClick={() => onSelectGame(game)}>
+                    <td><div className="schedule-matchup">
+                      <span className="schedule-team"><img src={game.HomeLogo || "/favicon.svg"} alt="" /><b>{game.HomeName || game.Home}</b></span>
+                      <em>@</em>
+                      <span className="schedule-team"><img src={game.AwayLogo || "/favicon.svg"} alt="" /><b>{game.AwayName || game.Away}</b></span>
+                    </div></td>
+                    <td><strong className="kickoff-time">{kickoffTime(game)}</strong></td>
+                    <td>{game.Network || "TBD"}</td>
+                    <td><span className="schedule-location">{locationFor(game)}</span>{game.Weather && <small className="schedule-weather">{game.Weather}</small>}</td>
+                  </tr>
+                ))}</tbody>
+              </table>
+            </section>
+          ))}
+          {!visibleGames.length && <div className="schedule-no-games"><strong>No games scheduled</strong><span>No matchups have been announced for Week {displayedWeek ?? "—"}.</span></div>}
         </div>
       </section>
     </main>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -318,16 +318,24 @@
 .schedule-table th { padding: 11px 8px; color: #69717a; text-align: left; text-transform: uppercase; font-size: .66rem; letter-spacing: .05em; }
 .schedule-table td { padding: 13px 8px; border-top: 1px solid #e6e8eb; color: #606871; font-size: .8rem; }
 .schedule-table tbody tr:nth-child(even) { background: #f7f8f9; }
+.schedule-table tbody tr { cursor: pointer; }
+.schedule-table tbody tr:hover { background: #edf5fc; }
 .schedule-table .schedule-week-row { background: #eef1f4; }
 .schedule-table .schedule-week-row th { padding: 17px 10px 9px; border-bottom: 2px solid #cfd4da; color: #242b33; }
 .schedule-week-row th span { font-size: .9rem; font-weight: 900; }
 .schedule-week-row th small { margin-left: 12px; color: #7a838d; font-size: .62rem; font-weight: 700; }
 .schedule-matchup { display: flex; align-items: center; gap: 14px; color: #1e252d; }
 .schedule-matchup span { display: grid; min-width: 58px; }
+.schedule-matchup .schedule-team { grid-template-columns: 30px minmax(70px, auto); align-items: center; gap: 8px; color: #076dcc; }
+.schedule-team img { width: 26px; height: 26px; object-fit: contain; }
 .schedule-matchup small { color: #89919a; font-size: .6rem; text-transform: uppercase; }
 .schedule-matchup em { color: #9299a1; font-style: normal; }
 .kickoff-time, .schedule-game-link { color: #076dcc; }
 .schedule-game-link { padding: 0; border: 0; background: transparent; cursor: pointer; font-weight: 700; }
+.schedule-day + .schedule-day { margin-top: 30px; }
+.schedule-day h2 { margin: 0; padding: 0 0 10px; border-bottom: 1px solid #d7dbe0; font-size: 1rem; }
+.schedule-location, .schedule-weather { display: block; }
+.schedule-weather { margin-top: 3px; color: #7c858f; font-size: .68rem; }
 .game-result { white-space: nowrap; color: #076dcc; }
 .game-result b { display: inline-grid; place-items: center; width: 24px; height: 24px; margin-right: 7px; color: #fff; border-radius: 50%; font-size: .67rem; }
 .game-result.win b { background: #05884e; }

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -19,6 +19,9 @@ export type LeagueGame = {
   Kickoff?: string;
   Network?: string;
   Weather?: string;
+  Location?: string;
+  Stadium?: string;
+  Venue?: string;
   HomeLogo?: string;
   AwayLogo?: string;
   HomeName?: string;


### PR DESCRIPTION
### Motivation
- Improve the league schedules UI to match the requested layout: group each week by day and present a compact row with matchup, time, TV, and location/weather. 
- Remove ticket and odds columns and ensure schedule rows show home/away logos and readable location information.

### Description
- Replaced the schedules view with a week selector and per-week grouping that organizes games by full day headings and renders day-level sections in `apps/web/src/components/league/LeagueSchedules.tsx`.
- Simplified the schedule table to four columns: `Matchup`, `Time`, `TV`, and `Location / Weather`, and rendered home/away logos and team names in each matchup row.
- Added support for `Location`, `Stadium`, and `Venue` fields to the `LeagueGame` type in `apps/web/src/components/league/types.ts` and added fallback location logic to use team city/name when explicit venue data is missing.
- Updated styles in `apps/web/src/components/league/league.css` to add row hover/interaction, team logo sizing, day-section headings, and location/weather presentation.

### Testing
- Ran `npm run build` which completed successfully and produced the production build artifacts. 
- Ran `npm run lint` which completed; linting surfaced one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` but no new errors from the modified files. 
- Ran `git diff --check` and repository checks show the working tree clean with the modified files applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d5f0fec648324bfc7933e27439941)