### PR TITLE
Restyle the league navigation as a compact tab bar

### DIFF
--- a/apps/web/src/components/league/LeagueHeader.tsx
+++ b/apps/web/src/components/league/LeagueHeader.tsx
@@ -10,7 +10,6 @@ export function LeagueHeader({
 }) {
   return (
     <div className="league-header">
-      <div className="league-name">AFL League</div>
       <nav className="nav-tabs" aria-label="League tabs">
         {LEAGUE_TABS.map((tab) => (
           <button

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -59,45 +59,33 @@
   position: sticky;
   top: 88px;
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: var(--gray-medium);
-  border-bottom: 1px solid var(--gray-light);
-  padding: 1vw 2vw;
+  min-height: 49px;
+  overflow-x: auto;
+  background: #fff;
+  border-bottom: 1px solid #b8b8b8;
+  scrollbar-width: none;
 }
-.league-name {
-  font-weight: 700;
-  padding-bottom: 2vw;
-  text-align: center;
-  font-size: 4vw;
-  background: linear-gradient(
-    to right,
-    var(--accent-red-dark),
-    var(--accent-red)
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
+.league-header::-webkit-scrollbar { display: none; }
 .nav-tabs {
   display: flex;
-  gap: 1vw;
+  justify-content: flex-start;
+  width: max-content;
+  min-width: 100%;
 }
 .nav-tab {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  padding: 1vw 2vw;
+  flex: 0 0 auto;
+  height: 49px;
+  padding: 0 10px;
+  color: #111;
+  background: transparent;
+  border: 0;
+  border-bottom: 3px solid transparent;
   cursor: pointer;
-  font-size: clamp(14px, 3vw, 24px);
-  border-bottom: 0.6vw solid transparent;
-  height: 8vw;
+  font: 400 15px/1 Roboto, Arial, sans-serif;
 }
 .nav-tab.active {
-  color: var(--text-light);
-  border-bottom-color: var(--text-light);
-  font-weight: 700;
+  color: #111;
+  border-bottom-color: #e51b23;
 }
 .league-tab-content {
   display: none;

--- a/apps/web/src/components/league/leagueConstants.ts
+++ b/apps/web/src/components/league/leagueConstants.ts
@@ -1,12 +1,12 @@
 import type { LeagueTab } from "./types";
 
 export const LEAGUE_TABS: Array<{ id: LeagueTab; label: string }> = [
-  { id: "news", label: "NEWS" },
-  { id: "scores", label: "SCORES" },
-  { id: "schedules", label: "SCHEDULES" },
-  { id: "standings", label: "STANDINGS" },
-  { id: "stats", label: "STATS" },
-  { id: "draft", label: "DRAFT" },
+  { id: "news", label: "Home" },
+  { id: "scores", label: "Scores" },
+  { id: "schedules", label: "Schedule" },
+  { id: "standings", label: "Standings" },
+  { id: "stats", label: "Stats" },
+  { id: "draft", label: "Draft" },
 ];
 
 export const PLACEHOLDER_LOGOS = {


### PR DESCRIPTION
### Motivation
- Make the league header compact and align navigation controls to the left to match the provided reference design. 
- Remove the prominent league name so the header only presents the navigation tabs and occupies much less vertical space. 
- Preserve horizontal scrolling behavior so tabs remain accessible on narrow viewports. 

### Description
- Removed the league name element from the header so the component now renders only the nav tabs in `apps/web/src/components/league/LeagueHeader.tsx`. 
- Updated the tab labels to title case (for example `NEWS` -> `Home`, `SCORES` -> `Scores`) in `apps/web/src/components/league/leagueConstants.ts`. 
- Reworked header styles in `apps/web/src/components/league/league.css` to create a compact white tab bar with `min-height: 49px`, left-justified buttons, fixed tab height/padding, a red active-tab underline, hidden scrollbars, and preserved horizontal overflow for narrow screens. 

### Testing
- Ran a production build with `npm run build` and it completed successfully. 
- Ran the code linter with `npm run lint` and it reported no blocking issues. 
- Ran `git diff --check` which returned no whitespace or diff errors. 
- Performed a Playwright visual smoke check (900×700) which confirmed the header rendered around 50px tall and the tabs appeared left-aligned (visual capture produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d6336e1bc832485a5f187215bf75b)