### PR TITLE
Standardize app-wide theme-aware dropdowns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# UI development rules
+
+- Every new or changed UI element must use the app's semantic design tokens from `apps/web/src/App.css`; do not introduce fixed light- or dark-only foregrounds, backgrounds, borders, shadows, or form-control colors.
+- Every UI element must be checked in both `data-theme="dark"` and `data-theme="light"` modes before the work is considered complete.
+- Use the shared `AppSelect` component for dropdowns. Do not add an unstyled native `<select>` or a one-off dropdown treatment.
+- Team colors, field markings, status colors, and other meaning-bearing colors may remain fixed when changing them would alter their meaning. All surrounding UI chrome must remain theme-aware.
+

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -18,6 +18,11 @@
   --text-inverse: #ffffff;
   --shadow-color: rgba(0, 0, 0, 0.38);
   --page-gradient: linear-gradient(135deg, #121212 0%, #1e1e1e 100%);
+  --control-bg: linear-gradient(180deg, #30343a, #24272c);
+  --control-bg-hover: linear-gradient(180deg, #383d44, #292d32);
+  --control-border: #4a4f58;
+  --control-border-hover: #7f8792;
+  --control-accent: #8fc2ff;
 }
 
 :root[data-theme="light"] {
@@ -36,6 +41,11 @@
   --text-inverse: #ffffff;
   --shadow-color: rgba(20, 30, 45, 0.14);
   --page-gradient: linear-gradient(135deg, #f7f9fb 0%, #e8edf2 100%);
+  --control-bg: linear-gradient(180deg, #ffffff, #edf1f5);
+  --control-bg-hover: linear-gradient(180deg, #ffffff, #e3e9ef);
+  --control-border: #aeb8c3;
+  --control-border-hover: #697786;
+  --control-accent: #075eb8;
 }
 
 body {
@@ -45,6 +55,54 @@ body {
   background: var(--page-gradient);
   color: var(--text-light);
 }
+
+.app-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 150px;
+  color: var(--text-primary);
+}
+
+.app-select select,
+.dropdown-button {
+  width: 100%;
+  min-height: 42px;
+  box-sizing: border-box;
+  appearance: none;
+  padding: 10px 42px 10px 16px;
+  border: 1px solid var(--control-border);
+  border-radius: 10px;
+  outline: 0;
+  color: var(--text-primary);
+  background: var(--control-bg);
+  box-shadow: inset 0 1px rgb(255 255 255 / 6%), 0 3px 10px var(--shadow-color);
+  font: inherit;
+  font-size: .875rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.app-select select:hover,
+.app-select select:focus-visible,
+.dropdown-button:hover,
+.dropdown-button:focus-visible {
+  border-color: var(--control-border-hover);
+  background: var(--control-bg-hover);
+}
+
+.app-select select:focus-visible,
+.dropdown-button:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--control-accent) 30%, transparent);
+}
+
+.app-select select:disabled { cursor: not-allowed; opacity: .6; }
+.app-select option { color: var(--text-primary); background: var(--surface-raised); }
+.app-select__chevron { position: absolute; right: 15px; top: 50%; transform: translateY(-58%); color: var(--control-accent); font-size: 1.1rem; pointer-events: none; }
+.app-select--compact { min-width: 0; }
+.app-select--compact select { min-height: 34px; padding-block: 6px; }
+.dropdown-button { display: inline-flex; align-items: center; justify-content: space-between; gap: 16px; width: auto; }
+.dropdown-button > span { color: var(--control-accent); font-size: 1.1rem; }
 
 .app {
   min-height: 100vh;
@@ -217,7 +275,7 @@ body {
 .setting-row { display: flex; align-items: center; justify-content: space-between; gap: 30px; padding-bottom: 30px; border-bottom: 1px solid var(--border-color); }
 .setting-row label { display: block; margin-bottom: 8px; font-size: 1.1rem; font-weight: 800; }
 .setting-row p, .settings-message { margin: 0; color: var(--text-secondary); }
-.setting-row select { min-width: 150px; padding: 11px 38px 11px 13px; border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-primary); background: var(--surface-canvas); cursor: pointer; }
+.setting-row .app-select { min-width: 150px; }
 .settings-message { padding-top: 20px; }
 @media (max-width: 620px) {
   .settings-layout { grid-template-columns: 1fr; }
@@ -253,7 +311,7 @@ body {
 :root[data-theme="light"] .player-table th,
 :root[data-theme="light"] .player-table td { border-color: var(--border-color); }
 
-/* The main menu intentionally keeps its stadium presentation in both modes. */
+/* Theme tokens also flow through the main menu; semantic stadium art remains unchanged. */
 
 .progress-bar {
   height: 100%;

--- a/apps/web/src/components/league/GamesBanner.tsx
+++ b/apps/web/src/components/league/GamesBanner.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { AppSelect } from "../ui/AppSelect";
 import type { LeagueGame } from "./types";
 import { formatBallOnForPoss, formatClock, formatDownDistance } from "./leagueMappers";
 
@@ -29,9 +30,9 @@ export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
       </button>
       <label className="games-banner__picker">
         <span>Week</span>
-        <select value={week} onChange={(event) => setWeek(Number(event.target.value))}>
+        <AppSelect containerClassName="app-select--compact" value={week} onChange={(event) => setWeek(Number(event.target.value))}>
           {WEEKS.map((item) => <option key={item} value={item}>Week {item}</option>)}
-        </select>
+        </AppSelect>
       </label>
       <div className="games-banner__rail">
         {weekGames.length ? (

--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { AppSelect } from "../ui/AppSelect";
 import type { LeagueGame, LeagueTeam } from "./types";
 
 const getWeek = (game: LeagueGame, index: number) => Number(game.Week ?? index + 1);
@@ -92,7 +93,7 @@ export function LeagueSchedules({
           <div><span className="schedule-kicker">2026 SEASON</span><h1>{selectedTeam ? `${selectedLabel} Schedule` : "AFL Schedule"}</h1></div>
           <label className="team-schedule-picker">
             <span className="sr-only">Choose a team schedule</span>
-            <select value={selectedTeam} onChange={(event) => {
+            <AppSelect value={selectedTeam} onChange={(event) => {
               const id = event.target.value;
               setSelectedTeam(id);
               const team = teamsByAbbrev.get(id);
@@ -100,7 +101,7 @@ export function LeagueSchedules({
             }}>
               <option value="">Team Schedules</option>
               {teamOptions.map(([id, label]) => <option value={id} key={id}>{label}</option>)}
-            </select>
+            </AppSelect>
           </label>
         </header>
 

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getPlayers, getPlayerStats, type PlayerStats } from "../../api/client";
 import { PlayerImage } from "../players/PlayerImage";
+import { AppSelect } from "../ui/AppSelect";
 import type { Player } from "../players/types";
 import type { LeagueGame, LeagueTeam } from "./types";
 
@@ -72,7 +73,7 @@ function LeaderTable({ category, leaders, loading, error, onComplete, onPlayer }
 }
 
 function StatsSelect({ value, onChange, children, label }: { value: string; onChange?: (value: string) => void; children: React.ReactNode; label: string }) {
-  return <label className="stats-select"><span className="sr-only">{label}</span><select value={value} onChange={(event) => onChange?.(event.target.value)}>{children}</select><span aria-hidden="true" className="stats-select-chevron">⌄</span></label>;
+  return <label className="stats-select"><span className="sr-only">{label}</span><AppSelect value={value} onChange={(event) => onChange?.(event.target.value)}>{children}</AppSelect></label>;
 }
 
 function PlayerStatsProfile({ player, row, team, onBack }: { player: Player; row?: PlayerStats; team?: LeagueTeam; onBack: () => void }) {
@@ -106,7 +107,7 @@ function TeamCompleteTable({ mode, rows, onBack, onSpecialTeams }: { mode: "tota
     if (mode === "passing") return [row.passing, row.passing / row.gp, sum(["Passing TD", "Pass TD", "TD Passes"]), sum(["Interceptions Thrown", "Pass INT"]), sum(["Sacked", "Times Sacked"])];
     return [attempts, row.rushing, attempts ? row.rushing / attempts : 0, row.rushing / row.gp, sum(["Rushing TD", "Rush TD", "TD"])];
   };
-  return <section className="team-complete-view"><div className="team-stat-nav"><span className={!defensive && mode !== "turnovers" ? "active" : ""}>Offense</span><span className={defensive ? "active" : ""}>Defense</span><button type="button" onClick={onSpecialTeams}>Special Teams</button><span className={mode === "turnovers" ? "active" : ""}>Turnovers</span></div><div className="team-stat-filters"><button type="button">{mode === "defense" ? "Total" : mode === "sacks" ? "Passing" : mode[0].toUpperCase() + mode.slice(1)}⌄</button><button type="button">Season 1 Regular Season⌄</button></div><button className="team-table-back" type="button" onClick={onBack}>← Back to stat leaders</button><div className="complete-leaders-table-scroll"><table className="team-complete-table"><thead><tr><th>TEAM</th><th>GP</th>{columns.map((column, index) => <th key={`${column}-${index}`}>{column}</th>)}</tr></thead><tbody>{rows.map((row) => <tr key={teamName(row.team)}><td><span className="team-table-name">{row.team.Logo && <img src={String(row.team.Logo)} alt="" />}{teamName(row.team)}</span></td><td>{row.gp}</td>{values(row).map((value, index) => <td key={index}>{Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1)}</td>)}</tr>)}</tbody></table></div></section>;
+  return <section className="team-complete-view"><div className="team-stat-nav"><span className={!defensive && mode !== "turnovers" ? "active" : ""}>Offense</span><span className={defensive ? "active" : ""}>Defense</span><button type="button" onClick={onSpecialTeams}>Special Teams</button><span className={mode === "turnovers" ? "active" : ""}>Turnovers</span></div><div className="team-stat-filters"><button className="dropdown-button" type="button">{mode === "defense" ? "Total" : mode === "sacks" ? "Passing" : mode[0].toUpperCase() + mode.slice(1)}<span aria-hidden="true">⌄</span></button><button className="dropdown-button" type="button">Season 1 Regular Season<span aria-hidden="true">⌄</span></button></div><button className="team-table-back" type="button" onClick={onBack}>← Back to stat leaders</button><div className="complete-leaders-table-scroll"><table className="team-complete-table"><thead><tr><th>TEAM</th><th>GP</th>{columns.map((column, index) => <th key={`${column}-${index}`}>{column}</th>)}</tr></thead><tbody>{rows.map((row) => <tr key={teamName(row.team)}><td><span className="team-table-name">{row.team.Logo && <img src={String(row.team.Logo)} alt="" />}{teamName(row.team)}</span></td><td>{row.gp}</td>{values(row).map((value, index) => <td key={index}>{Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1)}</td>)}</tr>)}</tbody></table></div></section>;
 }
 
 export function LeagueStats({ teams, games = [] }: { teams: LeagueTeam[]; games?: LeagueGame[] }) {

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -47,8 +47,8 @@
 }
 .games-banner__brand:hover, .games-banner__brand:focus-visible { filter: brightness(1.15); }
 .games-banner__picker { display: grid; align-content: center; gap: 4px; flex: 0 0 135px; padding: 10px 18px; border-right: 1px solid var(--gray-light); }
-.games-banner__picker span { color: var(--text-muted); font-size: .64rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
-.games-banner__picker select { border: 0; background: transparent; color: var(--text-light); font-weight: 800; cursor: pointer; outline-offset: 4px; }
+.games-banner__picker > span:first-child { color: var(--text-muted); font-size: .64rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+.games-banner__picker .app-select { width: 100%; }
 .games-banner__rail { display: flex; flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
 .banner-game { flex: 0 0 210px; padding: 10px 16px; border: 0; border-right: 1px solid var(--gray-light); background: transparent; color: inherit; text-align: left; font: inherit; cursor: pointer; }
 .banner-game:hover, .banner-game:focus-visible { background: color-mix(in srgb, var(--accent-red) 9%, transparent); }
@@ -296,7 +296,7 @@
 .schedule-card__heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 30px 34px 24px; }
 .schedule-card__heading h1 { margin: 4px 0 0; font-size: clamp(1.8rem, 3vw, 2.55rem); letter-spacing: -.035em; }
 .schedule-kicker { color: var(--accent-red); font-size: .68rem; font-weight: 900; letter-spacing: .16em; }
-.team-schedule-picker select { min-width: 220px; padding: 12px 38px 12px 16px; color: var(--text-light); border: 1px solid var(--border-color); border-radius: 22px; background: var(--gray-medium); cursor: pointer; font-weight: 700; }
+.team-schedule-picker .app-select { min-width: 220px; }
 .schedule-weeks { display: flex; margin: 0 24px; overflow-x: auto; border-block: 1px solid var(--border-color); scrollbar-width: thin; }
 .schedule-weeks button { flex: 0 0 130px; padding: 16px 10px 13px; color: var(--text-muted); border: 0; border-bottom: 4px solid transparent; background: transparent; cursor: pointer; }
 .schedule-weeks b, .schedule-weeks small { display: block; }
@@ -371,7 +371,7 @@
   .schedule-game__action { padding: 16px 12px; }
   .schedule-center { padding: 14px; }
   .schedule-card__heading { align-items: stretch; flex-direction: column; padding: 22px 18px; }
-  .team-schedule-picker select { width: 100%; }
+  .team-schedule-picker .app-select { width: 100%; }
   .schedule-table-wrap { padding: 18px 14px 28px; overflow-x: auto; }
   .schedule-table { min-width: 680px; }
   .team-schedule-panel { margin: 14px; padding: 22px 16px 28px; }
@@ -750,10 +750,8 @@
 .league-stats-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
 .league-stats-heading span { color: var(--accent-red); font-size: .68rem; font-weight: 900; letter-spacing: .15em; }
 .league-stats-heading h1 { margin: 5px 0 0; font-size: clamp(1.75rem, 4vw, 2.55rem); }
-.stats-select { position: relative; display: inline-flex; align-items: center; min-width: 190px; }
-.stats-select select { width: 100%; appearance: none; padding: 11px 42px 11px 17px; color: var(--text-light); border: 1px solid #4a4f58; border-radius: 8px; outline: 0; background: linear-gradient(180deg, #30343a, #24272c); box-shadow: inset 0 1px rgba(255,255,255,.06), 0 3px 10px rgba(0,0,0,.2); font: inherit; font-size: .85rem; font-weight: 700; cursor: pointer; }
-.stats-select select:hover, .stats-select select:focus-visible { border-color: #7f8792; background: linear-gradient(180deg, #383d44, #292d32); }
-.stats-select-chevron { position: absolute; right: 15px; top: 50%; transform: translateY(-58%); color: #8fc2ff; font-size: 1.1rem; pointer-events: none; }
+.stats-select { display: inline-flex; min-width: 190px; }
+.stats-select .app-select { width: 100%; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 .league-stats-card .stats-tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 0; margin: 18px 0; padding: 0; border-bottom: 1px solid var(--border-color); }
 .league-stats-card .stats-tab { padding: 12px; border: 0; border-bottom: 3px solid transparent; background: transparent; font-weight: 800; cursor: pointer; }
@@ -783,7 +781,7 @@
 .team-stat-nav .active { color: var(--text-light); border-bottom: 2px solid var(--accent-red); }
 .team-stat-nav button { border: 0; background: transparent; cursor: pointer; }
 .team-stat-filters { display: flex; gap: 10px; margin: 0 0 14px; }
-.team-stat-filters button { padding: 9px 15px; border: 1px solid var(--border-color); border-radius: 20px; color: var(--text-light); background: transparent; }
+.team-stat-filters .dropdown-button { min-width: 150px; }
 .team-table-back { margin: 0 0 12px; color: #69adff; font-size: .78rem; }
 .team-complete-table { width: 100%; min-width: 850px; border-collapse: collapse; font-size: .76rem; }
 .team-complete-table th, .team-complete-table td { padding: 8px 7px; border-top: 1px solid var(--border-color); text-align: right; white-space: nowrap; }

--- a/apps/web/src/components/settings/GameSettingsScreen.tsx
+++ b/apps/web/src/components/settings/GameSettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { updateGameplaySetting, type VisualMode } from "../../api/client";
+import { AppSelect } from "../ui/AppSelect";
 
 type GameSettingsScreenProps = {
   visualMode: VisualMode;
@@ -46,7 +47,7 @@ export function GameSettingsScreen({ visualMode, onVisualModeChange, onBack }: G
               <label htmlFor="visual-mode">UI Mode</label>
               <p>Choose the color theme used throughout the game.</p>
             </div>
-            <select
+            <AppSelect
               id="visual-mode"
               value={visualMode}
               disabled={isSaving}
@@ -54,7 +55,7 @@ export function GameSettingsScreen({ visualMode, onVisualModeChange, onBack }: G
             >
               <option value="Dark">Dark</option>
               <option value="Light">Light</option>
-            </select>
+            </AppSelect>
           </div>
           {message && <p className="settings-message" role="status">{message}</p>}
         </div>

--- a/apps/web/src/components/ui/AppSelect.tsx
+++ b/apps/web/src/components/ui/AppSelect.tsx
@@ -1,0 +1,14 @@
+import type { SelectHTMLAttributes } from "react";
+
+type AppSelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
+  containerClassName?: string;
+};
+
+export function AppSelect({ containerClassName = "", children, ...props }: AppSelectProps) {
+  return (
+    <span className={`app-select ${containerClassName}`.trim()}>
+      <select {...props}>{children}</select>
+      <span className="app-select__chevron" aria-hidden="true">⌄</span>
+    </span>
+  );
+}


### PR DESCRIPTION
### Motivation
- The app had multiple inconsistent, one-off dropdown styles and native `<select>` usages that did not reliably follow the app-wide dark/light theming tokens.
- Introduce a single, theme-aware dropdown control and enforce app-wide rules so future UI work always respects the semantic visual tokens.

### Description
- Add a reusable `AppSelect` component at `apps/web/src/components/ui/AppSelect.tsx` that wraps native `<select>` with a consistent chevron and container class support.
- Define shared dropdown tokens and states (backgrounds, hover/focus, borders, accent) in `apps/web/src/App.css` and add compact/disabled/option styles so controls respond to `data-theme` for both light and dark modes.
- Migrate native selects to `AppSelect` in `GamesBanner.tsx`, `LeagueSchedules.tsx`, `LeagueStats.tsx`, and `GameSettingsScreen.tsx`, and update the stats filter visuals to use the same visual system in `LeagueStats.tsx` and `apps/web/src/components/league/league.css`.
- Add repository UI rules in `AGENTS.md` requiring the use of semantic theme tokens, verification in both `data-theme="dark"` and `data-theme="light"`, and reuse of the shared dropdown component for future UI work.

### Testing
- Ran `npm run build` which completed successfully producing the production build. 
- Ran `npm run lint` which completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (unchanged by this PR).
- Verified repository checks with `git diff --check` and `git status --short` with the changes committed.
- Confirmed raw `<select>` usages were encapsulated by the `AppSelect` component via source grep, and noted there is no browser/Playwright screenshot tooling in this environment for automated visual snapshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e294d77808324864a78c3e613184c)