### PR TITLE
Include lead blocks in player stats responses

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -85,7 +85,7 @@ async function getTeamPlayers(teamAbbrev: string) {
   const [assignments, players, playerStats, jerseys] = await Promise.all([
     readSheetObjects("PlayerTeams!A1:B"),
     readSheetObjects("Players!A1:AM"),
-    readSheetObjects("PlayerStats!A1:AI"),
+    readSheetObjects("PlayerStats!A1:AJ"),
     getTeamJerseys(),
   ]);
   const teamKey = teamAbbrev.trim().toLowerCase();
@@ -396,7 +396,7 @@ async function savePlayAndGameWithRetry(data: Record<string, unknown>, gameId: s
 
 gameRoutes.get("/health", (_req, res) => res.json({ ok: true, app: "football-game-api", message: "API is running" }));
 gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await getPlayersWithTeamJerseys() }); } catch (e) { next(e); } });
-gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AI") }); } catch (e) { next(e); } });
+gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AJ") }); } catch (e) { next(e); } });
 gameRoutes.get("/players/:playerName/games", async (req, res, next) => {
   try {
     const [gamesSheet, historySheet] = await Promise.all([sheetRows("Games"), sheetRows("PlayHistory")]);


### PR DESCRIPTION
### Motivation
- Ensure the lead-blocker stat from the PlayerStats sheet is returned in APIs and included on team roster player records so the UI can display "Lead Block" values.

### Description
- Read `PlayerStats` through column `AJ` instead of `AI` when loading roster stats in `getTeamPlayers` by calling `readSheetObjects("PlayerStats!A1:AJ")`.
- Return `playerStats` from `GET /player-stats` using `readSheetObjects("PlayerStats!A1:AJ")` so the lead-block column is present in the API response.
- No other logic changes; the extra column will be available on `playerStats` responses and the `Stats` property on team player objects.

### Testing
- Ran `cd apps/api && npm test` and all tests passed.
- Ran `cd apps/api && npm run typecheck` and TypeScript checks passed.
- Ran `cd apps/web && npm run build` and the web build completed successfully.
- Ran `cd apps/web && npm run lint` and lint completed (one existing React hook dependency warning remains).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e4759c7a08324a482bfb5e34aceea)