### PR TITLE
Style scoreboard games based on final and unstarted status

### DIFF
--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -7,6 +7,18 @@ const WEEKS = Array.from({ length: 18 }, (_, index) => index + 1);
 const gameWeek = (game: LeagueGame, index: number) =>
   Number(game.Week ?? (index % WEEKS.length) + 1);
 
+function kickoffParts(game: LeagueGame) {
+  const raw = String(game["Kickoff Time"] ?? game.Kickoff ?? "").trim();
+  const parsed = new Date(raw);
+  if (!raw || Number.isNaN(parsed.getTime())) {
+    return { date: game.Date || `Week ${game.Week || "—"}`, time: raw || "Time TBD" };
+  }
+  return {
+    date: new Intl.DateTimeFormat("en-US", { weekday: "long", month: "long", day: "numeric" }).format(parsed),
+    time: new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit" }).format(parsed),
+  };
+}
+
 export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; onSelectGame: (game: LeagueGame) => void }) {
   const [activeWeek, setActiveWeek] = useState(1);
   const weekGames = useMemo(
@@ -39,17 +51,26 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
       <section className="week-scoreboard">
         <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>{finalGames ? "Scores & Results" : "Upcoming Games"}</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
         {weekGames.length ? weekGames.map((game) => {
-          const final = String(game.Qtr).toUpperCase() === "FINAL";
+          const gameStatus = String(game.Qtr).toUpperCase();
+          const final = gameStatus === "FINAL";
+          const unstarted = gameStatus === "UNSTARTED";
           const possession = String(game.Possession).toLowerCase();
+          const awayScore = Number(game.AwayScore);
+          const homeScore = Number(game.HomeScore);
+          const resultClass = (score: number, opponentScore: number) => final && score !== opponentScore
+            ? score > opponentScore ? "schedule-game__team--winner" : "schedule-game__team--loser"
+            : "";
+          const kickoff = unstarted ? kickoffParts(game) : null;
           return (
-          <article className="schedule-game" key={String(game.GameId)}>
+          <article className={`schedule-game ${unstarted ? "schedule-game--unstarted" : ""}`} key={String(game.GameId)}>
+            {kickoff && <div className="schedule-game__date"><strong>{kickoff.date}</strong><span>{kickoff.time} · {game.Network || "Network TBD"}</span>{game.Weather && <small>{game.Weather}</small>}</div>}
             <div className="schedule-game__teams">
-              <div><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away} {possession === "away" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
-              <div><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home} {possession === "home" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
+              <div className={resultClass(awayScore, homeScore)}><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away} {!final && possession === "away" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
+              <div className={resultClass(homeScore, awayScore)}><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home} {!final && possession === "home" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
             </div>
             <div className="schedule-game__action">
               <div className="schedule-game__situation">
-                {final ? <strong>FINAL</strong> : <><strong>{formatDownDistance(game.Down, game.Distance)}</strong><span>Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span><small>Q{game.Qtr} · {formatClock(game.Time)}</small></>}
+                {final ? <strong>FINAL</strong> : unstarted ? <strong>Q1 · {formatClock(game.Time)}</strong> : <><strong>{formatDownDistance(game.Down, game.Distance)}</strong><span>Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span><small>Q{game.Qtr} · {formatClock(game.Time)}</small></>}
               </div>
               <button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button>
             </div>

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -272,13 +272,20 @@
 .week-scoreboard__title span { color: var(--text-muted); font-size: .66rem; font-weight: 800; letter-spacing: .12em; }
 .week-scoreboard__title h2 { margin: 3px 0 0; font-size: 1.25rem; }
 .schedule-game { display: grid; grid-template-columns: minmax(300px, 1fr) 210px; min-height: 176px; border-bottom: 1px solid var(--gray-light); }
+.schedule-game--unstarted { grid-template-columns: minmax(190px, .85fr) minmax(300px, 1.5fr) 160px; }
 .schedule-game:last-child { border-bottom: 0; }
-.schedule-game__action { display: flex; flex-direction: column; justify-content: center; padding: 24px 26px; }
+.schedule-game__date, .schedule-game__action { display: flex; flex-direction: column; justify-content: center; padding: 24px 26px; }
+.schedule-game__date { border-right: 1px solid var(--gray-light); }
+.schedule-game__date strong { margin-bottom: 8px; font-size: .88rem; }
+.schedule-game__date span { color: var(--text-muted); font-size: .72rem; }
+.schedule-game__date small { margin-top: 9px; color: var(--text-muted); font-size: .66rem; }
 .schedule-game__teams { display: grid; align-content: center; padding: 18px 46px; }
 .schedule-game__teams > div { display: grid; grid-template-columns: 42px 1fr auto; align-items: center; gap: 16px; min-height: 64px; }
 .schedule-game__teams img { width: 38px; height: 38px; object-fit: contain; }
 .schedule-game__teams span { display: grid; gap: 3px; }
 .schedule-game__teams strong { font-size: 1.05rem; }
+.schedule-game__team--winner strong, .schedule-game__team--winner > b { font-weight: 900; }
+.schedule-game__team--loser strong, .schedule-game__team--loser > b { color: var(--text-secondary); opacity: .58; }
 .possession-football { margin-left: 5px; font-size: .9rem; font-style: normal; }
 .schedule-game__teams small { color: var(--text-muted); font-size: .65rem; letter-spacing: .06em; }
 .schedule-game__teams b { font-size: 1.55rem; }
@@ -367,6 +374,7 @@
   .league-header { top: 76px; }
   .scores-heading { align-items: start; flex-direction: column; gap: 10px; }
   .schedule-game { grid-template-columns: 1fr 105px; }
+  .schedule-game--unstarted { grid-template-columns: minmax(150px, .8fr) minmax(260px, 1.5fr) 105px; overflow-x: auto; }
   .schedule-game__teams { padding: 12px 18px; }
   .schedule-game__action { padding: 16px 12px; }
   .schedule-center { padding: 14px; }


### PR DESCRIPTION
### Motivation
- Make the scoreboard clearly indicate winners and losers when a game is finished by deemphasizing the losing team and emphasizing the winner. 
- Remove the possession marker for completed games while preserving it for live games to avoid misleading state. 
- Restore the legacy three-column layout for unstarted games so kickoff date/time, network and weather are visible while showing unstarted clocks in minutes:seconds.

### Description
- Updated `apps/web/src/components/league/LeagueSchedule.tsx` to detect `FINAL` and `UNSTARTED` game states, add `schedule-game--unstarted` when appropriate, and render a kickoff/date/network column for unstarted games using a new `kickoffParts` helper. 
- When a game is `FINAL` the component computes `schedule-game__team--winner` / `schedule-game__team--loser` classes and suppresses the possession football for completed games. 
- Unstarted-game clock values are displayed using the existing `formatClock` helper so times are shown as minutes and seconds. 
- Added CSS rules in `apps/web/src/components/league/league.css` for `.schedule-game--unstarted`, `.schedule-game__date`, and winner/loser treatments that use the app's semantic tokens (e.g. `var(--text-secondary)`) so the look remains theme-aware.

### Testing
- Ran `npm run lint`, which completed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` and no new errors. 
- Ran `npm run build`, which produced a successful production build. 
- Ran `git diff --check` to ensure no whitespace/patch problems were introduced and verified the working tree was clean after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e3cf808d48324bf79b6ae54fc91a6)