### PR TITLE
On-field pass setup: fade defense, highlight eligibles, depth+route selection, QB read ordering

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1476,6 +1476,7 @@ export function GameCenter({
     formation: {},
     routes: {},
     reads: {},
+    routeDepths: {},
   });
   const [log, setLog] = useState([
     "Loading game state, play history, players, and frontend settings...",
@@ -1487,6 +1488,8 @@ export function GameCenter({
   const [autoCloseFormationOnSave, setAutoCloseFormationOnSave] =
     useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
+  const [passSetup, setPassSetup] = useState(false);
+  const [selectedRoutePlayer, setSelectedRoutePlayer] = useState("");
   const [animationRequest, setAnimationRequest] = useState<{
     id: number;
     plan: AnimationPlan;
@@ -1579,11 +1582,14 @@ export function GameCenter({
       formation: {},
       routes: {},
       reads: {},
+      routeDepths: {},
       runner: undefined,
       defense: [],
     }));
     setSettingFormation(false);
     setSelectedFormationPlayer("");
+    setPassSetup(false);
+    setSelectedRoutePlayer("");
   }, [currentGame.Possession]);
   const persist = async (result: ReturnType<typeof runPlay>) => {
     if (playInFlightRef.current) return;
@@ -1780,6 +1786,24 @@ export function GameCenter({
                 distance={currentGame.Distance}
                 possession={currentGame.Possession}
                 selectedFormationPlayer={selectedFormationPlayer}
+                passSetup={passSetup}
+                routes={playOptions.routes}
+                routeDepths={playOptions.routeDepths}
+                reads={playOptions.reads}
+                selectedRoutePlayer={selectedRoutePlayer}
+                onRoutePlayerSelect={setSelectedRoutePlayer}
+                onPassOptionsChange={(patch) =>
+                  setPlayOptions((current) => ({ ...current, ...patch }))
+                }
+                onPassSetupClose={() => {
+                  setPassSetup(false);
+                  setSelectedRoutePlayer("");
+                }}
+                onPassPlay={() => {
+                  setPassSetup(false);
+                  setSelectedRoutePlayer("");
+                  action("Pass Play", playOptions);
+                }}
                 homeLogo={
                   teamValue(homeTeamDetails, "Logo") || currentGame.HomeLogo
                 }
@@ -1882,6 +1906,10 @@ export function GameCenter({
                   selectedFormationPlayer={selectedFormationPlayer}
                   requestedFormationMode={settingFormation}
                   disabled={isSavingPlay || isResettingPlay}
+                  onPassSetupChange={(active) => {
+                    setPassSetup(active);
+                    setSelectedRoutePlayer("");
+                  }}
                 />
               </GameField>
             </div>

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -35,6 +35,7 @@ type Props = {
   selectedFormationPlayer?: string;
   requestedFormationMode?: boolean;
   disabled?: boolean;
+  onPassSetupChange?: (active: boolean) => void;
 };
 
 /**
@@ -335,6 +336,7 @@ export function GameControls({
   selectedFormationPlayer = "",
   requestedFormationMode,
   disabled = false,
+  onPassSetupChange,
 }: Props) {
   const [activeMenu, setActiveMenu] = useState<"coach" | "play" | null>(null);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | "roster" | null>(null);
@@ -366,9 +368,6 @@ export function GameControls({
   const validFormation =
     formationPlayerCount === EXPECTED_PLAYERS_PER_SIDE &&
     [...REQUIRED].every((slot) => formation[slot]);
-  const canPass = receivers.some(
-    (r) => routes[r.player] && routes[r.player] !== "No Route",
-  );
   const pendingPointAfter = Boolean(
     (game as unknown as Record<string, unknown>).pendingFGTeam,
   );
@@ -518,8 +517,8 @@ export function GameControls({
               <button
                 disabled={disabled || !validFormation}
                 onClick={() => {
-                  if (!canPass) setModal("routes");
-                  else onAction("Pass Play", optionsWithDefense());
+                  setActiveMenu(null);
+                  onPassSetupChange?.(true);
                 }}
                 type="button"
               >

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -818,6 +818,111 @@ textarea {
   pointer-events: none;
 }
 
+.pass-setup-active .token.defense,
+.pass-setup-active .field-formation-slot.defense {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 420ms ease;
+}
+
+.pass-route-player {
+  position: absolute;
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  width: 72px;
+  padding: 4px;
+  transform: translate(-50%, -100%);
+  border: 2px solid var(--control-accent);
+  border-radius: 14px;
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--surface-overlay) 82%, transparent);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--control-accent) 24%, transparent), 0 8px 20px var(--shadow-color);
+  font: inherit;
+  font-size: 10px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.pass-route-player.assigned { border-color: var(--control-border-hover); }
+.pass-route-player.selected { box-shadow: 0 0 0 7px color-mix(in srgb, var(--control-accent) 48%, transparent), 0 8px 20px var(--shadow-color); }
+.pass-route-player__image { width: 44px; height: 52px; overflow: hidden; }
+.pass-route-player__image .player-image-layers { width: 100%; height: 100%; }
+.pass-route-qb { z-index: 210; }
+
+.pass-route-sheet,
+.qb-read-bubble,
+.pass-setup-toolbar {
+  position: sticky;
+  z-index: 310;
+  color: var(--text-primary);
+  background: var(--surface-overlay);
+  border: 1px solid var(--control-border);
+  box-shadow: 0 14px 34px var(--shadow-color);
+}
+
+.pass-setup-toolbar {
+  top: 12px;
+  left: 50%;
+  width: min(620px, calc(100% - 24px));
+  min-height: 64px;
+  margin: 12px auto 0;
+  padding: 10px 12px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.pass-setup-toolbar > div { display: grid; margin-right: auto; }
+.pass-setup-toolbar span, .pass-route-sheet > div span, .qb-read-bubble > span { color: var(--text-secondary); font-size: 12px; }
+.pass-setup-toolbar button, .pass-route-sheet > button, .qb-read-list button {
+  border: 1px solid var(--control-border);
+  border-radius: 10px;
+  padding: 9px 12px;
+  color: var(--text-primary);
+  background: var(--control-bg);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+.pass-setup-toolbar button:hover, .pass-route-sheet > button:hover, .qb-read-list button:hover { background: var(--control-bg-hover); border-color: var(--control-border-hover); }
+.pass-setup-toolbar button:disabled { opacity: .55; cursor: not-allowed; }
+
+.pass-route-sheet {
+  top: calc(100% - 176px);
+  width: min(720px, calc(100% - 24px));
+  min-height: 150px;
+  margin: 0 auto;
+  padding: 16px;
+  border-radius: 18px 18px 0 0;
+  display: flex;
+  align-items: end;
+  gap: 14px;
+}
+.pass-route-sheet > div { display: grid; margin-right: auto; align-self: center; }
+.pass-route-sheet label { display: grid; gap: 5px; color: var(--text-secondary); font-size: 12px; font-weight: 800; }
+
+.qb-read-bubble {
+  top: 90px;
+  width: min(760px, calc(100% - 24px));
+  margin: 0 auto;
+  padding: 14px;
+  border-radius: 18px;
+  display: grid;
+  gap: 5px;
+}
+.qb-read-list { display: flex; gap: 8px; overflow-x: auto; padding-top: 7px; }
+.qb-read-list button { white-space: nowrap; }
+.qb-read-list b { color: var(--control-accent); }
+.qb-read-list em { color: var(--text-secondary); }
+
+@media (max-width: 680px) {
+  .pass-route-sheet { align-items: stretch; flex-wrap: wrap; top: calc(100% - 270px); }
+  .pass-route-sheet > div { width: 100%; }
+  .pass-route-sheet label { flex: 1; }
+  .pass-setup-toolbar span { display: none; }
+}
+
 /* Full-body player presentation shared by formation setup and live plays. */
 .token {
   --player-size: clamp(46px, 5.5vw, 64px);

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import type { DefensiveAssignment, FormationSlot } from "./gameplay/gameEngine";
 import { PlayerImage } from "../players/PlayerImage";
 import { playerImageUrl, playerJerseyUrl } from "../players/playerImageUrls";
+import { AppSelect } from "../ui/AppSelect";
 
 import "./GameField.css";
 
@@ -265,6 +266,19 @@ const REQUIRED_FORMATION_SLOTS = new Set<FormationSlot>([
   "C",
   "RG",
 ]);
+const PASS_ROUTE_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4", "RB1", "RB2", "LT", "RT"];
+const ROUTE_DEPTHS = ["Quick", "Short", "Short-Mid", "Mid", "Mid-Long", "Long", "Deep", "Shot", "Bomb"];
+const ROUTES_BY_DEPTH: Record<string, string[]> = {
+  Quick: ["WR Screen", "Flat", "Swing", "Hitch", "Out", "Slant", "Drag"],
+  Short: ["Flat", "Swing", "Hitch", "Out", "Slant", "Drag", "Cross"],
+  "Short-Mid": ["Hitch", "Out", "Slant", "Drag", "Cross", "In", "Curl", "Wheel"],
+  Mid: ["Out", "Slant", "Cross", "In", "Curl", "Dig", "Wheel"],
+  "Mid-Long": ["Out", "Cross", "In", "Curl", "Dig", "Wheel", "Comeback", "Corner", "Seam"],
+  Long: ["Cross", "Wheel", "Comeback", "Corner", "Seam", "Fade", "Go", "Post", "Sluggo"],
+  Deep: ["Cross", "Comeback", "Corner", "Seam", "Fade", "Go", "Post", "Sluggo"],
+  Shot: ["Cross", "Corner", "Seam", "Fade", "Go", "Post", "Sluggo", "Post Corner"],
+  Bomb: ["Corner", "Seam", "Fade", "Go", "Post", "Post Corner"],
+};
 const nameOf = (p?: FormationPlayer) => String(p?.name ?? p?.Name ?? "");
 const imgOf = (p?: FormationPlayer) => playerImageUrl(p);
 
@@ -423,6 +437,15 @@ export default function GameField({
   onSetupTransitionChange,
   animationRequest,
   onAnimationComplete,
+  passSetup = false,
+  routes = {},
+  routeDepths = {},
+  reads = {},
+  selectedRoutePlayer = "",
+  onRoutePlayerSelect,
+  onPassOptionsChange,
+  onPassSetupClose,
+  onPassPlay,
   children,
 }: {
   formationMode?: boolean;
@@ -445,6 +468,15 @@ export default function GameField({
   onSetupTransitionChange?: (active: boolean) => void;
   animationRequest?: { id: number; plan: unknown } | null;
   onAnimationComplete?: (id: number) => void;
+  passSetup?: boolean;
+  routes?: Record<string, string>;
+  routeDepths?: Record<string, string>;
+  reads?: Record<string, string>;
+  selectedRoutePlayer?: string;
+  onRoutePlayerSelect?: (player: string) => void;
+  onPassOptionsChange?: (patch: { routes?: Record<string, string>; routeDepths?: Record<string, string>; reads?: Record<string, string> }) => void;
+  onPassSetupClose?: () => void;
+  onPassPlay?: () => void;
   children?: ReactNode;
 }) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
@@ -490,6 +522,32 @@ export default function GameField({
   const formationFirstDownYard = clampYard(
     formationLosYard + offenseDirection * formationDistance,
   );
+  const eligibleRoutePlayers = PASS_ROUTE_SLOTS.flatMap((slot) =>
+    formation[slot] ? [{ slot, player: formation[slot] as string }] : [],
+  );
+  const routedPlayers = eligibleRoutePlayers
+    .map(({ player }) => player)
+    .filter((player) => Boolean(routes[player]));
+  const orderedReads = [...routedPlayers].sort(
+    (a, b) => Number(reads[a] || 999) - Number(reads[b] || 999),
+  );
+  const updateReadOrder = (order: string[]) =>
+    onPassOptionsChange?.({
+      reads: Object.fromEntries(order.map((player, index) => [player, String(index + 1)])),
+    });
+
+  useEffect(() => {
+    if (!passSetup) return;
+    const viewport = fieldViewportRef.current;
+    const field = fieldRef.current;
+    if (!viewport || !field) return;
+    const boundaryYard = formationLosYard - offenseDirection * 6;
+    const boundaryPx = field.offsetHeight * (yardToYPct(boundaryYard) / 100);
+    viewport.scrollTo({
+      top: offenseDirection === 1 ? boundaryPx - viewport.clientHeight : boundaryPx,
+      behavior: "smooth",
+    });
+  }, [formationLosYard, offenseDirection, passSetup]);
 
   const buildFormationSetupPlan = useCallback((): AnimationPlan => {
     const losYard = formationLosYard;
@@ -1393,7 +1451,7 @@ export default function GameField({
       <div className="field-viewport" id="fieldViewport" ref={fieldViewportRef}>
         {children && <div className="field-controls-overlay">{children}</div>}
         <div
-          className="field-wrap"
+          className={`field-wrap ${passSetup ? "pass-setup-active" : ""}`}
           id="field"
           ref={fieldRef}
           onClick={() => {
@@ -1436,6 +1494,48 @@ export default function GameField({
             END
           </div>
           <div className="football" id="football" ref={footballRef} />
+          {passSetup && PASS_ROUTE_SLOTS.map((slot) => {
+            const playerName = formation[slot];
+            if (!playerName) return null;
+            const lineup = FORMATION_SLOT_LINEUP[slot];
+            const player = findFormationPlayer(playerName);
+            return (
+              <button
+                key={`route-${slot}`}
+                type="button"
+                className={`pass-route-player ${selectedRoutePlayer === playerName ? "selected" : ""} ${routes[playerName] ? "assigned" : ""}`}
+                style={{
+                  left: `${LANES[lineup.lane] ?? 50}%`,
+                  top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
+                  zIndex: playerDepthZIndex(formationLosYard + offenseDirection * lineup.yardOffsetFromLos) + 1,
+                }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRoutePlayerSelect?.(playerName);
+                }}
+                aria-label={`Set route for ${playerName}, ${slot}`}
+              >
+                <span className="pass-route-player__image"><PlayerImage player={player} alt="" /></span>
+                <span>{slot}</span>
+              </button>
+            );
+          })}
+          {passSetup && formation.QB && (() => {
+            const lineup = FORMATION_SLOT_LINEUP.QB;
+            const qb = findFormationPlayer(formation.QB);
+            const qbSelected = selectedRoutePlayer === formation.QB;
+            return (
+              <button
+                type="button"
+                className={`pass-route-player pass-route-qb ${qbSelected ? "selected" : ""}`}
+                style={{ left: `${LANES[lineup.lane]}%`, top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%` }}
+                onClick={(event) => { event.stopPropagation(); onRoutePlayerSelect?.(qbSelected ? "" : formation.QB as string); }}
+                aria-label={`Set read order for ${formation.QB}`}
+              >
+                <span className="pass-route-player__image"><PlayerImage player={qb} alt="" /></span><span>QB reads</span>
+              </button>
+            );
+          })()}
           {formationMode &&
             FORMATION_SLOTS.map((slot) => {
               const lineup = FORMATION_SLOT_LINEUP[slot];
@@ -1490,6 +1590,74 @@ export default function GameField({
                 </button>
               );
             })}
+
+          {passSetup && selectedRoutePlayer === formation.QB && (
+            <div className="qb-read-bubble" onClick={(event) => event.stopPropagation()}>
+              <strong>QB read order</strong>
+              <span>Drag receivers left to right</span>
+              <div className="qb-read-list">
+                {orderedReads.map((player, index) => (
+                  <button
+                    type="button"
+                    draggable
+                    key={player}
+                    onDragStart={(event) => event.dataTransfer.setData("text/plain", player)}
+                    onDragOver={(event) => event.preventDefault()}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      const moved = event.dataTransfer.getData("text/plain");
+                      const next = orderedReads.filter((name) => name !== moved);
+                      next.splice(index, 0, moved);
+                      updateReadOrder(next);
+                    }}
+                  >
+                    <b>{index + 1}</b> {player}
+                  </button>
+                ))}
+                {!orderedReads.length && <em>Assign at least one receiver route.</em>}
+              </div>
+            </div>
+          )}
+
+          {passSetup && selectedRoutePlayer && selectedRoutePlayer !== formation.QB && (
+            <div className="pass-route-sheet" onClick={(event) => event.stopPropagation()}>
+              <div><strong>{selectedRoutePlayer}</strong><span>Choose depth, then route</span></div>
+              <label>
+                Route depth
+                <AppSelect value={routeDepths[selectedRoutePlayer] || ""} onChange={(event) => {
+                  const depth = event.target.value;
+                  onPassOptionsChange?.({
+                    routeDepths: { ...routeDepths, [selectedRoutePlayer]: depth },
+                    routes: { ...routes, [selectedRoutePlayer]: "" },
+                  });
+                }}>
+                  <option value="" disabled>Select depth</option>
+                  {ROUTE_DEPTHS.map((depth) => <option key={depth}>{depth}</option>)}
+                </AppSelect>
+              </label>
+              <label>
+                Route
+                <AppSelect disabled={!routeDepths[selectedRoutePlayer]} value={routes[selectedRoutePlayer] || ""} onChange={(event) => {
+                  const route = event.target.value;
+                  const nextRoutes = { ...routes, [selectedRoutePlayer]: route };
+                  const nextOrder = orderedReads.includes(selectedRoutePlayer) ? orderedReads : [...orderedReads, selectedRoutePlayer];
+                  onPassOptionsChange?.({ routes: nextRoutes, reads: Object.fromEntries(nextOrder.map((name, index) => [name, String(index + 1)])) });
+                }}>
+                  <option value="" disabled>Select route</option>
+                  {(ROUTES_BY_DEPTH[routeDepths[selectedRoutePlayer]] || []).map((route) => <option key={route}>{route}</option>)}
+                </AppSelect>
+              </label>
+              <button type="button" onClick={() => onRoutePlayerSelect?.("")}>Done</button>
+            </div>
+          )}
+
+          {passSetup && (
+            <div className="pass-setup-toolbar" onClick={(event) => event.stopPropagation()}>
+              <div><strong>Design pass play</strong><span>Select a highlighted receiver or the QB.</span></div>
+              <button type="button" onClick={onPassSetupClose}>Cancel</button>
+              <button type="button" disabled={!routedPlayers.length} onClick={onPassPlay}>Run pass</button>
+            </div>
+          )}
 
           {/* The generated defense remains in the pending play data, but is
               deliberately not previewed while the offense is being placed. */}

--- a/apps/web/src/components/league/gameplay/engine/passEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/passEngine.ts
@@ -135,6 +135,11 @@ export function assignRoutes(
 ) {
   const offense = offenseTeam(game),
     routes = options.routes ?? {};
+  const depthRanges: Record<string, [number, number]> = {
+    Quick: [1, 2], Short: [3, 5], "Short-Mid": [6, 10], Mid: [11, 15],
+    "Mid-Long": [16, 20], Long: [21, 25], Deep: [26, 30], Shot: [31, 39],
+    Bomb: [40, Math.max(40, game.Possession === "Home" ? 100 - n(game.BallOn) : n(game.BallOn))],
+  };
   const names = Object.keys(routes).length
     ? Object.keys(routes)
     : [
@@ -147,8 +152,9 @@ export function assignRoutes(
     .map((name, i) => ({
       player: name,
       routeType: routes[name] || "Go",
-      airYards:
-        routes[name] === "Screen"
+      airYards: options.routeDepths?.[name] && depthRanges[options.routeDepths[name]]
+        ? choose(depthRanges[options.routeDepths[name]])
+        : routes[name] === "Screen"
           ? 0
           : routes[name] === "Slant"
             ? 5
@@ -194,7 +200,10 @@ export function choosePassTarget(
   const readOk = Math.random() * 100 < trait(qb, "readDefense");
   return weightedChoose(routes, (r) => {
     const read = options.reads?.[r.player] ?? "";
-    const readVal =
+    const numericRead = Number.parseInt(read, 10);
+    const readVal = Number.isFinite(numericRead)
+      ? Math.max(1, 6 - numericRead)
+      :
       read === "Primary"
         ? 5
         : read === "2nd"

--- a/apps/web/src/components/league/gameplay/engine/types.ts
+++ b/apps/web/src/components/league/gameplay/engine/types.ts
@@ -32,6 +32,7 @@ export type DefensiveAssignment = {
 export type PlayCallOptions = {
   formation?: Partial<Record<FormationSlot, string>>;
   routes?: Record<string, string>;
+  routeDepths?: Record<string, string>;
   reads?: Record<string, string>;
   runner?: string;
   clockMode?: ClockMode;


### PR DESCRIPTION
### Motivation

- Replace the existing off-canvas routes modal with an on-field pass-design mode so users can design pass plays visually without leaving the field. 
- Make the defense visually disappear during pass setup and scroll the viewport so the camera places a point six yards behind the line-of-scrimmage at the viewport edge for a consistent view of the whole play.
- Highlight eligible pass targets (occupied `WR*`, `RB*`, and exposed `LT`/`RT` slots) and let users assign route depths and routes from the official settings table, then persist those choices to the pass engine.

### Description

- Launches on-field pass setup from the play caller: `Call Play → Pass` now opens the in-field composer instead of immediately using the modal, via changes to `GameControls.tsx`.
- Adds an in-field pass-design UI inside `GameField.tsx` that fades defensive tokens (`.pass-setup-active`), highlights eligible players (`PASS_ROUTE_SLOTS`) only when occupied, scrolls the field so six yards behind LOS sits at the viewport boundary, and renders interactive controls for selecting route depth and route using the shared `AppSelect` component.
- Adds a QB read bubble UI that shows routed receivers and supports drag-and-drop reordering of read priority, and exposes pass controls: per-player `routeDepths`, `routes`, and `reads` are surfaced to the outer state via callbacks (`onPassOptionsChange`, `onPassPlay`, `onPassSetupClose`).
- Updates engine types and logic: `PlayCallOptions` gains `routeDepths`, and `assignRoutes` in `passEngine.ts` maps selected depth ranges into generated `airYards`; `choosePassTarget` now accepts numeric read orders and prefers numeric read positions when present.
- Styling added in `GameField.css` follows the app's semantic tokens and uses the shared `AppSelect` so theme-awareness (dark/light) is preserved per UI rules.

### Testing

- Ran `npm run build` (TypeScript + Vite) and the production build completed successfully.
- Ran `npm run lint`; lint completed but left one non-blocking `react-hooks/exhaustive-deps` warning in `GameField.tsx` (informational only).
- The TypeScript compile step in `npm run build` fixed earlier type errors introduced while adding `routeDepths` and related props.
- Attempted browser-based visual verification via `npx playwright install chromium`, but the environment failed to download Chromium (HTTP 403), so automated visual/browser tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a750f20eae08324895ecfe41c89bda9)