### PR TITLE
Highlight full player (including jersey) for pass setup and fix pass/QB menu visibility

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -825,7 +825,8 @@ textarea {
   transition: opacity 420ms ease;
 }
 
-.token.pass-route-eligible .player-character {
+.token.pass-route-eligible .player-character,
+.token.pass-route-eligible .player-jersey {
   filter: drop-shadow(0 0 5px var(--control-accent))
     drop-shadow(0 0 10px var(--control-accent));
 }
@@ -877,27 +878,35 @@ textarea {
 .pass-setup-toolbar button:disabled { opacity: .55; cursor: not-allowed; }
 
 .pass-route-sheet {
-  top: calc(100% - 176px);
+  position: fixed;
+  left: 50%;
+  right: auto;
+  bottom: 12px;
+  top: auto;
   width: min(720px, calc(100% - 24px));
   min-height: 150px;
-  margin: 0 auto;
+  margin: 0;
   padding: 16px;
   border-radius: 18px 18px 0 0;
   display: flex;
   align-items: end;
   gap: 14px;
+  transform: translateX(-50%);
 }
 .pass-route-sheet > div { display: grid; margin-right: auto; align-self: center; }
 .pass-route-sheet label { display: grid; gap: 5px; color: var(--text-secondary); font-size: 12px; font-weight: 800; }
 
 .qb-read-bubble {
+  position: fixed;
+  left: 50%;
   top: 90px;
   width: min(760px, calc(100% - 24px));
-  margin: 0 auto;
+  margin: 0;
   padding: 14px;
   border-radius: 18px;
   display: grid;
   gap: 5px;
+  transform: translateX(-50%);
 }
 .qb-read-list { display: flex; gap: 8px; overflow-x: auto; padding-top: 7px; }
 .qb-read-list button { white-space: nowrap; }
@@ -905,7 +914,7 @@ textarea {
 .qb-read-list em { color: var(--text-secondary); }
 
 @media (max-width: 680px) {
-  .pass-route-sheet { align-items: stretch; flex-wrap: wrap; top: calc(100% - 270px); }
+  .pass-route-sheet { align-items: stretch; flex-wrap: wrap; }
   .pass-route-sheet > div { width: 100%; }
   .pass-route-sheet label { flex: 1; }
   .pass-setup-toolbar span { display: none; }


### PR DESCRIPTION
### Motivation

- Ensure passing play highlights include the entire player art (jersey + head) so eligibility is visually clear. 
- Fix a bug where clicking a highlighted player did not surface the in-field action sheet or left the pass-design menus off-screen. 
- Keep UI chrome theme-aware by using the app's semantic design tokens for highlight and overlay styling.

### Description

- Updated `apps/web/src/components/league/GameField.css` so `.token.pass-route-eligible` applies the drop-shadow highlight to both `.player-character` and `.player-jersey`. 
- Repositioned the pass design sheet by making `.pass-route-sheet` fixed to the bottom-center of the viewport (`position: fixed; left: 50%; bottom: 12px; transform: translateX(-50%)`) so it remains visible after selecting a highlighted receiver. 
- Repositioned the QB read-order control by making `.qb-read-bubble` fixed at the top-center of the viewport so the QB menu remains visible when selected. 
- Preserved responsive behavior by keeping the existing media query rules and used existing semantic tokens such as `--control-accent`, `--surface-overlay`, `--control-border`, `--text-primary`, and `--shadow-color` for theme-aware visuals.

### Testing

- Ran `npm run build` which completed successfully. 
- Ran `npm run lint` which passed with zero errors and a single pre-existing React Hook dependency warning. 
- Ran `git diff --check` which reported no style issues. 
- Attempted to run browser-based checks via Playwright, but end-to-end browser execution could not be completed in this environment due to missing host browser dependencies, so automated screenshot/DOM interaction tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a762635da54832496a9acbb8f0cf0ef)