### PR TITLE
Improve stats filters and add player detail views

### DIFF
--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -5,6 +5,7 @@ import type { Player } from "../players/types";
 import type { LeagueTeam } from "./types";
 
 type StatsView = "Player" | "Team";
+type PlayerProfileTab = "Overview" | "News" | "Stats" | "Bio" | "Splits" | "Game Log";
 type CompleteView = "rushing" | "tackling" | "team-total" | "team-passing" | "team-rushing" | null;
 type Leader = { name: string; detail?: string; image?: string; player?: Player; value: number };
 type Category = { title: string; label: string; fields: string[]; positions?: string[] };
@@ -57,17 +58,40 @@ function teamName(team: LeagueTeam) { return String(team.Name || team.Team || te
 const teamGames = (team: LeagueTeam) => number(team.GP || team.Games || 1) || 1;
 function teamField(team: LeagueTeam, fields: string[]) { return statValue(team as PlayerStats, fields); }
 
-function LeaderTable({ category, leaders, loading, error, onComplete }: { category: Category; leaders: Leader[]; loading: boolean; error: string | null; onComplete?: () => void }) {
+function LeaderTable({ category, leaders, loading, error, onComplete, onPlayer }: { category: Category; leaders: Leader[]; loading: boolean; error: string | null; onComplete?: () => void; onPlayer?: (player: Player) => void }) {
   return <section className="leader-group">
     <table className="leader-table">
       <thead><tr><th>{category.title}</th><th>{category.label}</th></tr></thead>
       <tbody>{loading || error || !leaders.length ? <tr><td className="leader-message" colSpan={2}>{loading ? "Loading leaders…" : error || "No statistics recorded yet."}</td></tr> : leaders.map((leader, index) => <tr key={`${category.title}-${leader.name}`}>
-        <td className="leader-identity"><span className="rank">{index + 1}</span>{leader.player ? <PlayerImage player={leader.player} className="player-stats-image" /> : leader.image ? <img className="team-stats-logo" src={leader.image} alt="" /> : <span className="team-stats-logo-fallback">{leader.name.slice(0, 2)}</span>}<span><b>{leader.name}</b>{leader.detail && <small>{leader.detail}</small>}</span></td>
+        <td className="leader-identity"><span className="rank">{index + 1}</span>{leader.player ? <PlayerImage player={leader.player} className="player-stats-image" /> : leader.image ? <img className="team-stats-logo" src={leader.image} alt="" /> : <span className="team-stats-logo-fallback">{leader.name.slice(0, 2)}</span>}<span>{leader.player && onPlayer ? <button className="player-name-button" type="button" onClick={() => onPlayer(leader.player!)}>{leader.name}</button> : <b>{leader.name}</b>}{leader.detail && <small>{leader.detail}</small>}</span></td>
         <td className="stat-value">{leader.value.toLocaleString(undefined, { maximumFractionDigits: 1 })}</td>
       </tr>)}</tbody>
     </table>
     {onComplete && !loading && !error && leaders.length > 0 && <div className="complete-link"><button type="button" onClick={onComplete}>Complete Leaders</button></div>}
   </section>;
+}
+
+function StatsSelect({ value, onChange, children, label }: { value: string; onChange?: (value: string) => void; children: React.ReactNode; label: string }) {
+  return <label className="stats-select"><span className="sr-only">{label}</span><select value={value} onChange={(event) => onChange?.(event.target.value)}>{children}</select><span aria-hidden="true" className="stats-select-chevron">⌄</span></label>;
+}
+
+function PlayerStatsProfile({ player, row, team, onBack }: { player: Player; row?: PlayerStats; team?: LeagueTeam; onBack: () => void }) {
+  const [tab, setTab] = useState<PlayerProfileTab>("Overview");
+  const name = String(player.Name || row?.Player || "Player");
+  const statEntries = Object.entries(row || {}).filter(([key, value]) => normalized(key) !== "player" && value !== "" && value != null && number(value) !== 0);
+  const featured = statEntries.slice(0, 4);
+  const logo = String(team?.Logo || "");
+  return <main className="player-detail-page">
+    <button className="profile-back" type="button" onClick={onBack}>← Back to league leaders</button>
+    <section className="player-detail-hero">
+      <div className="player-detail-art"><div className="glass-line glass-line-one" /><div className="glass-line glass-line-two" />{logo && <img className="player-detail-watermark" src={logo} alt="" />}<PlayerImage player={player} className="player-detail-photo" fallback={<div className="player-detail-initials">{name.split(" ").map((part) => part[0]).join("").slice(0, 2)}</div>} /></div>
+      <div className="player-detail-name"><span>{String(player.Pos || "PLAYER")}</span><h1>{name}</h1><p>{logo && <img src={logo} alt="" />} <b>{teamName(team || {})}</b> · #{String(player.Jersey || player.jersey || "--")} · {String(player.Pos || "--")}</p></div>
+      <dl className="player-detail-facts"><div><dt>HEIGHT / WEIGHT</dt><dd>{String(player.Size || "—")}</dd></div><div><dt>TEAM</dt><dd>{teamName(team || {})}</dd></div><div><dt>POSITION</dt><dd>{String(player.Pos || "—")}</dd></div><div><dt>STATUS</dt><dd><i /> Active</dd></div></dl>
+    </section>
+    <section className="player-featured-stats"><h2>SEASON 1 REGULAR SEASON STATS</h2><div>{(featured.length ? featured : [["Games", "0"], ["Starts", "0"], ["Yards", "0"], ["Touchdowns", "0"]]).map(([key, value]) => <article key={key}><span>{key}</span><strong>{String(value)}</strong><small>Season 1</small></article>)}</div></section>
+    <nav className="player-detail-tabs">{(["Overview", "News", "Stats", "Bio", "Splits", "Game Log"] as PlayerProfileTab[]).map((item) => <button className={tab === item ? "active" : ""} type="button" onClick={() => setTab(item)} key={item}>{item}</button>)}</nav>
+    {tab === "Overview" ? <div className="player-overview-grid"><section><header><h3>Season 1 {String(player.Pos || "Player")} Statistics</h3></header><div className="player-stat-table-scroll"><table><thead><tr><th>STATS</th>{statEntries.slice(0, 10).map(([key]) => <th key={key}>{key}</th>)}</tr></thead><tbody><tr><td>Regular Season</td>{statEntries.slice(0, 10).map(([key, value]) => <td key={key}>{String(value)}</td>)}</tr></tbody></table></div></section><section><header><h3>Recent Games</h3></header><div className="empty-profile-state">Game-by-game statistics will appear after completed games.</div></section></div> : <section className="player-tab-stub"><span>{tab.toUpperCase()}</span><h2>{tab} coming soon</h2><p>This player section is ready for future league data.</p></section>}
+  </main>;
 }
 
 function TeamCompleteTable({ mode, rows, onBack }: { mode: "total" | "passing" | "rushing"; rows: TeamTotal[]; onBack: () => void }) {
@@ -93,6 +117,7 @@ export function LeagueStats({ teams }: { teams: LeagueTeam[] }) {
   const [error, setError] = useState<string | null>(null);
   const [completeView, setCompleteView] = useState<CompleteView>(null);
   const [filter, setFilter] = useState("");
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   useEffect(() => { Promise.all([getPlayerStats(), getPlayers()]).then(([statsResult, playersResult]) => { setStats(statsResult.playerStats); setPlayers(playersResult.players); }).catch((reason: unknown) => setError(reason instanceof Error ? reason.message : "Unable to load statistics")).finally(() => setLoading(false)); }, []);
 
@@ -123,11 +148,17 @@ export function LeagueStats({ teams }: { teams: LeagueTeam[] }) {
   const completeColumns: StatColumn[] = completeView === "rushing" ? RUSHING_COLUMNS.map((label) => ({ label, fields: [label] })) : DEFENSIVE_COLUMNS;
   const teamMode = completeView?.startsWith("team-") ? completeView.slice(5) as "total" | "passing" | "rushing" : null;
 
+  if (selectedPlayer) {
+    const row = stats.find((item) => normalized(item.Player) === normalized(selectedPlayer.Name));
+    const team = teamByKey.get(normalized(selectedPlayer.Team));
+    return <PlayerStatsProfile player={selectedPlayer} row={row} team={team} onBack={() => setSelectedPlayer(null)} />;
+  }
+
   return <main className="league-stats-card">
-    <header className="league-stats-heading"><div><span>LEAGUE STATISTICS</span><h1>{teamMode ? `AFL Team ${teamMode === "total" ? "Total Offense" : teamMode[0].toUpperCase() + teamMode.slice(1)} Stats` : "AFL Stat Leaders"}</h1></div><button type="button" onClick={() => setActiveView(activeView === "Player" ? "Team" : "Player")}>{activeView === "Player" ? "Team Statistics" : "Player Statistics"}⌄</button></header>
+    <header className="league-stats-heading"><div><span>LEAGUE STATISTICS</span><h1>{teamMode ? `AFL Team ${teamMode === "total" ? "Total Offense" : teamMode[0].toUpperCase() + teamMode.slice(1)} Stats` : "AFL Stat Leaders"}</h1></div><StatsSelect label="Statistics view" value={activeView} onChange={(value) => { setActiveView(value as StatsView); setCompleteView(null); }}><option value="Player">Player Statistics</option><option value="Team">Team Statistics</option></StatsSelect></header>
     <div className="stats-tabs" role="tablist">{(["Player", "Team"] as StatsView[]).map((view) => <button className={`stats-tab ${activeView === view ? "active" : ""}`} key={view} type="button" onClick={() => { setActiveView(view); setCompleteView(null); }}>{view}</button>)}</div>
-    <div className="season-row"><button className="season-pill" type="button">Season 1 Regular Season⌄</button></div>
-    {teamMode ? <TeamCompleteTable mode={teamMode} rows={[...teamTotals].sort((a, b) => b[teamMode] - a[teamMode])} onBack={() => setCompleteView(null)} /> : completeView ? <section className="complete-rushing-leaders"><div className="complete-leaders-tools"><button type="button" onClick={() => setCompleteView(null)}>← Back to stat leaders</button><label><span>Filter {completeView === "rushing" ? "rushers" : "tacklers"}</span><input type="search" value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Player name" /></label></div><div className="complete-leaders-table-scroll"><table className="complete-leaders-table"><thead><tr><th>Player</th>{completeColumns.map((column) => <th key={column.label}>{column.label}</th>)}</tr></thead><tbody>{completeRows.map((row) => <tr key={row.Player}><td className="complete-leader-player"><PlayerImage player={playerByName.get(normalized(row.Player)) || {}} className="player-stats-image" /><span>{row.Player}</span></td>{completeColumns.map((column) => <td key={column.label}>{displayStat(row, column.fields)}</td>)}</tr>)}</tbody></table></div></section> : <div className="stats-leader-grid"><section><h2>Offensive Leaders</h2>{(activeView === "Team" ? TEAM_OFFENSE : OFFENSE).map((category) => <LeaderTable key={category.title} category={category} leaders={activeView === "Team" ? teamLeadersFor(category) : leadersFor(category)} loading={loading} error={error} onComplete={activeView === "Team" ? () => setCompleteView(`team-${category.fields[0]}` as CompleteView) : category.title === "RUSHING" ? () => setCompleteView("rushing") : undefined} />)}</section><section><h2>Defensive Leaders</h2>{(activeView === "Team" ? TEAM_DEFENSE : DEFENSE).map((category) => <LeaderTable key={category.title} category={category} leaders={activeView === "Team" ? teamLeadersFor(category) : leadersFor(category)} loading={loading} error={error} onComplete={activeView === "Team" ? undefined : category.title === "TACKLES" ? () => setCompleteView("tackling") : undefined} />)}</section></div>}
+    <div className="season-row"><StatsSelect label="Season" value="season-1"><option value="season-1">Season 1 Regular Season</option></StatsSelect></div>
+    {teamMode ? <TeamCompleteTable mode={teamMode} rows={[...teamTotals].sort((a, b) => b[teamMode] - a[teamMode])} onBack={() => setCompleteView(null)} /> : completeView ? <section className="complete-rushing-leaders"><div className="complete-leaders-tools"><button type="button" onClick={() => setCompleteView(null)}>← Back to stat leaders</button><label><span>Filter {completeView === "rushing" ? "rushers" : "tacklers"}</span><input type="search" value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Player name" /></label></div><div className="complete-leaders-table-scroll"><table className="complete-leaders-table"><thead><tr><th>Player</th>{completeColumns.map((column) => <th key={column.label}>{column.label}</th>)}</tr></thead><tbody>{completeRows.map((row) => <tr key={row.Player}><td className="complete-leader-player"><PlayerImage player={playerByName.get(normalized(row.Player)) || {}} className="player-stats-image" /><button className="player-name-button" type="button" onClick={() => { const player = playerByName.get(normalized(row.Player)); if (player) setSelectedPlayer(player); }}>{row.Player}</button></td>{completeColumns.map((column) => <td key={column.label}>{displayStat(row, column.fields)}</td>)}</tr>)}</tbody></table></div></section> : <div className="stats-leader-grid"><section><h2>Offensive Leaders</h2>{(activeView === "Team" ? TEAM_OFFENSE : OFFENSE).map((category) => <LeaderTable key={category.title} category={category} leaders={activeView === "Team" ? teamLeadersFor(category) : leadersFor(category)} loading={loading} error={error} onPlayer={setSelectedPlayer} onComplete={activeView === "Team" ? () => setCompleteView(`team-${category.fields[0]}` as CompleteView) : category.title === "RUSHING" ? () => setCompleteView("rushing") : undefined} />)}</section><section><h2>Defensive Leaders</h2>{(activeView === "Team" ? TEAM_DEFENSE : DEFENSE).map((category) => <LeaderTable key={category.title} category={category} leaders={activeView === "Team" ? teamLeadersFor(category) : leadersFor(category)} loading={loading} error={error} onPlayer={setSelectedPlayer} onComplete={activeView === "Team" ? undefined : category.title === "TACKLES" ? () => setCompleteView("tackling") : undefined} />)}</section></div>}
     <p className="stats-updated">Statistics are updated after every completed game.</p>
   </main>;
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -750,12 +750,16 @@
 .league-stats-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
 .league-stats-heading span { color: var(--accent-red); font-size: .68rem; font-weight: 900; letter-spacing: .15em; }
 .league-stats-heading h1 { margin: 5px 0 0; font-size: clamp(1.75rem, 4vw, 2.55rem); }
-.league-stats-heading > button { padding: 10px 16px; color: var(--text-light); border: 1px solid var(--border-color); border-radius: 22px; background: transparent; cursor: pointer; }
+.stats-select { position: relative; display: inline-flex; align-items: center; min-width: 190px; }
+.stats-select select { width: 100%; appearance: none; padding: 11px 42px 11px 17px; color: var(--text-light); border: 1px solid #4a4f58; border-radius: 8px; outline: 0; background: linear-gradient(180deg, #30343a, #24272c); box-shadow: inset 0 1px rgba(255,255,255,.06), 0 3px 10px rgba(0,0,0,.2); font: inherit; font-size: .85rem; font-weight: 700; cursor: pointer; }
+.stats-select select:hover, .stats-select select:focus-visible { border-color: #7f8792; background: linear-gradient(180deg, #383d44, #292d32); }
+.stats-select-chevron { position: absolute; right: 15px; top: 50%; transform: translateY(-58%); color: #8fc2ff; font-size: 1.1rem; pointer-events: none; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 .league-stats-card .stats-tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 0; margin: 18px 0; padding: 0; border-bottom: 1px solid var(--border-color); }
 .league-stats-card .stats-tab { padding: 12px; border: 0; border-bottom: 3px solid transparent; background: transparent; font-weight: 800; cursor: pointer; }
 .league-stats-card .stats-tab.active { color: var(--text-light); border-bottom-color: var(--accent-red); background: transparent; }
 .league-stats-card .season-row { padding: 0; margin: 20px 0; }
-.league-stats-card .season-pill { padding: 9px 15px; border-color: var(--border-color); border-radius: 20px; cursor: pointer; }
+.league-stats-card .season-row .stats-select { min-width: 245px; }
 .stats-leader-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 40px; }
 .stats-leader-grid h2 { margin: 0 0 12px; font-size: 1.05rem; }
 .league-stats-card .leader-group { margin-bottom: 26px; border: 0; background: transparent; }
@@ -795,6 +799,28 @@
   .stats-leader-grid { grid-template-columns: 1fr; gap: 4px; }
   .complete-leaders-tools { align-items: stretch; flex-direction: column; }
 }
+
+/* Player statistics profile */
+.player-detail-page { width: min(1240px, calc(100% - 32px)); margin: 20px auto 50px; color: var(--text-light); }
+.player-detail-page .profile-back { padding: 8px 0; color: #80b9ff; font-weight: 700; }
+.player-detail-hero { position: relative; display: grid; grid-template-columns: minmax(260px, 34%) minmax(250px, 1fr) minmax(250px, .85fr); align-items: center; min-height: 310px; overflow: hidden; border: 1px solid #434850; border-radius: 12px 12px 0 0; background: linear-gradient(110deg, #111419, #242930 58%, #181b20); }
+.player-detail-art { position: relative; align-self: stretch; min-height: 310px; overflow: hidden; background: linear-gradient(135deg, rgba(255,255,255,.08), transparent 48%); }
+.player-detail-watermark { position: absolute; left: -7%; top: 3%; width: 105%; height: 105%; object-fit: contain; opacity: .12; filter: grayscale(.25); }
+.glass-line { position: absolute; z-index: 1; width: 150%; height: 54px; left: -25%; border: 1px solid rgba(255,255,255,.22); background: rgba(255,255,255,.035); transform: rotate(-55deg); backdrop-filter: blur(2px); }
+.glass-line-one { top: 18%; }.glass-line-two { top: 66%; left: -8%; height: 28px; }
+.player-detail-photo { position: absolute; z-index: 2; inset: 10px 0 0; width: 100%; height: calc(100% - 10px); }
+.player-detail-photo > img { object-fit: contain; object-position: bottom center; }
+.player-detail-initials { position: absolute; z-index: 2; inset: 20% 18% 0; display: grid; place-items: center; border-radius: 50% 50% 0 0; background: #343b44; font-size: 5rem; font-weight: 900; }
+.player-detail-name { padding: 25px 34px; border-right: 1px solid rgba(255,255,255,.11); }
+.player-detail-name > span { color: var(--accent-red); font-size: .68rem; font-weight: 900; letter-spacing: .16em; }
+.player-detail-name h1 { max-width: 500px; margin: 5px 0 14px; font-size: clamp(2.25rem, 5vw, 4.5rem); line-height: .95; text-transform: uppercase; }
+.player-detail-name p { display: flex; align-items: center; gap: 7px; margin: 0; color: var(--text-muted); }.player-detail-name p img { width: 25px; height: 25px; object-fit: contain; }.player-detail-name p b { color: #fff; }
+.player-detail-facts { display: grid; gap: 16px; margin: 0; padding: 26px 34px; }.player-detail-facts div { display: grid; grid-template-columns: 1fr 1.3fr; gap: 14px; }.player-detail-facts dt { color: var(--text-muted); font-size: .7rem; }.player-detail-facts dd { margin: 0; font-weight: 800; }.player-detail-facts i { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: #20c875; }
+.player-featured-stats { overflow: hidden; border: 1px solid #434850; border-top: 0; border-radius: 0 0 12px 12px; background: #1f2328; }.player-featured-stats h2 { margin: 0; padding: 6px; color: #fff; background: #a3131b; text-align: center; font-size: .7rem; letter-spacing: .04em; }.player-featured-stats > div { display: grid; grid-template-columns: repeat(4,1fr); }.player-featured-stats article { display: grid; gap: 4px; padding: 14px; text-align: center; }.player-featured-stats span,.player-featured-stats small { color: var(--text-muted); font-size: .7rem; }.player-featured-stats strong { font-size: 1.9rem; }
+.player-detail-tabs { display: flex; gap: 24px; margin-top: 18px; overflow-x: auto; border-bottom: 1px solid #454a52; }.player-detail-tabs button { padding: 13px 2px; color: var(--text-muted); border: 0; border-bottom: 3px solid transparent; background: none; font-weight: 700; white-space: nowrap; cursor: pointer; }.player-detail-tabs button.active { color: #fff; border-bottom-color: var(--accent-red); }
+.player-overview-grid { display: grid; gap: 12px; padding: 16px; background: #171a1e; }.player-overview-grid section,.player-tab-stub { overflow: hidden; border: 1px solid #3d424a; border-radius: 10px; background: #24282e; }.player-overview-grid header { padding: 14px 18px; }.player-overview-grid h3 { margin: 0; font-size: 1rem; }.player-stat-table-scroll { overflow-x: auto; }.player-stat-table-scroll table { width: 100%; border-collapse: collapse; font-size: .75rem; }.player-stat-table-scroll th,.player-stat-table-scroll td { padding: 10px; border: 1px solid #3d424a; text-align: right; white-space: nowrap; }.player-stat-table-scroll th:first-child,.player-stat-table-scroll td:first-child { text-align: left; }.empty-profile-state { padding: 34px; color: var(--text-muted); text-align: center; }.player-tab-stub { margin-top: 16px; padding: 70px 25px; text-align: center; }.player-tab-stub span { color: var(--accent-red); font-size: .7rem; font-weight: 900; letter-spacing: .16em; }.player-tab-stub h2 { margin-bottom: 5px; }.player-tab-stub p { color: var(--text-muted); }
+@media (max-width: 820px) { .player-detail-hero { grid-template-columns: 1fr 1fr; }.player-detail-facts { grid-column: 1/-1; grid-template-columns: 1fr 1fr; border-top: 1px solid #3d424a; }.player-featured-stats > div { grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 560px) { .player-detail-page { width: calc(100% - 20px); }.player-detail-hero { grid-template-columns: 1fr; }.player-detail-name { border-right: 0; }.player-detail-facts { grid-template-columns: 1fr; }.league-stats-heading .stats-select { width: 100%; } }
 .player-rushing-profile { padding: clamp(1rem, 3vw, 2.5rem); }
 .profile-back {
   margin-bottom: 1rem;


### PR DESCRIPTION
### Motivation
- Refresh the stats UI so dropdowns match the rest of the app and replace the current ugly pill controls with a consistent select control.
- Allow tapping player names to open a detailed player view showing season stats and a visual header with a faded team logo and angled glass accents.
- Provide a near-final player profile layout while leaving the non-shown tabs as stubs for future data.

### Description
- Replaced the stats view and season pills with a reusable `StatsSelect` component and added consistent styling for the dropdown chevron and hover/focus states in `apps/web/src/components/league/league.css`.
- Made player names interactive in leader lists by updating `LeaderTable` and the complete-leaders table to call a new `selectedPlayer` handler when clicked.
- Added a `PlayerStatsProfile` component inside `LeagueStats.tsx` that renders the player hero with a faded team watermark, angled glass lines, player artwork, featured season stats, and tabs (`Overview`, `News`, `Stats`, `Bio`, `Splits`, `Game Log`) with stub content for unimplemented tabs.
- Wired the new profile view into `LeagueStats` state via `selectedPlayer` so selecting a player replaces the leaders view with the player profile, and added responsive CSS rules to match mobile/tablet layouts.

### Testing
- Ran `npm run build` in `apps/web` which completed successfully and produced a production build.
- Ran `npm run lint` which finished with zero errors and one existing React hook warning in `GameField.tsx` that was unchanged by this PR.
- Verified `git diff --check` (no whitespace/patch errors) and ensured the app builds with the updated components and styles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e24ee7f8883248a9ae56d98b1f9da)