### PR TITLE
Show scheduled scorecards when quarter is blank

### DIFF
--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -51,9 +51,9 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
       <section className="week-scoreboard">
         <div className="week-scoreboard__title"><div><span>WEEK {activeWeek}</span><h2>{finalGames ? "Scores & Results" : "Upcoming Games"}</h2></div><span>{weekGames.length} {weekGames.length === 1 ? "GAME" : "GAMES"}</span></div>
         {weekGames.length ? weekGames.map((game) => {
-          const gameStatus = String(game.Qtr).toUpperCase();
+          const gameStatus = String(game.Qtr ?? "").trim().toUpperCase();
           const final = gameStatus === "FINAL";
-          const unstarted = gameStatus === "UNSTARTED";
+          const unstarted = gameStatus === "" || gameStatus === "UNSTARTED";
           const possession = String(game.Possession).toLowerCase();
           const awayScore = Number(game.AwayScore);
           const homeScore = Number(game.HomeScore);
@@ -65,12 +65,12 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
           <article className={`schedule-game ${unstarted ? "schedule-game--unstarted" : ""}`} key={String(game.GameId)}>
             {kickoff && <div className="schedule-game__date"><strong>{kickoff.date}</strong><span>{kickoff.time} · {game.Network || "Network TBD"}</span>{game.Weather && <small>{game.Weather}</small>}</div>}
             <div className="schedule-game__teams">
-              <div className={resultClass(awayScore, homeScore)}><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away} {!final && possession === "away" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
-              <div className={resultClass(homeScore, awayScore)}><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home} {!final && possession === "home" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
+              <div className={resultClass(awayScore, homeScore)}><img src={game.AwayLogo || "/favicon.svg"} alt="" /><span><strong>{game.AwayName || game.Away} {!final && !unstarted && possession === "away" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>AWAY · {game.Away}</small></span><b>{game.AwayScore}</b></div>
+              <div className={resultClass(homeScore, awayScore)}><img src={game.HomeLogo || "/favicon.svg"} alt="" /><span><strong>{game.HomeName || game.Home} {!final && !unstarted && possession === "home" && <i className="possession-football" aria-label="Possession">🏈</i>}</strong><small>HOME · {game.Home}</small></span><b>{game.HomeScore}</b></div>
             </div>
             <div className="schedule-game__action">
               <div className="schedule-game__situation">
-                {final ? <strong>FINAL</strong> : unstarted ? <strong>Q1 · {formatClock(game.Time)}</strong> : <><strong>{formatDownDistance(game.Down, game.Distance)}</strong><span>Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span><small>Q{game.Qtr} · {formatClock(game.Time)}</small></>}
+                {final ? <strong>FINAL</strong> : unstarted ? <strong>PRE-GAME</strong> : <><strong>{formatDownDistance(game.Down, game.Distance)}</strong><span>Ball on {formatBallOnForPoss(game.BallOn, game.Possession)}</span><small>Q{game.Qtr} · {formatClock(game.Time)}</small></>}
               </div>
               <button type="button" onClick={() => onSelectGame(game)}>Gamecast <b>›</b></button>
             </div>


### PR DESCRIPTION
### Motivation
- Games with an empty `Qtr` value in the Games sheet should be treated as unstarted/scheduled and show pre-game metadata instead of live-game details.
- Restore the legacy three-column pre-game scorecard that includes kickoff date/time, network, and weather for scheduled games.
- Prevent possession and live down/distance/ball-on UI from appearing for unstarted games until a valid quarter value exists.
- Keep compatibility with the existing `UNSTARTED` marker while also handling null/blank/whitespace `Qtr` values.

### Description
- Normalize and trim `Qtr` and treat `Qtr === ""` (blank), whitespace-only, or `"UNSTARTED"` as `unstarted` in `LeagueSchedule.tsx` by using `String(game.Qtr ?? "").trim().toUpperCase()` and `const unstarted = gameStatus === "" || gameStatus === "UNSTARTED"`.
- Render the three-column pre-game layout for unstarted games using the existing `schedule-game--unstarted` class and `kickoffParts(game)` to display kickoff date/time, network, and `Weather` when present.
- Hide possession indicators and live situation elements for unstarted games by gating the possession icon and down/distance/ball-on markup behind `!unstarted` and replace the live situation with the label `PRE-GAME`.
- Preserve winner/loser styling and score rendering and only compute live down/distance/clock UI for non-unstarted games.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing React Hooks warning in `GameField.tsx` (warning only).
- Ran `npm run build`, which completed successfully and produced the production build artifacts.
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e406fc70c832480acd02b5e8dd06b)