### PR TITLE
Make league banner navigation interactive

### DIFF
--- a/apps/web/src/components/league/GamesBanner.tsx
+++ b/apps/web/src/components/league/GamesBanner.tsx
@@ -6,13 +6,26 @@ const WEEKS = [1, 2, 3, 4, 5];
 const gameWeek = (game: LeagueGame, index: number) =>
   Number(game.Week ?? (index % WEEKS.length) + 1);
 
-export function GamesBanner({ games }: { games: LeagueGame[] }) {
+type GamesBannerProps = {
+  games: LeagueGame[];
+  onHome: () => void;
+  onSelectGame: (game: LeagueGame) => void;
+};
+
+export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
   const [week, setWeek] = useState(1);
   const weekGames = games.filter((game, index) => gameWeek(game, index) === week);
 
   return (
     <aside className="games-banner" aria-label="Games this week">
-      <div className="games-banner__brand">AFL</div>
+      <button
+        className="games-banner__brand"
+        type="button"
+        onClick={onHome}
+        aria-label="Return to the AFL league home"
+      >
+        AFL
+      </button>
       <label className="games-banner__picker">
         <span>Week</span>
         <select value={week} onChange={(event) => setWeek(Number(event.target.value))}>
@@ -20,13 +33,36 @@ export function GamesBanner({ games }: { games: LeagueGame[] }) {
         </select>
       </label>
       <div className="games-banner__rail">
-        {weekGames.length ? weekGames.map((game) => (
-          <article className="banner-game" key={String(game.GameId)}>
-            <div className="banner-game__meta">{game.Kickoff || "TBD"} <span>{game.Network || "AFL Network"}</span></div>
-            <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /> <strong>{game.Away}</strong><b>0-0</b></div>
-            <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /> <strong>{game.Home}</strong><b>0-0</b></div>
-          </article>
-        )) : <p className="games-banner__empty">Week {week} matchups are coming soon</p>}
+        {weekGames.length ? (
+          weekGames.map((game) => (
+            <button
+              className="banner-game"
+              type="button"
+              key={String(game.GameId)}
+              onClick={() => onSelectGame(game)}
+              aria-label={`Open gamecast for ${game.Away} at ${game.Home}`}
+            >
+              <div className="banner-game__meta">
+                {game.Kickoff || "TBD"}{" "}
+                <span>{game.Network || "AFL Network"}</span>
+              </div>
+              <div>
+                <img src={game.AwayLogo || "/favicon.svg"} alt="" />
+                <strong>{game.Away}</strong>
+                <b>0-0</b>
+              </div>
+              <div>
+                <img src={game.HomeLogo || "/favicon.svg"} alt="" />
+                <strong>{game.Home}</strong>
+                <b>0-0</b>
+              </div>
+            </button>
+          ))
+        ) : (
+          <p className="games-banner__empty">
+            Week {week} matchups are coming soon
+          </p>
+        )}
       </div>
       <div className="games-banner__all">Full Scoreboard <span aria-hidden="true">›</span></div>
     </aside>

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -87,17 +87,37 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
     setIsExitingGameLoad(false);
   };
 
+  const returnToLeagueHome = () => {
+    if (gameLoadTimeout.current !== null) {
+      window.clearTimeout(gameLoadTimeout.current);
+      gameLoadTimeout.current = null;
+    }
+    setSelectedGame(null);
+    setSelectedTeam(null);
+    setLoadingGame(null);
+    setIsExitingGameLoad(false);
+    setActiveTab("scores");
+  };
+
   if (selectedGame)
     return (
       <section className="league-app">
-        <GamesBanner games={games} />
+        <GamesBanner
+          games={games}
+          onHome={returnToLeagueHome}
+          onSelectGame={openGame}
+        />
         <GameCenter game={selectedGame} onBack={() => setSelectedGame(null)} />
       </section>
     );
   if (selectedTeam)
     return (
       <section className="league-app">
-        <GamesBanner games={games} />
+        <GamesBanner
+          games={games}
+          onHome={returnToLeagueHome}
+          onSelectGame={openGame}
+        />
         <TeamDetail team={selectedTeam} standings={standings} games={games} onBack={() => setSelectedTeam(null)} onGame={openGame} />
       </section>
     );
@@ -158,7 +178,11 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
               ← Back
             </button>
           )}
-          <GamesBanner games={games} />
+          <GamesBanner
+            games={games}
+            onHome={returnToLeagueHome}
+            onSelectGame={openGame}
+          />
           <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
           <div id="tabContents">
             {activeTab === "news" && (

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -41,12 +41,17 @@
   background: linear-gradient(125deg, #99000b 0 70%, #c10206 70%);
   font: italic 900 1.55rem/1 Arial, sans-serif;
   letter-spacing: .08em;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
 }
+.games-banner__brand:hover, .games-banner__brand:focus-visible { filter: brightness(1.15); }
 .games-banner__picker { display: grid; align-content: center; gap: 4px; flex: 0 0 135px; padding: 10px 18px; border-right: 1px solid var(--gray-light); }
 .games-banner__picker span { color: var(--text-muted); font-size: .64rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
 .games-banner__picker select { border: 0; background: transparent; color: var(--text-light); font-weight: 800; cursor: pointer; outline-offset: 4px; }
 .games-banner__rail { display: flex; flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
-.banner-game { flex: 0 0 210px; padding: 10px 16px; border-right: 1px solid var(--gray-light); }
+.banner-game { flex: 0 0 210px; padding: 10px 16px; border: 0; border-right: 1px solid var(--gray-light); background: transparent; color: inherit; text-align: left; font: inherit; cursor: pointer; }
+.banner-game:hover, .banner-game:focus-visible { background: color-mix(in srgb, var(--accent-red) 9%, transparent); }
 .banner-game__meta { display: flex; justify-content: space-between; margin-bottom: 6px; font-size: .68rem; font-weight: 800; }
 .banner-game__meta span { color: var(--text-muted); font-weight: 500; }
 .banner-game > div:not(.banner-game__meta) { display: grid; grid-template-columns: 20px 1fr auto; gap: 7px; align-items: center; min-height: 24px; font-size: .75rem; }


### PR DESCRIPTION
### Motivation
- Allow users to always return to the main league screen by clicking the AFL brand in the top banner and to open any gamecast by clicking a matchup in the banner. 
- Provide keyboard-accessible semantics and visual states for the banner so the controls are accessible from anywhere in the app.

### Description
- Added `GamesBanner` props `onHome` and `onSelectGame` and converted the AFL brand into a clickable `button` that calls `onHome`.
- Changed each matchup item from a static `article` into a focusable `button` that calls `onSelectGame(game)` and includes `aria-label` text for screen readers.
- Added a `returnToLeagueHome` handler in `LeagueAppScreen` that clears any pending `gameLoadTimeout`, resets `selectedGame`, `selectedTeam`, `loadingGame`, and `isExitingGameLoad`, and sets the active tab to `scores`.
- Wired the new `GamesBanner` handlers into the gamecast, team-detail, and main league views and added hover/focus/pointer styles in `league.css` for the interactive controls.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm run lint`, which completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d6a67af948324a3f42cae53d2c14b)