### PR TITLE
Pre-snap run selection and Snap Ball control

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -1489,6 +1489,8 @@ export function GameCenter({
     useState(false);
   const [selectedFormationPlayer, setSelectedFormationPlayer] = useState("");
   const [passSetup, setPassSetup] = useState(false);
+  const [runSetup, setRunSetup] = useState(false);
+  const [selectedPlayType, setSelectedPlayType] = useState<"run" | "pass" | null>(null);
   const [selectedRoutePlayer, setSelectedRoutePlayer] = useState("");
   const [animationRequest, setAnimationRequest] = useState<{
     id: number;
@@ -1589,6 +1591,8 @@ export function GameCenter({
     setSettingFormation(false);
     setSelectedFormationPlayer("");
     setPassSetup(false);
+    setRunSetup(false);
+    setSelectedPlayType(null);
     setSelectedRoutePlayer("");
   }, [currentGame.Possession]);
   const persist = async (result: ReturnType<typeof runPlay>) => {
@@ -1633,6 +1637,16 @@ export function GameCenter({
       onGameUpdate?.(result.game);
       setHistory((h) => [...h, result.play]);
       setLog((l) => [result.text, ...l]);
+      setSelectedPlayType(null);
+      setPassSetup(false);
+      setRunSetup(false);
+      setPlayOptions((options) => ({
+        ...options,
+        runner: undefined,
+        routes: {},
+        reads: {},
+        routeDepths: {},
+      }));
     } catch (error) {
       setCurrentGame(previousGame);
       setLog((l) => [
@@ -1787,6 +1801,8 @@ export function GameCenter({
                 possession={currentGame.Possession}
                 selectedFormationPlayer={selectedFormationPlayer}
                 passSetup={passSetup}
+                runSetup={runSetup}
+                runner={playOptions.runner}
                 routes={playOptions.routes}
                 routeDepths={playOptions.routeDepths}
                 reads={playOptions.reads}
@@ -1802,8 +1818,11 @@ export function GameCenter({
                 onPassPlay={() => {
                   setPassSetup(false);
                   setSelectedRoutePlayer("");
-                  action("Pass Play", playOptions);
                 }}
+                onRunnerSelect={(runner) =>
+                  setPlayOptions((current) => ({ ...current, runner }))
+                }
+                onRunSetupClose={() => setRunSetup(false)}
                 homeLogo={
                   teamValue(homeTeamDetails, "Logo") || currentGame.HomeLogo
                 }
@@ -1909,6 +1928,28 @@ export function GameCenter({
                   onPassSetupChange={(active) => {
                     setPassSetup(active);
                     setSelectedRoutePlayer("");
+                  }}
+                  selectedPlayType={selectedPlayType}
+                  onPlayTypeChange={(playType) => {
+                    setSelectedPlayType(playType);
+                    setPlayOptions((current) => ({
+                      ...current,
+                      ...(playType === "run"
+                        ? { routes: {}, reads: {}, routeDepths: {} }
+                        : { runner: undefined }),
+                    }));
+                  }}
+                  onRunSetupChange={setRunSetup}
+                  canSnap={
+                    selectedPlayType === "run"
+                      ? Boolean(playOptions.runner)
+                      : selectedPlayType === "pass"
+                        ? Object.values(playOptions.routes ?? {}).some(Boolean)
+                        : false
+                  }
+                  onSnap={() => {
+                    if (selectedPlayType === "run") action("Run Play", playOptions);
+                    if (selectedPlayType === "pass") action("Pass Play", playOptions);
                   }}
                 />
               </GameField>

--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -36,6 +36,11 @@ type Props = {
   requestedFormationMode?: boolean;
   disabled?: boolean;
   onPassSetupChange?: (active: boolean) => void;
+  selectedPlayType?: "run" | "pass" | null;
+  onPlayTypeChange?: (playType: "run" | "pass") => void;
+  onRunSetupChange?: (active: boolean) => void;
+  onSnap?: () => void;
+  canSnap?: boolean;
 };
 
 /**
@@ -337,6 +342,11 @@ export function GameControls({
   requestedFormationMode,
   disabled = false,
   onPassSetupChange,
+  selectedPlayType = null,
+  onPlayTypeChange,
+  onRunSetupChange,
+  onSnap,
+  canSnap = false,
 }: Props) {
   const [activeMenu, setActiveMenu] = useState<"coach" | "play" | null>(null);
   const [modal, setModal] = useState<"routes" | "run" | "clock" | "roster" | null>(null);
@@ -361,7 +371,7 @@ export function GameControls({
   const routes = options.routes ?? {};
   const reads = options.reads ?? {};
   const receivers = eligibleReceivers(formation);
-  const runners = (["QB", ...RB_SLOTS, ...WR_SLOTS] as FormationSlot[])
+  const runners = (["QB", "RB1", "RB2", "WR1", "WR4"] as FormationSlot[])
     .map((s) => formation[s])
     .filter((r): r is string => Boolean(r));
   const formationPlayerCount = Object.values(formation).filter(Boolean).length;
@@ -509,7 +519,12 @@ export function GameControls({
             <div className="radial-flyout play-flyout">
               <button
                 disabled={disabled || !validFormation || runners.length === 0}
-                onClick={() => setModal("run")}
+                onClick={() => {
+                  setActiveMenu(null);
+                  onPlayTypeChange?.("run");
+                  onPassSetupChange?.(false);
+                  onRunSetupChange?.(true);
+                }}
                 type="button"
               >
                 Run
@@ -518,6 +533,8 @@ export function GameControls({
                 disabled={disabled || !validFormation}
                 onClick={() => {
                   setActiveMenu(null);
+                  onPlayTypeChange?.("pass");
+                  onRunSetupChange?.(false);
                   onPassSetupChange?.(true);
                 }}
                 type="button"
@@ -578,6 +595,19 @@ export function GameControls({
               )}
             </div>
           )}
+        </div>
+        <div className="radial-control-group">
+          <button
+            className={`radial-control-button snap-ball-button ${selectedPlayType ? "play-called" : ""}`}
+            type="button"
+            disabled={disabled || !canSnap}
+            onClick={onSnap}
+            aria-label="Snap Ball"
+            title={!selectedPlayType ? "Call a play first" : !canSnap ? "Finish setting up the play" : "Snap Ball"}
+          >
+            <span className="radial-control-icon" aria-hidden="true">🏈</span>
+            <span className="radial-control-label">Snap Ball</span>
+          </button>
         </div>
       </div>
       {activeFormationMode && (

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -832,6 +832,15 @@ textarea {
 }
 
 .token.pass-route-eligible { cursor: pointer; }
+.token.run-player-eligible { cursor: pointer; }
+.token.run-player-eligible .player-marker {
+  opacity: 1;
+  border-color: var(--control-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--control-accent) 28%, transparent);
+}
+.token.run-player-selected .player-marker {
+  box-shadow: 0 0 0 7px color-mix(in srgb, var(--control-accent) 48%, transparent);
+}
 .token.pass-route-assigned .player-marker { border-color: var(--control-border-hover); }
 .token.pass-route-selected .player-marker {
   opacity: 1;

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -274,6 +274,7 @@ const REQUIRED_FORMATION_SLOTS = new Set<FormationSlot>([
   "RG",
 ]);
 const PASS_ROUTE_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4", "RB1", "RB2", "LT", "RT"];
+const RUNNER_SLOTS = new Set<FormationSlot>(["QB", "RB1", "RB2", "WR1", "WR4"]);
 const ROUTE_DEPTHS = ["Quick", "Short", "Short-Mid", "Mid", "Mid-Long", "Long", "Deep", "Shot", "Bomb"];
 const ROUTES_BY_DEPTH: Record<string, string[]> = {
   Quick: ["WR Screen", "Flat", "Swing", "Hitch", "Out", "Slant", "Drag"],
@@ -445,6 +446,8 @@ export default function GameField({
   animationRequest,
   onAnimationComplete,
   passSetup = false,
+  runSetup = false,
+  runner,
   routes = {},
   routeDepths = {},
   reads = {},
@@ -453,6 +456,8 @@ export default function GameField({
   onPassOptionsChange,
   onPassSetupClose,
   onPassPlay,
+  onRunnerSelect,
+  onRunSetupClose,
   children,
 }: {
   formationMode?: boolean;
@@ -476,6 +481,8 @@ export default function GameField({
   animationRequest?: { id: number; plan: unknown } | null;
   onAnimationComplete?: (id: number) => void;
   passSetup?: boolean;
+  runSetup?: boolean;
+  runner?: string;
   routes?: Record<string, string>;
   routeDepths?: Record<string, string>;
   reads?: Record<string, string>;
@@ -484,6 +491,8 @@ export default function GameField({
   onPassOptionsChange?: (patch: { routes?: Record<string, string>; routeDepths?: Record<string, string>; reads?: Record<string, string> }) => void;
   onPassSetupClose?: () => void;
   onPassPlay?: () => void;
+  onRunnerSelect?: (player: string) => void;
+  onRunSetupClose?: () => void;
   children?: ReactNode;
 }) {
   const fieldViewportRef = useRef<HTMLDivElement>(null);
@@ -505,8 +514,10 @@ export default function GameField({
   const footballFollowRafRef = useRef<number | null>(null);
   const activePhaseDurationMsRef = useRef(DEFAULT_PHASE_DURATION_MS);
   const passSetupRef = useRef(passSetup);
+  const runSetupRef = useRef(runSetup);
   const formationRef = useRef(formation);
   const onRoutePlayerSelectRef = useRef(onRoutePlayerSelect);
+  const onRunnerSelectRef = useRef(onRunnerSelect);
   const teamEndStyle = homeTeamPrimaryColor
     ? { background: homeTeamPrimaryColor }
     : undefined;
@@ -551,9 +562,11 @@ export default function GameField({
   // so opening pass setup never leaves the QB handler on the previous mode.
   useLayoutEffect(() => {
     passSetupRef.current = passSetup;
+    runSetupRef.current = runSetup;
     formationRef.current = formation;
     onRoutePlayerSelectRef.current = onRoutePlayerSelect;
-  }, [formation, onRoutePlayerSelect, passSetup]);
+    onRunnerSelectRef.current = onRunnerSelect;
+  }, [formation, onRoutePlayerSelect, onRunnerSelect, passSetup, runSetup]);
 
   useEffect(() => {
     const eligiblePlayers = new Set(eligibleRoutePlayers.map(({ player }) => player));
@@ -567,6 +580,10 @@ export default function GameField({
         player.el.style.removeProperty("opacity");
       }
       player.el.classList.toggle("pass-route-eligible", passSetup && isEligible);
+      const runnerSlot = Object.entries(formation).find(([, name]) => name === player.name)?.[0] as FormationSlot | undefined;
+      const isRunnerEligible = Boolean(runnerSlot && RUNNER_SLOTS.has(runnerSlot));
+      player.el.classList.toggle("run-player-eligible", runSetup && isRunnerEligible);
+      player.el.classList.toggle("run-player-selected", runSetup && runner === player.name);
       player.el.classList.toggle(
         "pass-route-selected",
         passSetup && selectedRoutePlayer === player.name,
@@ -586,7 +603,7 @@ export default function GameField({
         player.el.setAttribute("aria-label", `Open ${player.name} player actions`);
       }
     });
-  }, [eligibleRoutePlayers, formation.QB, passSetup, routes, selectedRoutePlayer]);
+  }, [eligibleRoutePlayers, formation, formation.QB, passSetup, routes, runSetup, runner, selectedRoutePlayer]);
 
   useEffect(() => {
     if (!passSetup) return;
@@ -1187,6 +1204,13 @@ export default function GameField({
             }
             return;
           }
+          if (runSetupRef.current) {
+            const runnerEntry = Object.entries(formationRef.current).find(
+              ([slot, name]) => name === player.name && RUNNER_SLOTS.has(slot as FormationSlot),
+            );
+            if (runnerEntry) onRunnerSelectRef.current?.(player.name);
+            return;
+          }
           const target = event.currentTarget as HTMLDivElement;
           const leftPct = parseFloat(target.style.left) || player.x;
           const topPct =
@@ -1526,13 +1550,14 @@ export default function GameField({
       <div className="field-viewport" id="fieldViewport" ref={fieldViewportRef}>
         {children && <div className="field-controls-overlay">{children}</div>}
         <div
-          className={`field-wrap ${passSetup ? "pass-setup-active" : ""}`}
+          className={`field-wrap ${passSetup ? "pass-setup-active" : ""} ${runSetup ? "run-setup-active" : ""}`}
           id="field"
           ref={fieldRef}
           onClick={() => {
             setSelectedPlayerMenu(null);
             setRevealedFormationSlot(null);
             if (passSetup) onPassSetupClose?.();
+            if (runSetup) onRunSetupClose?.();
           }}
         >
           <div className="field-title">Dynamic Football Animation View</div>
@@ -1751,7 +1776,15 @@ export default function GameField({
             <div className="pass-setup-toolbar" onClick={(event) => event.stopPropagation()}>
               <div><strong>Design pass play</strong><span>Select a highlighted receiver or the QB.</span></div>
               <button type="button" onClick={onPassSetupClose}>Cancel</button>
-              <button type="button" disabled={!routedPlayers.length} onClick={onPassPlay}>Run pass</button>
+              <button type="button" disabled={!routedPlayers.length} onClick={onPassPlay}>Set pass</button>
+            </div>
+          )}
+
+          {runSetup && (
+            <div className="pass-setup-toolbar run-setup-toolbar" onClick={(event) => event.stopPropagation()}>
+              <div><strong>Choose ball carrier</strong><span>Select a highlighted QB, RB1, RB2, WR1, or WR4.</span></div>
+              <button type="button" onClick={onRunSetupClose}>Cancel</button>
+              <button type="button" disabled={!runner} onClick={onRunSetupClose}>Set runner</button>
             </div>
           )}
 

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -2470,11 +2470,11 @@
 .radial-control-button {
   width: 74px;
   height: 74px;
-  border: 3px solid rgba(248, 250, 252, 0.92);
+  border: 3px solid var(--control-border-hover);
   border-radius: 50%;
-  background: rgba(15, 23, 42, 0.92);
-  color: #f8fafc;
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.48);
+  background: var(--surface-overlay);
+  color: var(--text-primary);
+  box-shadow: 0 14px 30px var(--shadow-color);
   display: grid;
   place-items: center;
   gap: 0;
@@ -2485,8 +2485,11 @@
 .radial-control-button.active,
 .radial-control-button:hover {
   border-color: var(--accent-red);
-  background: #0f172a;
+  background: var(--surface-raised);
 }
+
+.radial-control-button.play-called { border-color: var(--control-accent); }
+.radial-control-button:disabled { cursor: not-allowed; opacity: .5; }
 
 .radial-control-icon {
   font-size: 26px;


### PR DESCRIPTION
### Motivation

- Let the user choose a runner on the field when calling a run, matching the existing pass-setup UX for passes. 
- Add a dedicated "Snap Ball" football icon control that actually executes the play only when the selected play has been fully configured. 
- Keep new UI elements theme-aware by using the app's semantic design tokens.

### Description

- Introduces a pre-snap play state and runner-selection flow by adding `runSetup` and `selectedPlayType` state and plumbing through `GameCenter`, `GameControls`, and `GameField` via new props such as `onPlayTypeChange`, `onRunSetupChange`, `onRunnerSelect`, `onRunSetupClose`, `onSnap`, and `canSnap`. 
- Limits run-eligible field picks to the positions `QB`, `RB1`, `RB2`, `WR1`, and `WR4` (new `RUNNER_SLOTS`), highlights eligible tokens with `run-player-eligible` and `run-player-selected` classes, and makes clicking an eligible player assign the runner for the upcoming run play. 
- Adds a third radial button under Coach / Call Play that shows a football icon labeled `Snap Ball`, which is disabled until a play type is selected and the corresponding setup is complete (run requires a selected runner; pass requires at least one assigned receiver route). 
- Adjusts pass setup so the field toolbar now "sets" the pass configuration instead of immediately executing it, and execution of either play type is performed when Snap Ball is clicked; also updates CSS to use semantic tokens for control chrome and to style runner/pass highlight states.

### Testing

- Ran the production build with `npm run build`, which completed successfully and produced the `dist` artifacts. 
- Ran lint with `npm run lint`, which completed with no errors and a single existing React Hooks warning in `apps/web/src/components/league/GameField.tsx`.
- No automated browser or visual tests were executed in this environment, so interactive light/dark verification will need to be validated in a browser during QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a78c258ba888324bbca5ef8363d4602)