### PR TITLE
Add matchup-specific uniforms and pregame team preview

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -56,7 +56,7 @@ async function getStandingsFromSheet() {
     .filter((row) => standingsAbbrev(row) !== "")
     .map((row) => ({ ...row, Abbrev: standingsAbbrev(row) }));
 }
-async function getTeamJerseys() {
+async function getTeamJerseys(column: "Home Jersey Crop" | "Away Jersey Crop" = "Away Jersey Crop") {
   const teams = await getTeamsFromSheet();
   const jerseys = new Map<string, unknown>();
   const add = (key: unknown, jersey: unknown) => {
@@ -64,7 +64,7 @@ async function getTeamJerseys() {
     if (normalized && jersey) jerseys.set(normalized, jersey);
   };
   teams.forEach((team) => {
-    const jersey = team.Jersey;
+    const jersey = team[column];
     add(team.Team, jersey);
     add(team.Name, jersey);
     add(team.Abbrev, jersey);
@@ -74,7 +74,7 @@ async function getTeamJerseys() {
 async function getPlayersWithTeamJerseys() {
   const [players, jerseys] = await Promise.all([
     readSheetObjects("Players!A1:AM"),
-    getTeamJerseys(),
+    getTeamJerseys("Away Jersey Crop"),
   ]);
   return players.map((player) => ({
     ...player,
@@ -86,7 +86,7 @@ async function getTeamPlayers(teamAbbrev: string) {
     readSheetObjects("PlayerTeams!A1:B"),
     readSheetObjects("Players!A1:AM"),
     readSheetObjects("PlayerStats!A1:AJ"),
-    getTeamJerseys(),
+    getTeamJerseys("Away Jersey Crop"),
   ]);
   const teamKey = teamAbbrev.trim().toLowerCase();
   const rosterNames = new Set(
@@ -232,7 +232,9 @@ async function updateGameplaySetting(variable: string, value: string) {
   }]);
 }
 async function getPlayerTraitsFromSheet() {
-  const jerseys = await getTeamJerseys();
+  // Player-trait consumers outside a live matchup (including stats views) use
+  // the away crop. GameCenter replaces this with the matchup-specific crop.
+  const jerseys = await getTeamJerseys("Away Jersey Crop");
   const { headers, rows } = await sheetRows("Players"); const headerIndex: Record<string, number> = {};
   headers.forEach((h, i) => { const k = normHeader(h); if (k) headerIndex[k] = i; });
   const val = (row: Row, ...hs: string[]) => { for (const h of hs) { const i = headerIndex[normHeader(h)]; if (i !== undefined) return row[i] ?? ""; } return ""; };

--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -65,3 +65,31 @@
     right: clamp(10px, 3vw, 16px);
   }
 }
+.pregame-matchup {
+  margin: 18px auto;
+  padding: clamp(18px, 3vw, 32px);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: var(--gray-medium);
+  box-shadow: 0 8px 28px var(--shadow-color);
+}
+
+.pregame-heading { margin-bottom: 20px; text-align: center; }
+.pregame-heading span, .pregame-team-card header span { color: var(--text-muted); font-size: .7rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.pregame-heading h1, .pregame-team-card h2 { margin: 5px 0 0; color: var(--text-light); }
+.pregame-team-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.pregame-team-card { overflow: hidden; border: 1px solid var(--border-color); border-radius: 12px; background: var(--gray-dark); }
+.pregame-team-card header { display: flex; align-items: center; gap: 13px; padding: 16px; border-bottom: 1px solid var(--border-color); }
+.pregame-team-card h2 { font-size: 1.05rem; }
+.pregame-team-logo { width: 48px; height: 48px; object-fit: contain; }
+.pregame-uniform { display: grid; min-height: 260px; place-items: center; padding: 16px; background: var(--gray-light); color: var(--text-muted); }
+.pregame-uniform img { display: block; width: 100%; max-width: 260px; height: 280px; object-fit: contain; }
+.pregame-team-card section { padding: 16px; }
+.pregame-team-card h3 { margin: 0 0 10px; color: var(--text-light); font-size: .8rem; letter-spacing: .1em; text-transform: uppercase; }
+.pregame-leader { display: grid; grid-template-columns: 82px 1fr auto; gap: 10px; padding: 9px 0; border-top: 1px solid var(--border-color); color: var(--text-secondary); font-size: .8rem; }
+.pregame-leader span { color: var(--text-muted); }
+.pregame-leader b { color: var(--text-light); }
+
+@media (max-width: 700px) {
+  .pregame-team-grid { grid-template-columns: 1fr; }
+}

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -11,6 +11,7 @@ import {
 import {
   getFrontendSettings,
   getGameState,
+  getPlayerStats,
   getTeams,
   getPlayerTraits,
   getPlayHistory,
@@ -42,6 +43,16 @@ import type {
 const EXPECTED_PLAYERS_PER_SIDE = 8;
 const teamValue = (team: LeagueTeam | undefined, key: string) =>
   String(team?.[key] ?? "").trim();
+const normalizedTeamKey = (value: unknown) => String(value ?? "").trim().toLowerCase();
+const matchesTeam = (team: LeagueTeam, key: unknown) => {
+  const wanted = normalizedTeamKey(key);
+  return [team.Abbrev, team.Team, team.Name, `${team.Location ?? team.City ?? ""} ${team.Name ?? team.Nickname ?? ""}`]
+    .some((value) => normalizedTeamKey(value) === wanted);
+};
+const isPregame = (game: LeagueGame) => {
+  const quarter = String(game.Qtr ?? "").trim().toUpperCase();
+  return !quarter || quarter === "0" || quarter === "UNSTARTED" || quarter === "PREGAME";
+};
 
 type Play = Record<string, unknown>;
 type LineStatMatchup = {
@@ -1392,6 +1403,51 @@ function ScoreChart({ game, history }: { game: LeagueGame; history: Play[] }) {
     </div>
   );
 }
+const seasonStat = (row: Record<string, string>, ...keys: string[]) => {
+  for (const key of keys) {
+    const value = row[key];
+    if (value !== undefined && value !== "") return Number(value) || 0;
+  }
+  return 0;
+};
+
+function PregameMatchup({
+  game,
+  home,
+  away,
+  players,
+  stats,
+}: {
+  game: LeagueGame;
+  home?: LeagueTeam;
+  away?: LeagueTeam;
+  players: Play[];
+  stats: Record<string, string>[];
+}) {
+  const playerTeam = new Map(players.map((player) => [normalizedTeamKey(player.name ?? player.Name), player.team ?? player.Team]));
+  const categories = [
+    { label: "Passing", fields: ["Passing Yards", "Pass Yards", "PassYards"] },
+    { label: "Rushing", fields: ["Rushing Yards", "Rush Yards", "Yards"] },
+    { label: "Receiving", fields: ["Receiving Yards", "Rec Yards", "RecYards"] },
+    { label: "Tackles", fields: ["Tackles", "TKL"] },
+    { label: "Sacks", fields: ["Sacks", "SACK"] },
+  ];
+  const leader = (team: LeagueTeam | undefined, fields: string[]) => stats
+    .filter((row) => matchesTeam(team ?? {}, playerTeam.get(normalizedTeamKey(row.Player ?? row.Name))))
+    .map((row) => ({ name: String(row.Player ?? row.Name ?? "—"), value: seasonStat(row, ...fields) }))
+    .sort((a, b) => b.value - a.value)[0];
+  const teamCard = (team: LeagueTeam | undefined, side: "home" | "away") => {
+    const abbrev = String(team?.Abbrev ?? (side === "home" ? game.Home : game.Away));
+    const uniform = teamValue(team, side === "home" ? "Home Uniform" : "Away Uniform");
+    return <article className="pregame-team-card">
+      <header><TeamLogo src={team?.Logo} className="pregame-team-logo" alt="" /><div><span>{side} team</span><h2>{teamValue(team, "Location") || teamValue(team, "City")} {teamValue(team, "Name") || abbrev}</h2></div></header>
+      <div className="pregame-uniform">{uniform ? <img src={uniform} alt={`${abbrev} ${side} uniform`} /> : <span>Uniform unavailable</span>}</div>
+      <section><h3>Season Leaders</h3>{categories.map((category) => { const result = leader(team, category.fields); return <div className="pregame-leader" key={category.label}><span>{category.label}</span><strong>{result?.name ?? "—"}</strong><b>{result?.value.toLocaleString() ?? "—"}</b></div>; })}</section>
+    </article>;
+  };
+  return <section className="pregame-matchup" aria-label="Pregame matchup details"><div className="pregame-heading"><span>Pregame matchup</span><h1>Today's uniforms &amp; season leaders</h1></div><div className="pregame-team-grid">{teamCard(away, "away")}{teamCard(home, "home")}</div></section>;
+}
+
 /**
  * Main live-game container. It loads API data, owns the current tab and live
  * game state, coordinates the field/controls components, dispatches play calls
@@ -1411,6 +1467,7 @@ export function GameCenter({
   const [history, setHistory] = useState<Play[]>([]);
   const [players, setPlayers] = useState<Play[]>([]);
   const [teams, setTeams] = useState<LeagueTeam[]>([]);
+  const [seasonStats, setSeasonStats] = useState<Record<string, string>[]>([]);
   const [settings, setSettings] = useState<FrontendSettings>(
     normalizeFrontendSettings({}),
   );
@@ -1425,7 +1482,7 @@ export function GameCenter({
   ]);
   const [isSavingPlay, setIsSavingPlay] = useState(false);
   const [isResettingPlay, setIsResettingPlay] = useState(false);
-  const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(false);
+  const [isGameFieldCollapsed, setIsGameFieldCollapsed] = useState(() => isPregame(game));
   const [settingFormation, setSettingFormation] = useState(false);
   const [autoCloseFormationOnSave, setAutoCloseFormationOnSave] =
     useState(false);
@@ -1449,10 +1506,12 @@ export function GameCenter({
     const homeAbbrev = String(currentGame.Home || "")
       .trim()
       .toLowerCase();
-    return teams.find(
-      (team) => teamValue(team, "Abbrev").toLowerCase() === homeAbbrev,
-    );
+    return teams.find((team) => matchesTeam(team, homeAbbrev));
   }, [currentGame.Home, teams]);
+  const awayTeamDetails = useMemo(
+    () => teams.find((team) => matchesTeam(team, currentGame.Away)),
+    [currentGame.Away, teams],
+  );
   useEffect(() => {
     let active = true;
     Promise.all([
@@ -1461,11 +1520,20 @@ export function GameCenter({
       getPlayerTraits(),
       getFrontendSettings(),
       getTeams(),
+      getPlayerStats(),
     ])
-      .then(([stateRes, historyRes, playerRes, settingsRes, teamsRes]) => {
+      .then(([stateRes, historyRes, playerRes, settingsRes, teamsRes, statsRes]) => {
         if (!active) return;
         const loadedSettings = normalizeFrontendSettings(settingsRes);
-        const loadedPlayers = playerRes.players.map((player) => ({ ...player }));
+        const loadedTeams = teamsRes.teams as LeagueTeam[];
+        const loadedPlayers = playerRes.players.map((player) => {
+          const team = loadedTeams.find((candidate) => matchesTeam(candidate, player.team));
+          const homePlayer = matchesTeam(team ?? {}, game.Home);
+          return {
+            ...player,
+            jersey: teamValue(team, homePlayer ? "Home Jersey Crop" : "Away Jersey Crop"),
+          };
+        });
         applyFatigueFromPlayHistory(
           {
             players: loadedPlayers,
@@ -1474,10 +1542,13 @@ export function GameCenter({
           },
           historyRes.plays,
         );
-        setCurrentGame(normalizeGame(game, stateRes.gameState));
+        const normalizedGame = normalizeGame(game, stateRes.gameState);
+        setCurrentGame(normalizedGame);
+        setIsGameFieldCollapsed(isPregame(normalizedGame));
         setHistory(historyRes.plays);
         setPlayers(loadedPlayers);
-        setTeams(teamsRes.teams as LeagueTeam[]);
+        setTeams(loadedTeams);
+        setSeasonStats(statsRes.playerStats);
         setSettings(loadedSettings);
         setLog(
           historyRes.plays.length
@@ -1669,6 +1740,15 @@ export function GameCenter({
               </div>
             </div>
           </div>
+          {isPregame(currentGame) && (
+            <PregameMatchup
+              game={currentGame}
+              home={homeTeamDetails}
+              away={awayTeamDetails}
+              players={players}
+              stats={seasonStats}
+            />
+          )}
           <div
             className={`field-console-stage ${isGameFieldCollapsed ? "field-collapsed" : ""}`}
           >

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -31,6 +31,7 @@ export type LeagueGame = {
 };
 
 export type LeagueTeam = Record<string, string | number | undefined> & {
+  ID?: string | number;
   Team?: string;
   Name?: string;
   City?: string;
@@ -38,6 +39,15 @@ export type LeagueTeam = Record<string, string | number | undefined> & {
   Division?: string;
   Logo?: string;
   Abbrev?: string;
+  Location?: string;
+  "Home Jersey Crop"?: string;
+  "Away Jersey Crop"?: string;
+  "Home Uniform"?: string;
+  "Away Uniform"?: string;
+  "Primary Color"?: string;
+  "secondary color"?: string;
+  "third color"?: string;
+  CapSpace?: string | number;
   Wins?: string | number;
   Losses?: string | number;
   Ties?: string | number;


### PR DESCRIPTION
### Motivation
- Support the expanded Teams sheet with separate home/away jersey crops and full-uniform assets so the UI can show correct uniforms in-context. 
- Use the away jersey crop as the canonical uniform for non-live views (player stats, rosters, etc.) while applying matchup-specific crops during live games. 
- Improve pregame UX by hiding the live field by default and surfacing matchup details and season leaders when a game is unstarted.

### Description
- Read `Home Jersey Crop` and `Away Jersey Crop` from the Teams sheet via `getTeamJerseys(column)` and default non-game consumers to the away crop (API changes in `apps/api/src/routes/gameRoutes.ts`).
- Ensure player endpoints (`/players`, team rosters) return the away crop by default so stats and player views use the away jersey (`Jersey` field population updated). 
- In `GameCenter` load matchup data and assign `Home Jersey Crop` to home-team players and `Away Jersey Crop` to away-team players for in-game sprites, and add helpers `matchesTeam`/`isPregame` for robust team matching and pregame detection (`apps/web/src/components/league/GameCenter.tsx`).
- Add a `PregameMatchup` component and styles to show each team’s scheduled full uniform and season leaders (passing, rushing, receiving, tackles, sacks) when a game is pregame, and default the field panel collapsed for pregame states (`apps/web/src/components/league/GameCenter.css`, `GameCenter.tsx`).
- Extend `LeagueTeam` typing to include the new Teams sheet columns like `Home Jersey Crop`, `Away Jersey Crop`, `Home Uniform`, `Away Uniform`, colors, `CapSpace`, and `Location` (`apps/web/src/components/league/types.ts`).

### Testing
- Ran the web production build with `cd apps/web && npm run build` which completed successfully. 
- Ran web lint with `cd apps/web && npm run lint` which succeeded with one pre-existing `react-hooks/exhaustive-deps` warning (no new lint errors). 
- Ran API unit tests with `cd apps/api && npm test` and all tests passed. 
- Ran API typecheck with `cd apps/api && npm run typecheck` which completed with no errors, and verified `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6e495e94048324b9103155d2d7e028)