### PR TITLE
Populate scoreboard records from Games sheet

### DIFF
--- a/apps/web/src/components/league/GameScoreboard.tsx
+++ b/apps/web/src/components/league/GameScoreboard.tsx
@@ -8,10 +8,10 @@ export function GameScoreboard({ game }: { game: LeagueGame }) {
           <img
             className="team-logo"
             src={game.HomeLogo || "https://via.placeholder.com/96"}
-            alt="Home Logo"
+            alt={`${game.Home} logo`}
           />
           <div className="team-name">{game.Home}</div>
-          <div className="team-record">0-0</div>
+          <div className="team-record">{game["Home Record"] || "0-0"}</div>
         </div>
         <div className="score-section">
           <div className="score-row">
@@ -36,10 +36,10 @@ export function GameScoreboard({ game }: { game: LeagueGame }) {
           <img
             className="team-logo"
             src={game.AwayLogo || "https://via.placeholder.com/96"}
-            alt="Away Logo"
+            alt={`${game.Away} logo`}
           />
           <div className="team-name">{game.Away}</div>
-          <div className="team-record">0-0</div>
+          <div className="team-record">{game["Away Record"] || "0-0"}</div>
         </div>
         <div className="score-section">
           <div className="score-row">

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -26,6 +26,8 @@ export type LeagueGame = {
   AwayLogo?: string;
   HomeName?: string;
   AwayName?: string;
+  "Home Record"?: string;
+  "Away Record"?: string;
 };
 
 export type LeagueTeam = Record<string, string | number | undefined> & {


### PR DESCRIPTION
### Motivation
- The Games sheet now exposes `Home Record` and `Away Record` columns, and the scoreboard header should display those records under each team logo with a safe fallback.

### Description
- Add `"Home Record"` and `"Away Record"` to the `LeagueGame` type in `types.ts`.
- Render `game["Home Record"]` and `game["Away Record"]` in `GameScoreboard.tsx`, falling back to `"0-0"` when missing.
- Improve logo accessibility by updating the logo `alt` attributes to include the team abbreviation via the `game.Home` / `game.Away` values.

### Testing
- Ran `npm run lint`, which completed with no errors and one pre-existing React Hooks warning in `GameField.tsx`.
- Ran `npm run build`, which succeeded and produced a production build.
- Ran `git diff --check`, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e3e42e3f883249066eeeaae080e7d)