### PR TITLE
Fix pass play interactions: QB read selection and pass-setup closing

### DIFF
--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1170,8 +1170,18 @@ export default function GameField({
               (slot) => currentFormation[slot],
             );
             const quarterback = currentFormation.QB;
-            if (player.name === quarterback) {
-              onRoutePlayerSelectRef.current?.(quarterback);
+            // The currently rendered scene can briefly contain the previous
+            // formation's player metadata while the setup transition moves
+            // everyone into place. Treat the QB slot/role as authoritative so
+            // that its token still opens the read-order editor during that
+            // transition, and select the QB from the saved formation.
+            if (
+              player.name === quarterback ||
+              player.position === "QB" ||
+              player.role === "QB"
+            ) {
+              if (quarterback)
+                onRoutePlayerSelectRef.current?.(quarterback);
             } else if (eligibleNames.includes(player.name)) {
               onRoutePlayerSelectRef.current?.(player.name);
             }
@@ -1522,6 +1532,7 @@ export default function GameField({
           onClick={() => {
             setSelectedPlayerMenu(null);
             setRevealedFormationSlot(null);
+            if (passSetup) onPassSetupClose?.();
           }}
         >
           <div className="field-title">Dynamic Football Animation View</div>
@@ -1670,7 +1681,7 @@ export default function GameField({
                   {(ROUTES_BY_DEPTH[routeDepths[selectedRoutePlayer]] || []).map((route) => <option key={route}>{route}</option>)}
                 </AppSelect>
               </label>
-              <button type="button" onClick={() => onRoutePlayerSelect?.("")}>Done</button>
+              <button type="button" onClick={onPassSetupClose}>Done</button>
             </div>
           )}
 


### PR DESCRIPTION
### Motivation
- Pass-play mode left the defense hidden and players highlighted when closing or clicking out, and the QB token sometimes failed to open the QB read-order editor during formation transitions.

### Description
- Use the rendered player's `position`/`role` in addition to the saved formation slot to reliably identify the QB and open the read-order editor during pass setup transitions by routing to `onRoutePlayerSelectRef` with the formation `QB` when available (`apps/web/src/components/league/GameField.tsx`).
- Ensure clicking the field backdrop clears the selected player menu and also exits pass setup via `onPassSetupClose` so route highlights clear and the defense becomes visible again (`apps/web/src/components/league/GameField.tsx`).
- Change the route editor `Done` button to call the pass-setup close handler (`onPassSetupClose`) so it fully exits pass setup instead of only clearing the selected receiver (`apps/web/src/components/league/GameField.tsx`).
- Add a null check to avoid passing `undefined` into the route-selection handler when the saved `QB` is missing (`apps/web/src/components/league/GameField.tsx`).

### Testing
- Ran `npm run build` for the web app and the production build completed successfully. 
- Ran `npm run lint` and ESLint finished with one pre-existing React Hooks warning (no new errors). 
- Ran `git diff --check` to validate no whitespace or diff issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a78aa5b0b3883248d4802194dbbc159)