### PR TITLE
Scores UI: show possession, mm:ss clock, replace kickoff/date, and update banner + live refresh

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1367,9 +1367,11 @@ function ScoreChart({ game, history }: { game: LeagueGame; history: Play[] }) {
 export function GameCenter({
   game,
   onBack,
+  onGameUpdate,
 }: {
   game: LeagueGame;
   onBack: () => void;
+  onGameUpdate?: (game: LeagueGame) => void;
 }) {
   const [tab, setTab] = useState<GameTab>("gamecast");
   const [currentGame, setCurrentGame] = useState(game);
@@ -1518,6 +1520,7 @@ export function GameCenter({
       // Preserve the pre-snap situation while the play runs. This state change
       // advances the markers and resets the formation only after animation.
       setCurrentGame(result.game);
+      onGameUpdate?.(result.game);
       setHistory((h) => [...h, result.play]);
       setLog((l) => [result.text, ...l]);
     } catch (error) {

--- a/apps/web/src/components/league/GamesBanner.tsx
+++ b/apps/web/src/components/league/GamesBanner.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { LeagueGame } from "./types";
+import { formatBallOnForPoss, formatClock, formatDownDistance } from "./leagueMappers";
 
 const WEEKS = [1, 2, 3, 4, 5];
 
@@ -34,7 +35,10 @@ export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
       </label>
       <div className="games-banner__rail">
         {weekGames.length ? (
-          weekGames.map((game) => (
+          weekGames.map((game) => {
+            const final = String(game.Qtr).toUpperCase() === "FINAL";
+            const possession = String(game.Possession).toLowerCase();
+            return (
             <button
               className="banner-game"
               type="button"
@@ -43,21 +47,21 @@ export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
               aria-label={`Open gamecast for ${game.Away} at ${game.Home}`}
             >
               <div className="banner-game__meta">
-                {game.Kickoff || "TBD"}{" "}
-                <span>{game.Network || "AFL Network"}</span>
+                <span>{final ? "FINAL" : `Q${game.Qtr} · ${formatClock(game.Time)}`}</span>
+                {!final && <span>{formatDownDistance(game.Down, game.Distance)} · Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span>}
               </div>
               <div>
                 <img src={game.AwayLogo || "/favicon.svg"} alt="" />
-                <strong>{game.Away}</strong>
-                <b>0-0</b>
+                <strong>{game.Away} {possession === "away" && <i aria-label="Possession">🏈</i>}</strong>
+                <b>{game.AwayScore}</b>
               </div>
               <div>
                 <img src={game.HomeLogo || "/favicon.svg"} alt="" />
-                <strong>{game.Home}</strong>
-                <b>0-0</b>
+                <strong>{game.Home} {possession === "home" && <i aria-label="Possession">🏈</i>}</strong>
+                <b>{game.HomeScore}</b>
               </div>
             </button>
-          ))
+          );})
         ) : (
           <p className="games-banner__empty">
             Week {week} matchups are coming soon

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -27,6 +27,13 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
   const [isExitingGameLoad, setIsExitingGameLoad] = useState(false);
   const gameLoadTimeout = useRef<number | null>(null);
+  const refreshGames = () =>
+    getGames().then((response) => {
+      setGames((current) => normalizeGames(response.games, teams.length ? teams : mockTeams).map((game) => ({
+        ...current.find((item) => String(item.GameId) === String(game.GameId)),
+        ...game,
+      })));
+    });
   useEffect(() => {
     Promise.all([getGames(), getStandings(), getTeams()])
       .then(([gamesResponse, standingsResponse, teamsResponse]) => {
@@ -97,6 +104,18 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
     setLoadingGame(null);
     setIsExitingGameLoad(false);
     setActiveTab("scores");
+    void refreshGames().catch(() => undefined);
+  };
+
+  const updateLiveGame = (updatedGame: LeagueGame) => {
+    setGames((current) => current.map((item) =>
+      String(item.GameId) === String(updatedGame.GameId) ? { ...item, ...updatedGame } : item,
+    ));
+  };
+
+  const closeGame = () => {
+    setSelectedGame(null);
+    void refreshGames().catch(() => undefined);
   };
 
   if (selectedGame)
@@ -107,7 +126,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
           onHome={returnToLeagueHome}
           onSelectGame={openGame}
         />
-        <GameCenter game={selectedGame} onBack={() => setSelectedGame(null)} />
+        <GameCenter game={selectedGame} onBack={closeGame} onGameUpdate={updateLiveGame} />
       </section>
     );
   if (selectedTeam)

--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -1,22 +1,11 @@
 import { useMemo, useState } from "react";
 import type { LeagueGame } from "./types";
+import { formatBallOnForPoss, formatClock, formatDownDistance } from "./leagueMappers";
 
 const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
 
 const gameWeek = (game: LeagueGame, index: number) =>
   Number(game.Week ?? (index % WEEKS.length) + 1);
-
-function kickoffParts(game: LeagueGame) {
-  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
-  const parsed = new Date(raw);
-  if (!raw || Number.isNaN(parsed.getTime())) {
-    return { date: game.Date || `Week ${game.Week || "—"}`, time: raw || "Time TBD" };
-  }
-  return {
-    date: new Intl.DateTimeFormat("en-US", { weekday: "long", month: "long", day: "numeric" }).format(parsed),
-    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
-  };
-}
 
 export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; onSelectGame: (game: LeagueGame) => void }) {
   const [activeWeek, setActiveWeek] = useState(1);
@@ -50,16 +39,20 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
       <section className="week-scoreboard">
         <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>{finalGames ? "Scores & Results" : "Upcoming Games"}</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
         {weekGames.length ? weekGames.map((game) => {
-          const kickoff = kickoffParts(game);
           const final = String(game.Qtr).toUpperCase() === "FINAL";
+          const possession = String(game.Possession).toLowerCase();
           return (
           <article className="schedule-game" key={String(game.GameId)}>
-            <div className="schedule-game__date"><strong>{kickoff.date}</strong><span>{kickoff.time} · {game.Network || "Network TBD"}</span>{game.Weather && <small>{game.Weather}</small>}</div>
             <div className="schedule-game__teams">
-              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
-              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
+              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away} {possession === "away" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
+              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home} {possession === "home" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
             </div>
-            <div className="schedule-game__action"><span>{final ? "FINAL" : `Q${game.Qtr} · ${game.Time}`}</span><button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button></div>
+            <div className="schedule-game__action">
+              <div className="schedule-game__situation">
+                {final ? <strong>FINAL</strong> : <><strong>{formatDownDistance(game.Down, game.Distance)}</strong><span>Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span><small>Q{game.Qtr} · {formatClock(game.Time)}</small></>}
+              </div>
+              <button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button>
+            </div>
           </article>
         );}) : <div className="schedule-empty"><strong>No games scheduled yet</strong><span>Check back for the Week {activeWeek} matchup announcement.</span></div>}
       </section>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -56,7 +56,8 @@
 .banner-game__meta span { color: var(--text-muted); font-weight: 500; }
 .banner-game > div:not(.banner-game__meta) { display: grid; grid-template-columns: 20px 1fr auto; gap: 7px; align-items: center; min-height: 24px; font-size: .75rem; }
 .banner-game img { width: 18px; height: 18px; object-fit: contain; }
-.banner-game b { font-size: .68rem; }
+.banner-game b { font-size: .78rem; }
+.banner-game strong i { margin-left: 3px; font-size: .68rem; font-style: normal; }
 .games-banner__empty { margin: auto 24px; color: var(--text-muted); font-size: .8rem; }
 .games-banner__all { display: grid; place-items: center; grid-auto-flow: column; gap: 14px; flex: 0 0 145px; padding: 12px; color: var(--text-muted); border-left: 1px solid var(--gray-light); font-size: .74rem; }
 .games-banner__all span { color: var(--accent-red); font-size: 1.7rem; }
@@ -270,22 +271,21 @@
 .week-scoreboard__title { display: flex; justify-content: space-between; align-items: center; padding: 22px 26px; border-bottom: 1px solid var(--gray-light); }
 .week-scoreboard__title span { color: var(--text-muted); font-size: .66rem; font-weight: 800; letter-spacing: .12em; }
 .week-scoreboard__title h2 { margin: 3px 0 0; font-size: 1.25rem; }
-.schedule-game { display: grid; grid-template-columns: minmax(190px, .85fr) minmax(300px, 1.5fr) 160px; min-height: 176px; border-bottom: 1px solid var(--gray-light); }
+.schedule-game { display: grid; grid-template-columns: minmax(300px, 1fr) 210px; min-height: 176px; border-bottom: 1px solid var(--gray-light); }
 .schedule-game:last-child { border-bottom: 0; }
-.schedule-game__date, .schedule-game__action { display: flex; flex-direction: column; justify-content: center; padding: 24px 26px; }
-.schedule-game__date { border-right: 1px solid var(--gray-light); }
-.schedule-game__date strong { margin-bottom: 8px; font-size: .88rem; }
-.schedule-game__date span { color: var(--text-muted); font-size: .72rem; }
-.schedule-game__date small { margin-top: 9px; color: var(--text-muted); font-size: .66rem; }
-.schedule-game__teams { display: grid; align-content: center; padding: 18px 34px; }
+.schedule-game__action { display: flex; flex-direction: column; justify-content: center; padding: 24px 26px; }
+.schedule-game__teams { display: grid; align-content: center; padding: 18px 46px; }
 .schedule-game__teams > div { display: grid; grid-template-columns: 42px 1fr auto; align-items: center; gap: 16px; min-height: 64px; }
 .schedule-game__teams img { width: 38px; height: 38px; object-fit: contain; }
 .schedule-game__teams span { display: grid; gap: 3px; }
 .schedule-game__teams strong { font-size: 1.05rem; }
+.possession-football { margin-left: 5px; font-size: .9rem; font-style: normal; }
 .schedule-game__teams small { color: var(--text-muted); font-size: .65rem; letter-spacing: .06em; }
 .schedule-game__teams b { font-size: 1.55rem; }
 .schedule-game__action { align-items: stretch; gap: 13px; border-left: 1px solid var(--gray-light); }
-.schedule-game__action > span { color: var(--text-muted); text-align: center; font-size: .62rem; font-weight: 800; letter-spacing: .12em; }
+.schedule-game__situation { display: grid; gap: 5px; text-align: center; }
+.schedule-game__situation strong { font-size: .85rem; text-transform: uppercase; }
+.schedule-game__situation span, .schedule-game__situation small { color: var(--text-muted); font-size: .68rem; }
 .schedule-game__action button { display: flex; justify-content: space-between; padding: 11px 14px; color: #fff; border: 1px solid var(--border-color); border-radius: 3px; background: transparent; cursor: pointer; font-size: .74rem; font-weight: 700; }
 .schedule-game__action button:hover { border-color: #e84b50; background: #c102061f; }
 .schedule-game__action button b { color: #e84b50; }
@@ -367,7 +367,6 @@
   .league-header { top: 76px; }
   .scores-heading { align-items: start; flex-direction: column; gap: 10px; }
   .schedule-game { grid-template-columns: 1fr 105px; }
-  .schedule-game__date { grid-column: 1 / -1; padding: 15px 20px; border-right: 0; border-bottom: 1px solid #292e35; }
   .schedule-game__teams { padding: 12px 18px; }
   .schedule-game__action { padding: 16px 12px; }
   .schedule-center { padding: 14px; }


### PR DESCRIPTION
### Motivation
- Surface current possession next to the possessing team and make the clock show minutes:seconds for clarity during live games.  
- Replace kickoff/date footprint with a compact scores layout that pushes teams/scores left and moves situation (down/distance, ball-on, quarter/clock) to the right.  
- Keep the Games banner consistent with live game status and ensure the home scoreboard updates when returning to the home screen or when a scoring play is recorded.

### Description
- LeagueSchedule: removed the kickoff/date rendering and replaced the schedule row layout so team blocks are left-aligned and the right column shows the play situation (down/distance, ball-on, quarter and clock formatted as mm:ss); added a football possession indicator next to the possessing team and imported `formatBallOnForPoss`, `formatClock`, and `formatDownDistance` from `leagueMappers`.  
- GamesBanner: show live status in the banner meta (FINAL or `Q{n} · mm:ss`) and display down/distance · ball-on when available; render possession icon next to the possessing team and show live scores instead of placeholders.  
- LeagueAppScreen: added `refreshGames`, `updateLiveGame`, and `closeGame` helpers and wired `returnToLeagueHome` to refresh games; pass `onGameUpdate` and a new `onBack` handler into `GameCenter` so the home list receives live updates.  
- GameCenter: accept optional `onGameUpdate` prop and invoke it when persisting a play so the schedule/banner state updates after scoring or possession changes.  
- league.css: adjusted `.schedule-game` grid, team/score positioning, possession icon styles, and added a `.schedule-game__situation` block for the right column.  
- Removed the `kickoffParts` helper usage from the schedule UI to avoid showing date/time in the scores view.  
- Small imports/formatter usages were added across components to reuse `leagueMappers` helpers for clock and formatting.

### Testing
- ✅ `npm run build` in `apps/web` (Vite production build completed).  
- ✅ `npm run lint` (ESLint ran; there is 1 warning in `GameField.tsx` about hook dependencies).  
- ⚠️ Headless screenshot: I attempted a Playwright screenshot of the updated scores tab; system browser dependencies were required and I installed them before running the screenshot, after which a screenshot was produced at `/tmp/scores-tab.png` (environment required installing browser packages, hence the warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d6cc1bf088324a629e82900b9e75c)