### PR TITLE
Restore deterministic breakaway tackles

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngineHelper.ts
@@ -914,7 +914,7 @@ function addSecondarySpeedYards(
   }
   if (pursuitResult?.escaped) {
     addSecondaryBreakawayYards(runState, players, settings);
-    resolveBreakawayPursuit(runState, defenseFormation, players, pursuitResult.chaser);
+    tackleByFastestSecondaryDefender(runState, defenseFormation, players);
   }
 }
 
@@ -996,11 +996,10 @@ function addSecondaryBreakawayYards(
   }
 }
 
-function resolveBreakawayPursuit(
+function tackleByFastestSecondaryDefender(
   runState: RunPlayState,
   defenseFormation: DefensiveAssignment[],
   players: PlayerTrait[],
-  initialChaser?: string,
 ) {
   if (runState.stopped) return;
 
@@ -1022,29 +1021,21 @@ function resolveBreakawayPursuit(
 
   const startYards = runState.yards;
   const chaser = fastestDefender.assignment.player;
-  const runnerSpeed = trait(findPlayerByName(players, runState.runner), "speed");
-  // A defender already beaten in the first chase has less leverage on a second
-  // attempt; a new pursuit angle gets a small positioning advantage.
-  const catchChance = Math.max(
-    8,
-    Math.min(82, 48 + fastestDefender.speed - runnerSpeed + (chaser === initialChaser ? -12 : 6)),
+  handleRunnerTackle(
+    runState,
+    chaser,
+    "Breakaway End Fastest Secondary Defender",
+    players,
   );
-  const caught = Math.random() * 100 < catchChance;
-  if (caught) {
-    handleRunnerTackle(runState, chaser, "Breakaway Pursuit", players);
-    runState.log.push(`${chaser} stays in hot pursuit and tracks down ${runState.runner} after the breakaway.`);
-  } else {
-    // Crossing the goal line is clamped to the actual remaining field distance
-    // by runPlay's scoreboard resolution.
-    addYards(runState, 100, `${runState.runner} pulls away from ${chaser} and races to the end zone`);
-    runState.log.push(`${chaser} cannot close the gap; ${runState.runner} finishes the escape in the end zone.`);
-  }
+  runState.log.push(
+    `${chaser} tracks down ${runState.runner} after the breakaway as the fastest DB/LB/S on the field.`,
+  );
   runState.pursuitEvents.push({
     stage: "breakaway",
     chaser,
     startYards,
     endYards: runState.yards,
-    escaped: !caught,
+    escaped: false,
   });
 }
 


### PR DESCRIPTION
### Motivation

- A recent animation-focused change introduced an extra post-breakaway catch/"leverage" roll that altered game outcomes by letting the fastest secondary defender sometimes fail to make the automatic post-breakaway tackle.  
- Breakaway resolution should be a deterministic application of the configured breakaway-yard roll followed by an immediate tackle by the fastest eligible secondary defender.  
- Pursuit metadata is needed for animations but must not affect the simulation results.

### Description

- Reverted the probabilistic post-breakaway pursuit logic in `apps/web/src/components/league/gameplay/engine/runEngineHelper.ts` and restored a deterministic `tackleByFastestSecondaryDefender` which immediately calls `handleRunnerTackle` for the fastest DB/LB/S and logs the outcome.  
- Removed the additional catch-chance calculation and the code path that awarded a 100-yard end-zone escape as a result of that roll.  
- Retained `runState.pursuitEvents` collection strictly as animation metadata so the animation builder still receives pursuit information without influencing game outcomes.  
- Left other animation-related engine additions (collection of challenge order, `runChallenges`, and related metadata) intact because they do not change simulation results.

### Testing

- Ran `npm run build` which completed successfully.  
- Ran `npm run lint` which completed with zero errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`.  
- Verified project compiles through the TypeScript build step in the `build` run (no type/build failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e28c1a78c8324a667fb716b3fa08a)