### PR TITLE
Add QB read-order modal to order eligible receivers

### DIFF
--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -840,7 +840,6 @@ textarea {
 }
 
 .pass-route-sheet,
-.qb-read-bubble,
 .pass-setup-toolbar {
   position: sticky;
   z-index: 310;
@@ -863,8 +862,8 @@ textarea {
   gap: 10px;
 }
 .pass-setup-toolbar > div { display: grid; margin-right: auto; }
-.pass-setup-toolbar span, .pass-route-sheet > div span, .qb-read-bubble > span { color: var(--text-secondary); font-size: 12px; }
-.pass-setup-toolbar button, .pass-route-sheet > button, .qb-read-list button {
+.pass-setup-toolbar span, .pass-route-sheet > div span { color: var(--text-secondary); font-size: 12px; }
+.pass-setup-toolbar button, .pass-route-sheet > button, .qb-read-dialog button {
   border: 1px solid var(--control-border);
   border-radius: 10px;
   padding: 9px 12px;
@@ -874,7 +873,7 @@ textarea {
   font-weight: 800;
   cursor: pointer;
 }
-.pass-setup-toolbar button:hover, .pass-route-sheet > button:hover, .qb-read-list button:hover { background: var(--control-bg-hover); border-color: var(--control-border-hover); }
+.pass-setup-toolbar button:hover, .pass-route-sheet > button:hover, .qb-read-dialog button:hover { background: var(--control-bg-hover); border-color: var(--control-border-hover); }
 .pass-setup-toolbar button:disabled { opacity: .55; cursor: not-allowed; }
 
 .pass-route-sheet {
@@ -896,22 +895,42 @@ textarea {
 .pass-route-sheet > div { display: grid; margin-right: auto; align-self: center; }
 .pass-route-sheet label { display: grid; gap: 5px; color: var(--text-secondary); font-size: 12px; font-weight: 800; }
 
-.qb-read-bubble {
+.qb-read-modal {
   position: fixed;
-  left: 50%;
-  top: 90px;
-  width: min(760px, calc(100% - 24px));
-  margin: 0;
-  padding: 14px;
-  border-radius: 18px;
+  inset: 0;
+  z-index: 400;
   display: grid;
-  gap: 5px;
-  transform: translateX(-50%);
+  place-items: center;
+  padding: 18px;
+  background: color-mix(in srgb, var(--surface-overlay) 35%, transparent);
+  backdrop-filter: blur(4px);
 }
-.qb-read-list { display: flex; gap: 8px; overflow-x: auto; padding-top: 7px; }
-.qb-read-list button { white-space: nowrap; }
-.qb-read-list b { color: var(--control-accent); }
-.qb-read-list em { color: var(--text-secondary); }
+.qb-read-dialog {
+  width: min(620px, 100%);
+  max-height: min(720px, calc(100vh - 36px));
+  overflow: auto;
+  color: var(--text-primary);
+  background: var(--surface-overlay);
+  border: 1px solid var(--control-border);
+  border-radius: 18px;
+  box-shadow: 0 14px 34px var(--shadow-color);
+}
+.qb-read-dialog > header, .qb-read-dialog > footer { display: flex; align-items: center; gap: 14px; padding: 16px 18px; }
+.qb-read-dialog > header { justify-content: space-between; border-bottom: 1px solid var(--control-border); }
+.qb-read-dialog h3, .qb-read-dialog p { margin: 0; }
+.qb-read-dialog header p, .qb-read-dialog footer span, .qb-read-list small { color: var(--text-secondary); font-size: 12px; }
+.qb-read-close { font-size: 20px !important; line-height: 1; }
+.qb-read-list { display: grid; gap: 8px; margin: 0; padding: 14px 18px; list-style: none; }
+.qb-read-list li { display: flex; align-items: center; gap: 12px; padding: 10px; background: var(--control-bg); border: 1px solid var(--control-border); border-radius: 12px; cursor: grab; }
+.qb-read-list li > b { display: grid; place-items: center; width: 32px; height: 32px; flex: 0 0 auto; color: var(--control-accent); background: var(--surface-raised); border-radius: 50%; }
+.qb-read-list li > span { display: grid; min-width: 0; margin-right: auto; }
+.qb-read-list small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.qb-read-actions { display: flex; gap: 6px; }
+.qb-read-actions button { min-width: 38px; }
+.qb-read-dialog button:disabled { opacity: .4; cursor: not-allowed; }
+.qb-read-empty { padding: 28px 18px; color: var(--text-secondary); text-align: center; }
+.qb-read-dialog > footer { justify-content: flex-end; border-top: 1px solid var(--control-border); }
+.qb-read-dialog > footer span { margin-right: auto; }
 
 @media (max-width: 680px) {
   .pass-route-sheet { align-items: stretch; flex-wrap: wrap; }

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -1626,30 +1626,92 @@ export default function GameField({
             })}
 
           {passSetup && selectedRoutePlayer === formation.QB && (
-            <div className="qb-read-bubble" onClick={(event) => event.stopPropagation()}>
-              <strong>QB read order</strong>
-              <span>Drag receivers left to right</span>
-              <div className="qb-read-list">
-                {orderedReads.map((player, index) => (
+            <div
+              className="qb-read-modal"
+              role="presentation"
+              onClick={(event) => {
+                event.stopPropagation();
+                if (event.target === event.currentTarget) onRoutePlayerSelect?.("");
+              }}
+            >
+              <section
+                className="qb-read-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="qb-read-title"
+              >
+                <header>
+                  <div>
+                    <h3 id="qb-read-title">Quarterback read order</h3>
+                    <p>All eligible receivers with assigned routes are shown below.</p>
+                  </div>
                   <button
                     type="button"
-                    draggable
-                    key={player}
-                    onDragStart={(event) => event.dataTransfer.setData("text/plain", player)}
-                    onDragOver={(event) => event.preventDefault()}
-                    onDrop={(event) => {
-                      event.preventDefault();
-                      const moved = event.dataTransfer.getData("text/plain");
-                      const next = orderedReads.filter((name) => name !== moved);
-                      next.splice(index, 0, moved);
-                      updateReadOrder(next);
-                    }}
+                    className="qb-read-close"
+                    aria-label="Close quarterback read order"
+                    onClick={() => onRoutePlayerSelect?.("")}
                   >
-                    <b>{index + 1}</b> {player}
+                    ×
                   </button>
-                ))}
-                {!orderedReads.length && <em>Assign at least one receiver route.</em>}
-              </div>
+                </header>
+                <ol className="qb-read-list">
+                  {orderedReads.map((player, index) => (
+                    <li
+                      key={player}
+                      draggable
+                      onDragStart={(event) => event.dataTransfer.setData("text/plain", player)}
+                      onDragOver={(event) => event.preventDefault()}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const moved = event.dataTransfer.getData("text/plain");
+                        if (!orderedReads.includes(moved)) return;
+                        const next = orderedReads.filter((name) => name !== moved);
+                        next.splice(index, 0, moved);
+                        updateReadOrder(next);
+                      }}
+                    >
+                      <b aria-label={`Read ${index + 1}`}>{index + 1}</b>
+                      <span>
+                        <strong>{player}</strong>
+                        <small>{routes[player]}{routeDepths[player] ? ` · ${routeDepths[player]}` : ""}</small>
+                      </span>
+                      <div className="qb-read-actions" aria-label={`Reorder ${player}`}>
+                        <button
+                          type="button"
+                          disabled={index === 0}
+                          aria-label={`Move ${player} earlier`}
+                          onClick={() => {
+                            const next = [...orderedReads];
+                            [next[index - 1], next[index]] = [next[index], next[index - 1]];
+                            updateReadOrder(next);
+                          }}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          disabled={index === orderedReads.length - 1}
+                          aria-label={`Move ${player} later`}
+                          onClick={() => {
+                            const next = [...orderedReads];
+                            [next[index], next[index + 1]] = [next[index + 1], next[index]];
+                            updateReadOrder(next);
+                          }}
+                        >
+                          ↓
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+                {!orderedReads.length && (
+                  <p className="qb-read-empty">Assign a route to an eligible receiver first.</p>
+                )}
+                <footer>
+                  <span>Drag rows or use the arrow buttons to set the progression.</span>
+                  <button type="button" onClick={() => onRoutePlayerSelect?.("")}>Done</button>
+                </footer>
+              </section>
             </div>
           )}
 


### PR DESCRIPTION
### Motivation
- The existing pass setup only showed QB reads inline and left `reads` difficult to populate when multiple receivers had routes, so a dedicated ordering UI was needed.
- The intent is to present all eligible receivers with assigned routes and allow the user to set the QB progression so the `reads` map can be populated deterministically.

### Description
- Added an accessible modal dialog in `apps/web/src/components/league/GameField.tsx` that lists all routed eligible receivers and exposes drag-and-drop plus arrow buttons to reorder the QB read progression, updating `reads` via `onPassOptionsChange` (`updateReadOrder`).
- The modal includes close/Done controls, an empty-state message, and closes when clicking the backdrop; it uses `role="dialog"`, `aria-modal`, `aria-labelledby`, and appropriate aria labels for controls.
- Added styling in `apps/web/src/components/league/GameField.css` for the modal (`.qb-read-modal` / `.qb-read-dialog` / `.qb-read-list` etc.) and ensured all colors and surfaces use the app's semantic tokens so the UI remains theme-aware in dark and light modes.
- Changes affect `GameField.tsx` and `GameField.css`; the commit message is `Add modal for ordering quarterback reads` (commit `30229fc`).

### Testing
- Ran `npm run build` which completed successfully and produced a production build without errors.
- Ran `npm run lint` which completed with no errors and one existing `react-hooks/exhaustive-deps` warning at `GameField.tsx:1341` that was not introduced by this change.
- Verified `git diff --check` passed and used a small `python` assertion to confirm the modal CSS uses semantic tokens (no fixed hex colors) and that both dark/light token sets exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a78c0eb0eb083248c234024e0b3cc17)