### PR TITLE
Track lead blockers in play history and in-game OL stats

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -298,6 +298,7 @@ function playValueForHeader(play: Record<string, unknown>, header: string) {
     ollosses: ["olLosses", "ollosses"],
     dlwins: ["dlWins", "dlwins"],
     dllosses: ["dlLosses", "dllosses"],
+    leadblocker: ["leadblocker", "leadBlocker"],
     jukes: ["jukes"],
     trucks: ["trucks"],
     brokentackles: ["brokenTackles", "brokentackles"],

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -91,6 +91,7 @@ type Stat = {
   dLineLosses?: number;
   oLineWins?: number;
   oLineLosses?: number;
+  leadBlocks?: number;
 };
 const str = (v: unknown) => String(v ?? "");
 const num = (v: unknown) => Number(v) || 0;
@@ -567,6 +568,13 @@ function calcStats(history: Play[]) {
         else if (m.winner === "OL") s.dLineLosses = (s.dLineLosses || 0) + 1;
       }
     });
+    const leadBlocker = str(
+      playField(p, "leadblocker", "LeadBlocker", "leadBlocker"),
+    ).trim();
+    if (leadBlocker) {
+      const s = get(offball, leadBlocker, team);
+      s.leadBlocks = (s.leadBlocks || 0) + 1;
+    }
     if (type === "Pass" || isSack) {
       if (qb) {
         const s = get(pass, qb, team);
@@ -830,11 +838,36 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
         p.ints || 0,
         p.deflections || 0,
       ]);
-  const offballRows = (team: string) =>
-    stats.offball
+  const offballRows = (team: string) => {
+    const rows = stats.offball
       .filter((p) => p.team === team)
-      .sort((a, b) => (b.oLineWins || 0) - (a.oLineWins || 0))
-      .map((p) => [p.playername, p.oLineWins || 0, p.oLineLosses || 0]);
+      .sort((a, b) => (b.oLineWins || 0) - (a.oLineWins || 0));
+    const totals = rows.reduce(
+      (total, player) => ({
+        wins: total.wins + (player.oLineWins || 0),
+        losses: total.losses + (player.oLineLosses || 0),
+        leadBlocks: total.leadBlocks + (player.leadBlocks || 0),
+      }),
+      { wins: 0, losses: 0, leadBlocks: 0 },
+    );
+    const winPct = (wins: number, losses: number) =>
+      `${(wins + losses ? (wins / (wins + losses)) * 100 : 0).toFixed(1)}%`;
+    const output: (string | number)[][] = rows.map((p) => [
+      p.playername,
+      p.oLineWins || 0,
+      p.oLineLosses || 0,
+      p.leadBlocks || 0,
+      winPct(p.oLineWins || 0, p.oLineLosses || 0),
+    ]);
+    output.push([
+      "TEAM",
+      totals.wins,
+      totals.losses,
+      totals.leadBlocks,
+      winPct(totals.wins, totals.losses),
+    ]);
+    return output;
+  };
   const teamName = (t: string) => (t === "Home" ? game.Home : game.Away);
   const renderTeam = (team: string) => (
     <>
@@ -880,8 +913,8 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
         rows={defRows(team)}
       />
       <TeamTable
-        title={`${teamName(team)} Offensive Offball`}
-        columns={["Player", "OL W", "OL L"]}
+        title={`${teamName(team)} Offensive Line`}
+        columns={["Player", "OL W", "OL L", "LEAD", "WIN %"]}
         rows={offballRows(team)}
       />
     </>

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -560,6 +560,12 @@ export function runPlay(
       olLosses: dlWins,
       dlWins,
       dlLosses: olWins,
+      // A lead blocker is credited only when the runner sees and hits an OL-won
+      // lane. Missed-hole plays intentionally leave the sheet cell empty.
+      leadblocker:
+        visionCheck.getsPastDL && runLaneTarget.selectedSide === "OL"
+          ? runLaneTarget.selectedPlayer
+          : "",
       trucks: successfulTrucks,
       brokenTackles: successfulTrucks,
       jukes: successfulJukes,


### PR DESCRIPTION
### Motivation
- Record which offensive lineman created the running lane so play history and live stats can report lead-block credits alongside OL win/loss data.
- Surface lead-block counts and OL win percentage in the in-game Offensive Line table so team and player OL metrics update during play and on page load.

### Description
- Added `leadblocker` to the play header aliases so the API will read `leadblocker` / `leadBlocker` from PlayHistory rows when normalizing play records (`apps/api/src/routes/gameRoutes.ts`).
- Log the lead blocker for generated run plays by writing `leadblocker` when the runner successfully hits an OL-won lane, leaving the field empty for missed-hole plays (`apps/web/src/components/league/gameplay/engine/runEngine.ts`).
- Aggregate lead-block credits from play history into the UI stat rollup by parsing `leadblocker` values and counting per-player lead blocks (`apps/web/src/components/league/GameCenter.tsx`).
- Expanded the Offensive Line (Offensive Offball) table to include a `LEAD` column, a calculated `WIN %` column, and an always-present team totals row that sums wins, losses, and lead blocks (`apps/web/src/components/league/GameCenter.tsx`).
- Kept UI changes theme-aware and used existing shared table components and styles consistent with the app’s semantic tokens (no fixed color or chrome additions).

### Testing
- Ran frontend production build with `cd apps/web && npm run build`, which completed successfully.
- Ran frontend linter with `cd apps/web && npm run lint`, which passed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`.
- Typechecked the API with `cd apps/api && npm run typecheck`, which succeeded.
- Ran API unit tests with `cd apps/api && npm test`, all tests passed (3/3).
- Verified `git diff --check` and committed the changes; no diff-check failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e45e2c54083248787ebdd24e3e59c)