### PR TITLE
Fix recent games to follow each player’s current team

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -410,6 +410,9 @@ gameRoutes.get("/players/:playerName/games", async (req, res, next) => {
     const assignedTeam = String(playerTeams.find((assignment) =>
       String(assignment.Name ?? "").trim().toLowerCase() === playerName,
     )?.Team ?? "").trim();
+    // Prefer the current roster context supplied by the profile's entry point.
+    const requestedTeam = String(req.query.team ?? "").trim();
+    const currentTeam = requestedTeam || assignedTeam;
     const index = (headers: string[], ...names: string[]) =>
       headers.findIndex((header) => names.includes(normHeader(header)));
     const playGame = index(historySheet.headers, "gameid");
@@ -450,20 +453,26 @@ gameRoutes.get("/players/:playerName/games", async (req, res, next) => {
     const possession = index(historySheet.headers, "possession", "team");
     const games = gamesSheet.rows.flatMap((game) => {
       const id = String(cell(game, gameId));
-      const plays = byGame.get(id);
-      if (!plays?.length || String(cell(game, quarter)).trim().toUpperCase() !== "FINAL") return [];
+      const plays = byGame.get(id) ?? [];
+      if (String(cell(game, quarter)).trim().toUpperCase() !== "FINAL") return [];
+      const homeTeam = String(cell(game, home));
+      const awayTeam = String(cell(game, away));
+      const normalizedCurrentTeam = currentTeam.toLowerCase();
+      const belongsToCurrentTeam = normalizedCurrentTeam && [homeTeam, awayTeam]
+        .some((candidate) => candidate.trim().toLowerCase() === normalizedCurrentTeam);
+      // A player's current schedule—not their first recorded snap—determines
+      // their game log. Keep play-based behavior only for legacy assignments.
+      if (currentTeam ? !belongsToCurrentTeam : !plays.length) return [];
       const rushingPlays = plays.filter((play) =>
         String(cell(play, playPlayer)).trim().toLowerCase() === playerName &&
         (!cell(play, playType) || /run|rush/i.test(String(cell(play, playType)))),
       );
-      const homeTeam = String(cell(game, home));
-      const awayTeam = String(cell(game, away));
       // Possession belongs to the offense on a play, so it cannot identify the
       // player's team when this log contains one of their defensive plays.
       // Prefer the roster assignment and retain possession as a fallback for
       // legacy players without a PlayerTeams row.
-      const possessionTeam = String(cell(plays[0], possession)).trim();
-      const playerTeam = assignedTeam || possessionTeam;
+      const possessionTeam = plays[0] ? String(cell(plays[0], possession)).trim() : "";
+      const playerTeam = currentTeam || possessionTeam;
       const normalizedPlayerTeam = playerTeam.toLowerCase();
       const isHome = normalizedPlayerTeam === "home" || normalizedPlayerTeam === homeTeam.trim().toLowerCase();
       const teamScore = asNumber(cell(game, isHome ? homeScore : awayScore));

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -64,9 +64,11 @@ export type PlayerGame = {
 };
 export async function getPlayerGames(
   playerName: string,
+  team?: string,
 ): Promise<{ games: PlayerGame[] }> {
+  const teamQuery = team ? `?team=${encodeURIComponent(team)}` : "";
   return getJson(
-    `/players/${encodeURIComponent(playerName)}/games`,
+    `/players/${encodeURIComponent(playerName)}/games${teamQuery}`,
     "Failed to load player game log",
   );
 }

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -207,13 +207,14 @@ function PlayerStatsProfile({ player, row, team, stats, onBack }: { player: Play
   const isQuarterback = statSide === "offense" && shownPosition === "QB";
   const isReceiver = statSide === "offense" && (shownPosition === "WR" || shownPosition === "TE");
   const isDefensive = statSide === "defense";
+  const currentTeam = String(player.Team || team?.Abbrev || team?.Name || team?.Team || "").trim();
   useEffect(() => {
     if (!isRunningBack && !isQuarterback && !isReceiver && !isDefensive) return;
-    getPlayerGames(name).then(({ games }) => {
+    getPlayerGames(name, currentTeam).then(({ games }) => {
       setRecentGames(games);
       setGameStatTab(isDefensive ? "Defense" : isQuarterback ? "Passing" : isReceiver ? "Receiving" : "Rushing");
     }).catch(() => setRecentGames([])).finally(() => setGamesLoading(false));
-  }, [isDefensive, isQuarterback, isReceiver, isRunningBack, name]);
+  }, [currentTeam, isDefensive, isQuarterback, isReceiver, isRunningBack, name]);
   const rbGroups = [
     { title: "RUSHING", stats: [{ label: "CAR", fields: ["Carries", "Rushing Attempts", "Rush Attempts"] }, { label: "YDS", fields: ["Yards", "Rushing Yards", "Rush Yards"] }, { label: "AVG", value: summary.find((item) => item.label === "AVG")?.value || "0.0" }, { label: "TD", fields: RUSHING_TD_FIELDS }, { label: "LNG", fields: ["Long", "LNG"] }] },
     { title: "RECEIVING", stats: [{ label: "REC", fields: ["Receptions", "REC"] }, { label: "YDS", fields: ["Receiving Yards", "Rec Yards", "RecYards"] }, { label: "AVG", value: (statValue(row || {} as PlayerStats, ["Receptions", "REC"]) ? statValue(row || {} as PlayerStats, ["Receiving Yards", "Rec Yards", "RecYards"]) / statValue(row || {} as PlayerStats, ["Receptions", "REC"]) : 0).toFixed(1) }, { label: "TD", fields: ["Receiving TD", "Rec TD"] }, { label: "LNG", fields: ["Receiving Long", "Rec Long"] }] },
@@ -380,7 +381,7 @@ export function LeagueStats({ teams, games = [], onTeam }: { teams: LeagueTeam[]
   if (selectedPlayer) {
     const row = stats.find((item) => normalized(item.Player) === normalized(selectedPlayer.Name));
     const team = teamByKey.get(normalized(selectedPlayer.Team));
-    return <PlayerStatsProfile player={selectedPlayer} row={row} team={team} stats={stats} onBack={() => setSelectedPlayer(null)} />;
+    return <PlayerStatsProfile key={`${selectedPlayer.Name}-${selectedPlayer.Team}`} player={selectedPlayer} row={row} team={team} stats={stats} onBack={() => setSelectedPlayer(null)} />;
   }
 
   return <main className="league-stats-card">


### PR DESCRIPTION
### Motivation

- Recent-games shown on a player profile could reflect the team inferred from a play or the first play they participated in, causing incorrect opponent/score/home-away context. 
- The app should always show completed games for the team the player is currently assigned to on the profile, regardless of where the profile was opened or when the player first recorded a play. 

### Description

- Pass the selected player’s current team through the client API by adding an optional `team` parameter to `getPlayerGames` and appending it as a query string. (apps/web/src/api/client.ts)
- Use the supplied roster context in the backend handler for `/players/:playerName/games` so completed games are drawn from that team’s schedule instead of only games where the player has a recorded play. Legacy players without a team assignment retain play-based behavior. (apps/api/src/routes/gameRoutes.ts)
- Prefer the provided `team` when computing home/away, opponent, and score so results are consistent with the player’s current roster. (apps/api/src/routes/gameRoutes.ts)
- Prevent recent-game state leaking between profiles by forcing a fresh profile render when switching players via a keyed `PlayerStatsProfile` and guard against missing play rows when deriving possession. (apps/web/src/components/league/LeagueStats.tsx, apps/api/src/routes/gameRoutes.ts)

### Testing

- `cd apps/api && npm run typecheck` — succeeded. 
- `cd apps/api && npm test` — succeeded (all tests passed). 
- `cd apps/web && npm run build` — succeeded (production build completed). 
- `cd apps/web && npm run lint` — completed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` but no new errors. 
- `git diff --check` and commit completed; working tree is clean after commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a792478ee68832489dc9d9107d70644)