### PR TITLE
Add complete rushing and tackling leader views

### DIFF
--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -5,8 +5,10 @@ import type { Player } from "../players/types";
 import type { LeagueTeam } from "./types";
 
 type StatsView = "Player" | "Team";
+type CompleteView = "rushing" | "tackling" | null;
 type Leader = { name: string; detail?: string; image?: string; player?: Player; value: number };
 type Category = { title: string; label: string; fields: string[]; positions?: string[] };
+type StatColumn = { label: string; fields: string[] };
 
 const OFFENSE: Category[] = [
   { title: "PASSING", label: "YDS", fields: ["Passing Yards", "Pass Yards", "PassYards"], positions: ["QB"] },
@@ -19,6 +21,15 @@ const DEFENSE: Category[] = [
   { title: "INTERCEPTIONS", label: "INT", fields: ["Interceptions", "INT"] },
 ];
 const RUSHING_COLUMNS = ["Carries", "Yards", "TD", "Fum", "Fum Lost", "First Down", "Juke", "BrokenTackle", "Avg", "Loss", "5+", "10+", "20+", "30+", "50+", "Long"] as const;
+const DEFENSIVE_COLUMNS: StatColumn[] = [
+  { label: "Tackles", fields: ["Tackles", "Total Tackles", "TOT"] },
+  { label: "TFL", fields: ["TFL", "Tackles For Loss", "TacklesForLoss"] },
+  { label: "FF", fields: ["FF", "Forced Fumbles", "ForcedFumbles"] },
+  { label: "Sacks", fields: ["Sacks", "Sack"] },
+  { label: "FR", fields: ["FR", "Fumble Recoveries", "FumbleRecoveries"] },
+  { label: "INT", fields: ["INT", "Interceptions"] },
+  { label: "Defl", fields: ["Defl", "Deflections", "Passes Defended", "PassDeflections"] },
+];
 
 const normalized = (value: unknown) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]/g, "");
 const number = (value: unknown) => Number(String(value ?? 0).replace(/,/g, "")) || 0;
@@ -26,6 +37,10 @@ function statValue(row: PlayerStats, fields: string[]) {
   const wanted = new Set(fields.map(normalized));
   const match = Object.entries(row).find(([field]) => wanted.has(normalized(field)));
   return number(match?.[1]);
+}
+function displayStat(row: PlayerStats, fields: readonly string[]) {
+  const wanted = new Set(fields.map(normalized));
+  return String(Object.entries(row).find(([field]) => wanted.has(normalized(field)))?.[1] || "0");
 }
 function teamName(team: LeagueTeam) { return String(team.Name || team.Team || team.Nickname || team.Abbrev || "Team"); }
 
@@ -48,7 +63,7 @@ export function LeagueStats({ teams }: { teams: LeagueTeam[] }) {
   const [players, setPlayers] = useState<Player[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showAllRushers, setShowAllRushers] = useState(false);
+  const [completeView, setCompleteView] = useState<CompleteView>(null);
   const [filter, setFilter] = useState("");
 
   useEffect(() => { Promise.all([getPlayerStats(), getPlayers()]).then(([statsResult, playersResult]) => { setStats(statsResult.playerStats); setPlayers(playersResult.players); }).catch((reason: unknown) => setError(reason instanceof Error ? reason.message : "Unable to load statistics")).finally(() => setLoading(false)); }, []);
@@ -62,12 +77,15 @@ export function LeagueStats({ teams }: { teams: LeagueTeam[] }) {
     return [...totals].filter(([, value]) => value > 0).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([key, value]) => { const team = teamByKey.get(key); return { name: team ? teamName(team) : players.find((player) => normalized(player.Team) === key)?.Team || key.toUpperCase(), image: String(team?.Logo || ""), value }; });
   };
   const allRushers = stats.filter((row) => number(row.Carries) > 0 && (!filter || normalized(row.Player).includes(normalized(filter)))).sort((a, b) => number(b.Yards) - number(a.Yards));
+  const allTacklers = stats.filter((row) => statValue(row, DEFENSIVE_COLUMNS[0].fields) >= 1 && (!filter || normalized(row.Player).includes(normalized(filter)))).sort((a, b) => statValue(b, DEFENSIVE_COLUMNS[0].fields) - statValue(a, DEFENSIVE_COLUMNS[0].fields));
+  const completeRows = completeView === "rushing" ? allRushers : allTacklers;
+  const completeColumns: StatColumn[] = completeView === "rushing" ? RUSHING_COLUMNS.map((label) => ({ label, fields: [label] })) : DEFENSIVE_COLUMNS;
 
   return <main className="league-stats-card">
     <header className="league-stats-heading"><div><span>LEAGUE STATISTICS</span><h1>AFL Stat Leaders</h1></div><button type="button" onClick={() => setActiveView(activeView === "Player" ? "Team" : "Player")}>{activeView === "Player" ? "Team Statistics" : "Player Statistics"}⌄</button></header>
-    <div className="stats-tabs" role="tablist">{(["Player", "Team"] as StatsView[]).map((view) => <button className={`stats-tab ${activeView === view ? "active" : ""}`} key={view} type="button" onClick={() => { setActiveView(view); setShowAllRushers(false); }}>{view}</button>)}</div>
+    <div className="stats-tabs" role="tablist">{(["Player", "Team"] as StatsView[]).map((view) => <button className={`stats-tab ${activeView === view ? "active" : ""}`} key={view} type="button" onClick={() => { setActiveView(view); setCompleteView(null); }}>{view}</button>)}</div>
     <div className="season-row"><button className="season-pill" type="button">Season 1 Regular Season⌄</button></div>
-    {showAllRushers ? <section className="complete-rushing-leaders"><div className="complete-leaders-tools"><button type="button" onClick={() => setShowAllRushers(false)}>← Back to stat leaders</button><label><span>Filter rushers</span><input type="search" value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Player name" /></label></div><div className="complete-leaders-table-scroll"><table className="complete-leaders-table"><thead><tr><th>Player</th>{RUSHING_COLUMNS.map((column) => <th key={column}>{column}</th>)}</tr></thead><tbody>{allRushers.map((row) => <tr key={row.Player}><td className="complete-leader-player"><PlayerImage player={playerByName.get(normalized(row.Player)) || {}} className="player-stats-image" /><span>{row.Player}</span></td>{RUSHING_COLUMNS.map((column) => <td key={column}>{row[column] || "0"}</td>)}</tr>)}</tbody></table></div></section> : <div className="stats-leader-grid"><section><h2>Offensive Leaders</h2>{OFFENSE.map((category) => <LeaderTable key={category.title} category={category} leaders={leadersFor(category)} loading={loading} error={error} onComplete={category.title === "RUSHING" ? () => setShowAllRushers(true) : undefined} />)}</section><section><h2>Defensive Leaders</h2>{DEFENSE.map((category) => <LeaderTable key={category.title} category={category} leaders={leadersFor(category)} loading={loading} error={error} />)}</section></div>}
+    {completeView ? <section className="complete-rushing-leaders"><div className="complete-leaders-tools"><button type="button" onClick={() => setCompleteView(null)}>← Back to stat leaders</button><label><span>Filter {completeView === "rushing" ? "rushers" : "tacklers"}</span><input type="search" value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Player name" /></label></div><div className="complete-leaders-table-scroll"><table className="complete-leaders-table"><thead><tr><th>Player</th>{completeColumns.map((column) => <th key={column.label}>{column.label}</th>)}</tr></thead><tbody>{completeRows.map((row) => <tr key={row.Player}><td className="complete-leader-player"><PlayerImage player={playerByName.get(normalized(row.Player)) || {}} className="player-stats-image" /><span>{row.Player}</span></td>{completeColumns.map((column) => <td key={column.label}>{displayStat(row, column.fields)}</td>)}</tr>)}</tbody></table></div></section> : <div className="stats-leader-grid"><section><h2>Offensive Leaders</h2>{OFFENSE.map((category) => <LeaderTable key={category.title} category={category} leaders={leadersFor(category)} loading={loading} error={error} onComplete={category.title === "RUSHING" ? () => setCompleteView("rushing") : undefined} />)}</section><section><h2>Defensive Leaders</h2>{DEFENSE.map((category) => <LeaderTable key={category.title} category={category} leaders={leadersFor(category)} loading={loading} error={error} onComplete={category.title === "TACKLES" ? () => setCompleteView("tackling") : undefined} />)}</section></div>}
     <p className="stats-updated">Statistics are updated after every completed game.</p>
   </main>;
 }


### PR DESCRIPTION
### Motivation
- Provide a single, reusable full-player table for both rushing and tackling so clicking the leaders can show complete per-player stat lines. 
- Include every player with at least one carry in the full rushing view and every player with at least one tackle in the full tackling view. 

### Description
- Generalize the complete-leaders UI by introducing a `CompleteView` state and a `StatColumn` type and reuse the full-stat table for both rushing and tackling in `apps/web/src/components/league/LeagueStats.tsx`. 
- Add `DEFENSIVE_COLUMNS` with alternate source-column names and implement `displayStat` to normalize and render arbitrary stat column headers. 
- Replace the prior `showAllRushers` flow with `completeView` and add `allTacklers`, `completeRows`, and `completeColumns` so both `RUSHING` and `TACKLES` leader sections can open the complete table. 
- Wire the `Complete Leaders` action under the Rushing and Tackles leader tables to call `setCompleteView("rushing")` or `setCompleteView("tackling")` respectively. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` which completed successfully with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e22801bc4832495434fd1dea01b3c)