### PR TITLE
Add expandable league search (teams, players, articles)

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { getGames, getStandings, getTeams } from "../../api/client";
+import { getGames, getPlayers, getStandings, getTeams } from "../../api/client";
+import type { Player } from "../players/types";
+import { PlayerCard } from "../players/PlayerCard";
 import type { LeagueGame, LeagueTab, LeagueTeam } from "./types";
 import { mockGames, mockTeams } from "./leagueMockData";
 import { mergeStandingsWithTeams, normalizeGames } from "./leagueMappers";
@@ -22,6 +24,8 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [games, setGames] = useState<LeagueGame[]>(mockGames);
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [standings, setStandings] = useState<LeagueTeam[]>(mockTeams);
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
   const [selectedTeam, setSelectedTeam] = useState<LeagueTeam | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
@@ -35,8 +39,8 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
       })));
     });
   useEffect(() => {
-    Promise.all([getGames(), getStandings(), getTeams()])
-      .then(([gamesResponse, standingsResponse, teamsResponse]) => {
+    Promise.all([getGames(), getStandings(), getTeams(), getPlayers()])
+      .then(([gamesResponse, standingsResponse, teamsResponse, playersResponse]) => {
         const sheetTeams = teamsResponse.teams as LeagueTeam[];
         setTeams(sheetTeams);
         setGames(normalizeGames(gamesResponse.games, sheetTeams));
@@ -46,6 +50,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             sheetTeams,
           ),
         );
+        setPlayers(playersResponse.players);
       })
       .catch(() => {
         setGames(normalizeGames(mockGames, mockTeams));
@@ -140,6 +145,8 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
         <TeamDetail team={selectedTeam} standings={standings} games={games} onBack={() => setSelectedTeam(null)} onGame={openGame} />
       </section>
     );
+  if (selectedPlayer)
+    return <PlayerCard player={selectedPlayer} onBack={() => setSelectedPlayer(null)} />;
   return (
     <section className="league-app">
       <div className="app-loading hidden">
@@ -202,7 +209,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             onHome={returnToLeagueHome}
             onSelectGame={openGame}
           />
-          <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} />
+          <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} teams={teams} players={players} onTeam={setSelectedTeam} onPlayer={setSelectedPlayer} />
           <div id="tabContents">
             {activeTab === "news" && (
               <div className="league-tab-content active">

--- a/apps/web/src/components/league/LeagueHeader.tsx
+++ b/apps/web/src/components/league/LeagueHeader.tsx
@@ -1,15 +1,27 @@
 import type { LeagueTab } from "./types";
 import { LEAGUE_TABS } from "./leagueConstants";
+import { LeagueSearch } from "./LeagueSearch";
+import type { Player } from "../players/types";
+import type { LeagueTeam } from "./types";
 
 export function LeagueHeader({
   activeTab,
   onTabChange,
+  teams,
+  players,
+  onTeam,
+  onPlayer,
 }: {
   activeTab: LeagueTab;
   onTabChange: (tab: LeagueTab) => void;
+  teams: LeagueTeam[];
+  players: Player[];
+  onTeam: (team: LeagueTeam) => void;
+  onPlayer: (player: Player) => void;
 }) {
   return (
     <div className="league-header">
+      <LeagueSearch teams={teams} players={players} onTeam={onTeam} onPlayer={onPlayer} onArticle={(index) => { onTabChange("news"); window.setTimeout(() => document.getElementById(`article-${index}`)?.scrollIntoView({ behavior: "smooth", block: "center" }), 0); }} />
       <nav className="nav-tabs" aria-label="League tabs">
         {LEAGUE_TABS.map((tab) => (
           <button

--- a/apps/web/src/components/league/LeagueNews.tsx
+++ b/apps/web/src/components/league/LeagueNews.tsx
@@ -1,12 +1,6 @@
+import { leagueHeadlines } from "./leagueArticles";
+
 export function LeagueNews() {
-  const headlines = [
-    "Placeholder Headline One highlights late-game heroics",
-    "Placeholder Headline Two recaps pivotal injury report",
-    "Placeholder Headline Three focuses on coaching comments",
-    "Placeholder Headline Four previews Sunday night showdown",
-    "Placeholder Headline Five details roster shake-up notes",
-    "Placeholder Headline Six breaks down analyst power rankings",
-  ];
   return (
     <div className="news-feed">
       <section className="news-panel">
@@ -14,8 +8,8 @@ export function LeagueNews() {
           <h2 className="news-panel-title">Top Headlines</h2>
         </header>
         <ul className="news-headline-list">
-          {headlines.map((h, i) => (
-            <li className="news-headline-item" key={h}>
+          {leagueHeadlines.map((h, i) => (
+            <li className="news-headline-item" id={`article-${i}`} key={h}>
               <a className="news-headline-link" href="#">
                 <span className="headline-icon">📰</span>
                 {h}

--- a/apps/web/src/components/league/LeagueSearch.tsx
+++ b/apps/web/src/components/league/LeagueSearch.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Player } from "../players/types";
+import { PlayerImage } from "../players/PlayerImage";
+import { leagueHeadlines } from "./leagueArticles";
+import type { LeagueTeam } from "./types";
+
+type Props = {
+  teams: LeagueTeam[];
+  players: Player[];
+  onTeam: (team: LeagueTeam) => void;
+  onPlayer: (player: Player) => void;
+  onArticle: (index: number) => void;
+};
+
+const searchableTeamName = (team: LeagueTeam) =>
+  [team.City, team.Location, team.Name, team.Nickname, team.Team, team.Abbrev]
+    .filter(Boolean).join(" ");
+
+export function LeagueSearch({ teams, players, onTeam, onPlayer, onArticle }: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const normalized = query.trim().toLocaleLowerCase();
+  const results = useMemo(() => ({
+    teams: normalized ? teams.filter((team) => searchableTeamName(team).toLocaleLowerCase().includes(normalized)) : [],
+    players: normalized ? players.filter((player) => `${player.Name ?? ""} ${player.Team ?? ""} ${player.Pos ?? ""}`.toLocaleLowerCase().includes(normalized)) : [],
+    articles: normalized ? leagueHeadlines.map((headline, index) => ({ headline, index })).filter(({ headline }) => headline.toLocaleLowerCase().includes(normalized)) : [],
+  }), [normalized, players, teams]);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+    const close = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  const choose = (action: () => void) => { action(); setOpen(false); setQuery(""); };
+  const total = results.teams.length + results.players.length + results.articles.length;
+
+  return (
+    <div className={`league-search ${open ? "league-search--open" : ""}`} ref={rootRef} onKeyDown={(event) => event.key === "Escape" && setOpen(false)}>
+      {!open ? (
+        <button className="league-search__toggle" type="button" aria-label="Search teams, players, and articles" onClick={() => setOpen(true)}>
+          <span aria-hidden="true">⌕</span>
+        </button>
+      ) : (
+        <div className="league-search__control">
+          <span aria-hidden="true">⌕</span>
+          <input ref={inputRef} type="search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search teams, players, articles" aria-label="Search teams, players, and articles" />
+          <button type="button" aria-label="Close search" onClick={() => { setOpen(false); setQuery(""); }}>×</button>
+        </div>
+      )}
+      {open && normalized && (
+        <div className="league-search__results" role="listbox" aria-label="Search results">
+          {results.teams.length > 0 && <section><h3>Teams</h3>{results.teams.map((team) => <button type="button" key={String(team.ID ?? team.Team ?? team.Name)} onClick={() => choose(() => onTeam(team))}><img src={String(team.Logo ?? "")} alt="" /><span><strong>{searchableTeamName(team)}</strong><small>{team.Division ?? "League team"}</small></span></button>)}</section>}
+          {results.players.length > 0 && <section><h3>Players</h3>{results.players.map((player, index) => <button type="button" key={`${player.Name}-${player.Team}-${index}`} onClick={() => choose(() => onPlayer(player))}><PlayerImage player={player} className="league-search__player-image" /><span><strong>{player.Name}</strong><small>{player.Team}{player.Pos ? ` · ${player.Pos}` : ""}</small></span></button>)}</section>}
+          {results.articles.length > 0 && <section><h3>Articles</h3>{results.articles.map(({ headline, index }) => <button className="league-search__article" type="button" key={headline} onClick={() => choose(() => onArticle(index))}><strong>{headline}</strong></button>)}</section>}
+          {total === 0 && <p className="league-search__empty">No teams, players, or articles found.</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -62,21 +62,44 @@
 .games-banner__all { display: grid; place-items: center; grid-auto-flow: column; gap: 14px; flex: 0 0 145px; padding: 12px; color: var(--text-muted); border-left: 1px solid var(--gray-light); font-size: .74rem; }
 .games-banner__all span { color: var(--accent-red); font-size: 1.7rem; }
 .league-header {
+  display: flex;
   position: sticky;
   top: 88px;
   z-index: 100;
   min-height: 49px;
-  overflow-x: auto;
+  overflow: visible;
   background: var(--gray-medium);
   border-bottom: 1px solid var(--gray-light);
   scrollbar-width: none;
 }
+.league-search { position: relative; flex: 0 0 auto; align-self: stretch; display: flex; border-right: 1px solid var(--border-color); }
+.league-search__toggle { width: 58px; border: 0; background: transparent; color: var(--text-primary); cursor: pointer; font-size: 2rem; line-height: 1; }
+.league-search__toggle:hover, .league-search__toggle:focus-visible { background: var(--surface-subtle); color: var(--control-accent); }
+.league-search__control { display: flex; align-items: center; width: min(420px, 72vw); padding: 0 12px; color: var(--text-secondary); background: var(--surface-raised); }
+.league-search__control > span { font-size: 1.8rem; }
+.league-search__control input { min-width: 0; flex: 1; padding: 15px 10px; border: 0; outline: 0; color: var(--text-primary); background: transparent; font: inherit; }
+.league-search__control input::placeholder { color: var(--text-secondary); }
+.league-search__control button { border: 0; background: transparent; color: var(--text-secondary); cursor: pointer; font-size: 1.25rem; }
+.league-search__results { position: absolute; z-index: 150; top: 100%; left: 0; width: min(430px, 92vw); max-height: min(640px, 72vh); overflow-y: auto; border: 1px solid var(--border-color); background: var(--surface-raised); box-shadow: 0 12px 30px var(--shadow-color); }
+.league-search__results section + section { border-top: 1px solid var(--border-color); }
+.league-search__results h3 { margin: 0; padding: 18px 16px 10px; color: var(--text-secondary); font-size: .72rem; letter-spacing: .1em; text-transform: uppercase; }
+.league-search__results section > button { display: flex; align-items: center; gap: 12px; width: calc(100% - 24px); margin: 0 12px; padding: 11px 4px; border: 0; border-top: 1px dotted var(--border-color); background: transparent; color: var(--text-primary); cursor: pointer; text-align: left; }
+.league-search__results section > button:hover, .league-search__results section > button:focus-visible { background: var(--surface-subtle); outline: none; }
+.league-search__results img, .league-search__player-image { width: 38px; height: 38px; object-fit: contain; border-radius: 50%; background: var(--surface-subtle); }
+.league-search__results span { display: grid; gap: 3px; }
+.league-search__results strong { font-size: .8rem; }
+.league-search__results small { color: var(--text-secondary); }
+.league-search__results .league-search__article { padding-block: 14px; }
+.league-search__empty { margin: 0; padding: 24px 16px; color: var(--text-secondary); }
 .league-header::-webkit-scrollbar { display: none; }
 .nav-tabs {
   display: flex;
+  flex: 1 1 auto;
   justify-content: flex-start;
-  width: max-content;
-  min-width: 100%;
+  width: auto;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
 .nav-tab {
   flex: 0 0 auto;

--- a/apps/web/src/components/league/leagueArticles.ts
+++ b/apps/web/src/components/league/leagueArticles.ts
@@ -1,0 +1,8 @@
+export const leagueHeadlines = [
+  "Placeholder Headline One highlights late-game heroics",
+  "Placeholder Headline Two recaps pivotal injury report",
+  "Placeholder Headline Three focuses on coaching comments",
+  "Placeholder Headline Four previews Sunday night showdown",
+  "Placeholder Headline Five details roster shake-up notes",
+  "Placeholder Headline Six breaks down analyst power rankings",
+];


### PR DESCRIPTION
### Motivation

- Provide a quick, global search from the league tabs toolbar so users can find teams, players, or news headlines without navigating through each screen.  
- Results should be grouped and actionable so search hits directly open the related detail view or jump to an article.

### Description

- Add a new `LeagueSearch` component that toggles an expandable search control in the left side of the league header and performs case-insensitive matching across teams, players, and article headlines. (`apps/web/src/components/league/LeagueSearch.tsx`).
- Move article headlines into a shared `leagueArticles` module and add stable `id` anchors to headlines so article results can navigate into the News tab and scroll to a headline. (`apps/web/src/components/league/leagueArticles.ts`, `apps/web/src/components/league/LeagueNews.tsx`).
- Wire up players to be loaded with games/teams and surface player/team result actions that open the appropriate detail views (team detail, `PlayerCard`). (`apps/web/src/components/league/LeagueAppScreen.tsx`, `apps/web/src/components/league/LeagueHeader.tsx`).
- Add theme-aware styles and layout fixes for the header/search UI using the app semantic tokens and CSS variables, and adjust header layout to host the search control. (`apps/web/src/components/league/league.css`).

### Testing

- Built the web app with `npm run build` and the build completed successfully.  
- Ran lint with `npm run lint`; lint passed with a single pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`.  
- Started the dev server and verified a basic HTTP response with `curl -I http://127.0.0.1:5173`.  
- Visual/browser automation could not be completed in this environment because Playwright failed to download browsers (CDN responded with HTTP 403), so screenshot/visual theme verification was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7927f500d483249bc156c5acbe2432)