### PR TITLE
Add runtime light/dark UI settings with Game Settings screen

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -192,6 +192,45 @@ async function getFrontendSettingsFromSheet() {
     sackLossTable: settingRows(rows, "SackLoss_").map((r) => ({ label: r[0], pct: Number(r[1]), max: Number(r[2]), min: Number(r[3]) })),
   };
 }
+
+const GAMEPLAY_SETTING_VALUES = {
+  Visual_Mode: ["Dark", "Light"],
+} as const;
+
+async function getGameplaySettingsFromSheet() {
+  const { headers, rows } = await sheetRows("GamePlaySettings");
+  const variableColumn = headers.findIndex((header) => normHeader(header) === "variable");
+  const valueColumn = headers.findIndex((header) => normHeader(header) === "value");
+  if (variableColumn === -1 || valueColumn === -1) {
+    throw new Error("GamePlaySettings must have Variable and Value columns.");
+  }
+
+  return Object.fromEntries(
+    rows
+      .map((row) => [String(cell(row, variableColumn)).trim(), String(cell(row, valueColumn)).trim()])
+      .filter(([variable]) => variable),
+  );
+}
+
+async function updateGameplaySetting(variable: string, value: string) {
+  const allowedValues = GAMEPLAY_SETTING_VALUES[variable as keyof typeof GAMEPLAY_SETTING_VALUES];
+  if (!allowedValues || !(allowedValues as readonly string[]).includes(value)) {
+    throw new Error(`Invalid GamePlaySettings value for '${variable}'.`);
+  }
+
+  const { headers, rows } = await sheetRows("GamePlaySettings");
+  const variableColumn = headers.findIndex((header) => normHeader(header) === "variable");
+  const valueColumn = headers.findIndex((header) => normHeader(header) === "value");
+  const rowIndex = rows.findIndex((row) => String(cell(row, variableColumn)).trim() === variable);
+  if (variableColumn === -1 || valueColumn === -1 || rowIndex === -1) {
+    throw new Error(`GamePlaySettings variable '${variable}' was not found.`);
+  }
+
+  await batchUpdateSheetValues([{
+    range: `GamePlaySettings!${columnToLetters(valueColumn + 1)}${rowIndex + 2}`,
+    values: [[value]],
+  }]);
+}
 async function getPlayerTraitsFromSheet() {
   const jerseys = await getTeamJerseys();
   const { headers, rows } = await sheetRows("Players"); const headerIndex: Record<string, number> = {};
@@ -412,6 +451,14 @@ gameRoutes.get("/games", async (_req, res, next) => { try { res.json({ games: aw
 gameRoutes.get("/games/:gameId/state", async (req, res, next) => { try { res.json({ gameState: await getGameState(req.params.gameId) }); } catch (e) { next(e); } });
 gameRoutes.get("/games/:gameId/play-history", async (req, res, next) => { try { res.json({ plays: await getPlayHistory(req.params.gameId) }); } catch (e) { next(e); } });
 gameRoutes.get("/frontend-settings", async (_req, res, next) => { try { res.json(await getFrontendSettingsFromSheet()); } catch (e) { next(e); } });
+gameRoutes.get("/gameplay-settings", async (_req, res, next) => { try { res.json({ settings: await getGameplaySettingsFromSheet() }); } catch (e) { next(e); } });
+gameRoutes.put("/gameplay-settings/:variable", async (req, res, next) => {
+  try {
+    const value = String(req.body?.value ?? "");
+    await updateGameplaySetting(req.params.variable, value);
+    res.json({ ok: true, variable: req.params.variable, value });
+  } catch (e) { next(e); }
+});
 gameRoutes.post("/games/:gameId/save-play-and-game", async (req, res, next) => { try { await savePlayAndGameWithRetry(req.body, req.params.gameId); res.json({ ok: true }); } catch (e) { next(e); } });
 
 // Legacy route retained for existing callers while LeagueApp uses save-play-and-game.

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -8,17 +8,41 @@
   --gray-light: #2c2c2c;
   --text-light: #f5f5f5;
   --text-muted: #b0b0b0;
+  --surface-canvas: #121212;
+  --surface-raised: #1e1e1e;
+  --surface-subtle: #2c2c2c;
+  --surface-overlay: rgba(15, 23, 42, 0.92);
+  --border-color: #3f3f46;
+  --text-primary: #f5f5f5;
+  --text-secondary: #b0b0b0;
+  --text-inverse: #ffffff;
+  --shadow-color: rgba(0, 0, 0, 0.38);
+  --page-gradient: linear-gradient(135deg, #121212 0%, #1e1e1e 100%);
+}
+
+:root[data-theme="light"] {
+  --gray-dark: #f4f6f8;
+  --gray-medium: #ffffff;
+  --gray-light: #e5e9ee;
+  --text-light: #18202a;
+  --text-muted: #5f6b78;
+  --surface-canvas: #f4f6f8;
+  --surface-raised: #ffffff;
+  --surface-subtle: #e5e9ee;
+  --surface-overlay: rgba(255, 255, 255, 0.94);
+  --border-color: #c9d1da;
+  --text-primary: #18202a;
+  --text-secondary: #5f6b78;
+  --text-inverse: #ffffff;
+  --shadow-color: rgba(20, 30, 45, 0.14);
+  --page-gradient: linear-gradient(135deg, #f7f9fb 0%, #e8edf2 100%);
 }
 
 body {
   margin: 0;
   min-height: 100vh;
   font-family: "Roboto", Arial, sans-serif;
-  background: linear-gradient(
-    135deg,
-    var(--gray-dark) 0%,
-    var(--gray-medium) 100%
-  );
+  background: var(--page-gradient);
   color: var(--text-light);
 }
 
@@ -92,7 +116,7 @@ body {
   grid-template-rows: 30% auto;
   gap: 2vw;
   align-items: flex-start;
-  color: #fff;
+  color: var(--text-primary);
   padding: 2vw;
 }
 
@@ -151,7 +175,7 @@ body {
 }
 
 .trait-bar-card {
-  background: #1e1e1e;
+  background: var(--surface-raised);
   padding: 0.5vw;
   border-radius: 6px;
 }
@@ -168,11 +192,72 @@ body {
 }
 
 .progress {
-  background: #333;
+  background: var(--surface-subtle);
   height: 10px;
   border-radius: 4px;
   overflow: hidden;
 }
+
+.settings-screen {
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: clamp(24px, 5vw, 72px);
+  color: var(--text-primary);
+  background: var(--page-gradient);
+}
+.settings-header { display: flex; align-items: center; gap: 20px; max-width: 1080px; margin: 0 auto 38px; }
+.settings-header h1 { margin: 2px 0 0; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.04em; }
+.settings-eyebrow { margin: 0; color: var(--accent-red); font-size: .75rem; font-weight: 800; letter-spacing: .18em; text-transform: uppercase; }
+.settings-back { width: 48px; height: 48px; border: 1px solid var(--border-color); border-radius: 50%; color: var(--text-primary); background: var(--surface-raised); cursor: pointer; font-size: 1.5rem; box-shadow: 0 8px 24px var(--shadow-color); }
+.settings-layout { display: grid; grid-template-columns: minmax(150px, 220px) 1fr; max-width: 1080px; margin: auto; border: 1px solid var(--border-color); border-radius: 16px; overflow: hidden; background: var(--surface-raised); box-shadow: 0 18px 55px var(--shadow-color); }
+.settings-tabs { padding: 18px; background: var(--surface-subtle); }
+.settings-tab { width: 100%; padding: 14px 16px; border: 0; border-left: 3px solid transparent; color: var(--text-secondary); background: transparent; cursor: pointer; text-align: left; font-weight: 700; }
+.settings-tab--active { border-left-color: var(--accent-red); color: var(--text-primary); background: var(--surface-raised); }
+.settings-panel { padding: clamp(24px, 4vw, 48px); }
+.setting-row { display: flex; align-items: center; justify-content: space-between; gap: 30px; padding-bottom: 30px; border-bottom: 1px solid var(--border-color); }
+.setting-row label { display: block; margin-bottom: 8px; font-size: 1.1rem; font-weight: 800; }
+.setting-row p, .settings-message { margin: 0; color: var(--text-secondary); }
+.setting-row select { min-width: 150px; padding: 11px 38px 11px 13px; border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-primary); background: var(--surface-canvas); cursor: pointer; }
+.settings-message { padding-top: 20px; }
+@media (max-width: 620px) {
+  .settings-layout { grid-template-columns: 1fr; }
+  .settings-tabs { padding: 10px; }
+  .setting-row { align-items: stretch; flex-direction: column; }
+}
+
+/* Theme-aware application chrome. Game markings and team colors stay semantic. */
+:root[data-theme="light"] .league-app {
+  --gray-dark: var(--surface-canvas);
+  --gray-medium: var(--surface-raised);
+  --gray-light: var(--surface-subtle);
+  --text-light: var(--text-primary);
+  --text-muted: var(--text-secondary);
+  --text-link: #075eb8;
+}
+:root[data-theme="light"] .games-banner,
+:root[data-theme="light"] .league-header { color: var(--text-primary); background: var(--surface-raised); border-color: var(--border-color); }
+:root[data-theme="light"] .games-banner__picker select,
+:root[data-theme="light"] .nav-tab,
+:root[data-theme="light"] .nav-tab.active { color: var(--text-primary); }
+:root[data-theme="light"] .scores-screen,
+:root[data-theme="light"] .team-detail,
+:root[data-theme="light"] .league-schedules { color: var(--text-primary); background: var(--surface-canvas); }
+:root[data-theme="light"] .score-card,
+:root[data-theme="light"] .schedule-card,
+:root[data-theme="light"] .standings-table,
+:root[data-theme="light"] .game-log,
+:root[data-theme="light"] .game-controls { color: var(--text-primary); background: var(--surface-raised); border-color: var(--border-color); box-shadow: 0 8px 22px var(--shadow-color); }
+:root[data-theme="light"] .game-field-toggle,
+:root[data-theme="light"] .play-caller,
+:root[data-theme="light"] .game-scoreboard { color: var(--text-primary); background: var(--surface-overlay); border-color: var(--border-color); }
+:root[data-theme="light"] .player-table th,
+:root[data-theme="light"] .player-table td { border-color: var(--border-color); }
+
+/* Keep the stadium artwork readable while making its menu chrome follow the selected mode. */
+:root[data-theme="light"] .main-menu-screen::before { content: ""; position: absolute; inset: 0; z-index: 1; background: rgba(255,255,255,.34); pointer-events: none; }
+:root[data-theme="light"] .main-menu-screen .panel { background: rgba(255,255,255,.78); color: #18202a; border-color: rgba(24,32,42,.22); }
+:root[data-theme="light"] .main-menu-screen .menu-button { color: #18202a; background: linear-gradient(135deg, rgba(193,2,6,.16), rgba(255,255,255,.82)); }
+:root[data-theme="light"] .main-menu-screen .brand { color: #fff; }
 
 .progress-bar {
   height: 100%;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,33 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { getGameplaySettings, type VisualMode } from "./api/client";
+import { GameSettingsScreen } from "./components/settings/GameSettingsScreen";
 import { MainMenuScreen } from "./components/mainMenu/MainMenuScreen";
 import { PlayersScreen } from "./components/players/PlayersScreen";
 import { LeagueAppScreen } from "./components/league/LeagueAppScreen";
 import "./App.css";
 
-export type Screen = "mainMenu" | "players" | "league";
+export type Screen = "mainMenu" | "players" | "league" | "settings";
 
 function App() {
   const [screen, setScreen] = useState<Screen>("mainMenu");
+  const [visualMode, setVisualMode] = useState<VisualMode>("Dark");
+
+  useEffect(() => {
+    let active = true;
+    getGameplaySettings()
+      .then(({ settings }) => {
+        if (active && (settings.Visual_Mode === "Dark" || settings.Visual_Mode === "Light")) {
+          setVisualMode(settings.Visual_Mode);
+        }
+      })
+      .catch(() => undefined);
+    return () => { active = false; };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = visualMode.toLowerCase();
+    document.documentElement.style.colorScheme = visualMode.toLowerCase();
+  }, [visualMode]);
 
   return (
     <main className="app">
@@ -21,6 +41,13 @@ function App() {
       )}
       {screen === "league" && (
         <LeagueAppScreen onBack={() => setScreen("mainMenu")} />
+      )}
+      {screen === "settings" && (
+        <GameSettingsScreen
+          visualMode={visualMode}
+          onVisualModeChange={setVisualMode}
+          onBack={() => setScreen("mainMenu")}
+        />
       )}
     </main>
   );

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -21,6 +21,15 @@ async function postJson<T>(
   if (!response.ok) throw new Error(message);
   return response.json();
 }
+async function putJson<T>(path: string, body: unknown, message: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(message);
+  return response.json();
+}
 export async function getApiHealth(): Promise<ApiHealth> {
   return getJson("/health", "Failed to reach backend API");
 }
@@ -116,4 +125,18 @@ export async function getPlayerTraits(): Promise<{
 }
 export async function getFrontendSettings(): Promise<Record<string, unknown>> {
   return getJson("/frontend-settings", "Failed to load frontend settings");
+}
+export type VisualMode = "Dark" | "Light";
+export type GameplaySettings = Record<string, string> & { Visual_Mode?: VisualMode };
+
+export async function getGameplaySettings(): Promise<{ settings: GameplaySettings }> {
+  return getJson("/gameplay-settings", "Failed to load game settings");
+}
+
+export async function updateGameplaySetting(variable: "Visual_Mode", value: VisualMode) {
+  return putJson<{ ok: boolean; variable: string; value: string }>(
+    `/gameplay-settings/${encodeURIComponent(variable)}`,
+    { value },
+    "Failed to save game settings",
+  );
 }

--- a/apps/web/src/components/mainMenu/MainMenuScreen.tsx
+++ b/apps/web/src/components/mainMenu/MainMenuScreen.tsx
@@ -16,6 +16,7 @@ const menuItems: MainMenuItem[] = [
     placeholderMessage:
       "New League coming soon! TODO: port the old league creation flow when its backend/API behavior is available.",
   },
+  { label: "Game Settings", screen: "settings" },
 ];
 
 type MainMenuScreenProps = {

--- a/apps/web/src/components/settings/GameSettingsScreen.tsx
+++ b/apps/web/src/components/settings/GameSettingsScreen.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { updateGameplaySetting, type VisualMode } from "../../api/client";
+
+type GameSettingsScreenProps = {
+  visualMode: VisualMode;
+  onVisualModeChange: (mode: VisualMode) => void;
+  onBack: () => void;
+};
+
+export function GameSettingsScreen({ visualMode, onVisualModeChange, onBack }: GameSettingsScreenProps) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const changeVisualMode = async (nextMode: VisualMode) => {
+    const previousMode = visualMode;
+    onVisualModeChange(nextMode);
+    setIsSaving(true);
+    setMessage(null);
+    try {
+      await updateGameplaySetting("Visual_Mode", nextMode);
+      setMessage("UI mode saved.");
+    } catch {
+      onVisualModeChange(previousMode);
+      setMessage("Could not save UI mode. Your previous mode was restored.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="settings-screen" aria-labelledby="settings-title">
+      <header className="settings-header">
+        <button className="settings-back" type="button" onClick={onBack} aria-label="Back to main menu">←</button>
+        <div>
+          <p className="settings-eyebrow">Animal Football</p>
+          <h1 id="settings-title">Game Settings</h1>
+        </div>
+      </header>
+      <div className="settings-layout">
+        <nav className="settings-tabs" aria-label="Settings sections">
+          <button className="settings-tab settings-tab--active" type="button" aria-current="page">Visual</button>
+        </nav>
+        <div className="settings-panel">
+          <div className="setting-row">
+            <div>
+              <label htmlFor="visual-mode">UI Mode</label>
+              <p>Choose the color theme used throughout the game.</p>
+            </div>
+            <select
+              id="visual-mode"
+              value={visualMode}
+              disabled={isSaving}
+              onChange={(event) => void changeVisualMode(event.target.value as VisualMode)}
+            >
+              <option value="Dark">Dark</option>
+              <option value="Light">Light</option>
+            </select>
+          </div>
+          {message && <p className="settings-message" role="status">{message}</p>}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a single runtime-controlled Visual Mode so the entire UI can switch between Dark and Light themes consistently. 
- Store and persist the selected mode in the `GamePlaySettings` sheet so settings can be read and updated by backend and frontend. 
- Expose a simple in-app control so users can pick the UI mode immediately and extend settings later. 

### Description

- Backend: added `getGameplaySettingsFromSheet` and `updateGameplaySetting` helpers plus validated endpoints `GET /api/gameplay-settings` and `PUT /api/gameplay-settings/:variable` that read and write the `GamePlaySettings` sheet and validate allowed values via `GAMEPLAY_SETTING_VALUES`. 
- Frontend API: added `getGameplaySettings` and `updateGameplaySetting` in `apps/web/src/api/client.ts` and a small `putJson` helper for PUT calls. 
- UI: added a fourth main-menu item `Game Settings` and a new `GameSettingsScreen` component with a `Visual` tab and a `UI Mode` dropdown that optimistically applies `Dark`/`Light`, persists via the new API, and rolls back on failure while showing a status message. 
- The application root now loads the persisted visual mode at startup in `App.tsx`, applies it immediately by setting `document.documentElement.dataset.theme` and `document.documentElement.style.colorScheme`, and exposes a `visualMode` state to drive theme changes. 
- Styling: centralized theme tokens in `apps/web/src/App.css` (semantic CSS custom properties for surfaces, borders, text, overlay, shadows, and gradients) and added `:root[data-theme="light"]` overrides so the whole UI flips consistently; a responsive settings layout was also added. 

### Testing

- Built the frontend with `cd apps/web && npm run build` which succeeded and produced `dist/` assets. 
- Ran frontend lint with `cd apps/web && npm run lint` which completed with one existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`. 
- Ran backend tests with `cd apps/api && npm test` which passed all suites. 
- Ran TypeScript checks with `cd apps/api && npm run typecheck` which succeeded and reported no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d64ade49083249ca21916601992a0)