### PR TITLE
Fix pass-play eligible player interactions

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -825,30 +825,18 @@ textarea {
   transition: opacity 420ms ease;
 }
 
-.pass-route-player {
-  position: absolute;
-  display: grid;
-  justify-items: center;
-  gap: 2px;
-  width: 72px;
-  padding: 4px;
-  transform: translate(-50%, -100%);
-  border: 2px solid var(--control-accent);
-  border-radius: 14px;
-  color: var(--text-primary);
-  background: color-mix(in srgb, var(--surface-overlay) 82%, transparent);
-  box-shadow: 0 0 0 5px color-mix(in srgb, var(--control-accent) 24%, transparent), 0 8px 20px var(--shadow-color);
-  font: inherit;
-  font-size: 10px;
-  font-weight: 900;
-  cursor: pointer;
+.token.pass-route-eligible .player-character {
+  filter: drop-shadow(0 0 5px var(--control-accent))
+    drop-shadow(0 0 10px var(--control-accent));
 }
 
-.pass-route-player.assigned { border-color: var(--control-border-hover); }
-.pass-route-player.selected { box-shadow: 0 0 0 7px color-mix(in srgb, var(--control-accent) 48%, transparent), 0 8px 20px var(--shadow-color); }
-.pass-route-player__image { width: 44px; height: 52px; overflow: hidden; }
-.pass-route-player__image .player-image-layers { width: 100%; height: 100%; }
-.pass-route-qb { z-index: 210; }
+.token.pass-route-eligible { cursor: pointer; }
+.token.pass-route-assigned .player-marker { border-color: var(--control-border-hover); }
+.token.pass-route-selected .player-marker {
+  opacity: 1;
+  border-color: var(--control-accent);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--control-accent) 35%, transparent);
+}
 
 .pass-route-sheet,
 .qb-read-bubble,

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -497,6 +497,9 @@ export default function GameField({
   const isSetupTransitionRef = useRef(false);
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
+  const passSetupRef = useRef(passSetup);
+  const formationRef = useRef(formation);
+  const onRoutePlayerSelectRef = useRef(onRoutePlayerSelect);
   const teamEndStyle = homeTeamPrimaryColor
     ? { background: homeTeamPrimaryColor }
     : undefined;
@@ -535,6 +538,39 @@ export default function GameField({
     onPassOptionsChange?.({
       reads: Object.fromEntries(order.map((player, index) => [player, String(index + 1)])),
     });
+
+  useEffect(() => {
+    passSetupRef.current = passSetup;
+    formationRef.current = formation;
+    onRoutePlayerSelectRef.current = onRoutePlayerSelect;
+  }, [formation, onRoutePlayerSelect, passSetup]);
+
+  useEffect(() => {
+    const eligiblePlayers = new Set(eligibleRoutePlayers.map(({ player }) => player));
+    Object.values(playersRef.current).forEach((player) => {
+      const isQuarterback = player.name === formation.QB;
+      const isEligible = eligiblePlayers.has(player.name) || isQuarterback;
+      player.el.classList.toggle("pass-route-eligible", passSetup && isEligible);
+      player.el.classList.toggle(
+        "pass-route-selected",
+        passSetup && selectedRoutePlayer === player.name,
+      );
+      player.el.classList.toggle(
+        "pass-route-assigned",
+        passSetup && Boolean(routes[player.name]),
+      );
+      if (passSetup && isEligible) {
+        player.el.setAttribute(
+          "aria-label",
+          isQuarterback
+            ? `Set read order for ${player.name}`
+            : `Set route for ${player.name}`,
+        );
+      } else {
+        player.el.setAttribute("aria-label", `Open ${player.name} player actions`);
+      }
+    });
+  }, [eligibleRoutePlayers, formation.QB, passSetup, routes, selectedRoutePlayer]);
 
   useEffect(() => {
     if (!passSetup) return;
@@ -1112,6 +1148,19 @@ export default function GameField({
         el.setAttribute("aria-label", `Open ${player.name} player actions`);
         const openPlayerMenu = (event: MouseEvent | KeyboardEvent) => {
           event.stopPropagation();
+          if (passSetupRef.current) {
+            const currentFormation = formationRef.current;
+            const eligibleNames = PASS_ROUTE_SLOTS.map(
+              (slot) => currentFormation[slot],
+            );
+            if (
+              player.name === currentFormation.QB ||
+              eligibleNames.includes(player.name)
+            ) {
+              onRoutePlayerSelectRef.current?.(player.name);
+            }
+            return;
+          }
           const target = event.currentTarget as HTMLDivElement;
           const leftPct = parseFloat(target.style.left) || player.x;
           const topPct =
@@ -1494,48 +1543,6 @@ export default function GameField({
             END
           </div>
           <div className="football" id="football" ref={footballRef} />
-          {passSetup && PASS_ROUTE_SLOTS.map((slot) => {
-            const playerName = formation[slot];
-            if (!playerName) return null;
-            const lineup = FORMATION_SLOT_LINEUP[slot];
-            const player = findFormationPlayer(playerName);
-            return (
-              <button
-                key={`route-${slot}`}
-                type="button"
-                className={`pass-route-player ${selectedRoutePlayer === playerName ? "selected" : ""} ${routes[playerName] ? "assigned" : ""}`}
-                style={{
-                  left: `${LANES[lineup.lane] ?? 50}%`,
-                  top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%`,
-                  zIndex: playerDepthZIndex(formationLosYard + offenseDirection * lineup.yardOffsetFromLos) + 1,
-                }}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRoutePlayerSelect?.(playerName);
-                }}
-                aria-label={`Set route for ${playerName}, ${slot}`}
-              >
-                <span className="pass-route-player__image"><PlayerImage player={player} alt="" /></span>
-                <span>{slot}</span>
-              </button>
-            );
-          })}
-          {passSetup && formation.QB && (() => {
-            const lineup = FORMATION_SLOT_LINEUP.QB;
-            const qb = findFormationPlayer(formation.QB);
-            const qbSelected = selectedRoutePlayer === formation.QB;
-            return (
-              <button
-                type="button"
-                className={`pass-route-player pass-route-qb ${qbSelected ? "selected" : ""}`}
-                style={{ left: `${LANES[lineup.lane]}%`, top: `${yardToYPct(formationLosYard + offenseDirection * lineup.yardOffsetFromLos)}%` }}
-                onClick={(event) => { event.stopPropagation(); onRoutePlayerSelect?.(qbSelected ? "" : formation.QB as string); }}
-                aria-label={`Set read order for ${formation.QB}`}
-              >
-                <span className="pass-route-player__image"><PlayerImage player={qb} alt="" /></span><span>QB reads</span>
-              </button>
-            );
-          })()}
           {formationMode &&
             FORMATION_SLOTS.map((slot) => {
               const lineup = FORMATION_SLOT_LINEUP[slot];


### PR DESCRIPTION
### Motivation

- The pass-play UI rendered duplicate small receiver cards and clicking them did not open the expected route/read options, so the intent is to reuse the existing on-field tokens as interactive targets during pass setup and make clicks/keyboard actions open the route or QB-read controls.

### Description

- Remove the duplicated `pass-route-player` JSX overlay and instead mark existing player tokens in `GameField` as eligible, assigned, or selected during pass setup by toggling DOM classes on the token elements in `apps/web/src/components/league/GameField.tsx`.
- Intercept clicks/keyboard activation on the rendered player tokens so that when `passSetup` is active clicks call `onRoutePlayerSelect` for eligible receivers or the QB, enabling the route-depth/read UI to open from the token itself (`GameField.tsx` changes around token creation and `openPlayerMenu`).
- Update accessible `aria-label`s for tokens in pass setup so eligible players say `Set route for <name>` and QB says `Set read order for <name>`, preserving keyboard/assistive support (`GameField.tsx` effect that updates token attributes).
- Replace the floating card stylesheet with theme-aware token-based highlights by adding `.pass-route-eligible`, `.pass-route-selected`, and `.pass-route-assigned` rules that use semantic tokens (in `apps/web/src/components/league/GameField.css`).

### Testing

- Ran `npm run lint` which completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning.  
- Built the web app with `npm run build` which succeeded and produced a production build.  
- Verified repository sanity with `git diff --check` which reported no problems.  
- Attempted an automated visual check with Playwright (`npx playwright screenshot`) but the browser download/install in this environment failed with an HTTP 403 from the Playwright CDN, so screenshots could not be generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a75119c2640832486669b82ab0e5295)