### PR TITLE
Show player jersey in search preview and open player card on Offensive Overview

### DIFF
--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { getGames, getPlayers, getStandings, getTeams } from "../../api/client";
 import type { Player } from "../players/types";
-import { PlayerCard } from "../players/PlayerCard";
 import type { LeagueGame, LeagueTab, LeagueTeam } from "./types";
 import { mockGames, mockTeams } from "./leagueMockData";
 import { mergeStandingsWithTeams, normalizeGames } from "./leagueMappers";
@@ -25,7 +24,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [standings, setStandings] = useState<LeagueTeam[]>(mockTeams);
   const [players, setPlayers] = useState<Player[]>([]);
-  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
+  const [searchedPlayer, setSearchedPlayer] = useState<Player | null>(null);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
   const [selectedTeam, setSelectedTeam] = useState<LeagueTeam | null>(null);
   const [loadingGame, setLoadingGame] = useState<LeagueGame | null>(null);
@@ -123,6 +122,17 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
     void refreshGames().catch(() => undefined);
   };
 
+  const searchablePlayers = useMemo(() => players.map((player) => {
+    const team = teams.find((candidate) => [candidate.Abbrev, candidate.Team, candidate.Name]
+      .some((value) => String(value || "").trim().toLocaleLowerCase() === String(player.Team || "").trim().toLocaleLowerCase()));
+    return { ...player, jersey: String(team?.["Away Jersey Crop"] || player.jersey || "") };
+  }), [players, teams]);
+
+  const openSearchedPlayer = (player: Player) => {
+    setSearchedPlayer(player);
+    setActiveTab("stats");
+  };
+
   if (selectedGame)
     return (
       <section className="league-app">
@@ -145,8 +155,6 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
         <TeamDetail team={selectedTeam} standings={standings} games={games} onBack={() => setSelectedTeam(null)} onGame={openGame} />
       </section>
     );
-  if (selectedPlayer)
-    return <PlayerCard player={selectedPlayer} onBack={() => setSelectedPlayer(null)} />;
   return (
     <section className="league-app">
       <div className="app-loading hidden">
@@ -209,7 +217,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             onHome={returnToLeagueHome}
             onSelectGame={openGame}
           />
-          <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} teams={teams} players={players} onTeam={setSelectedTeam} onPlayer={setSelectedPlayer} />
+          <LeagueHeader activeTab={activeTab} onTabChange={setActiveTab} teams={teams} players={searchablePlayers} onTeam={setSelectedTeam} onPlayer={openSearchedPlayer} />
           <div id="tabContents">
             {activeTab === "news" && (
               <div className="league-tab-content active">
@@ -233,7 +241,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             )}
             {activeTab === "stats" && (
               <div className="league-tab-content active">
-                <LeagueStats teams={teams} games={games} onTeam={setSelectedTeam} />
+                <LeagueStats key={`${searchedPlayer?.Name || "leaders"}-${searchedPlayer?.Team || ""}`} teams={teams} games={games} onTeam={setSelectedTeam} requestedPlayer={searchedPlayer} onPlayerClose={() => setSearchedPlayer(null)} />
               </div>
             )}
             {activeTab === "draft" && (

--- a/apps/web/src/components/league/LeagueStats.tsx
+++ b/apps/web/src/components/league/LeagueStats.tsx
@@ -279,7 +279,7 @@ function TeamCompleteTable({ mode, rows, onBack, onMode, onTeam }: { mode: "tota
   return <section className="team-complete-view"><div className="team-stat-nav" role="tablist" aria-label="Team statistic category"><button role="tab" aria-selected={!defensive && !special && mode !== "turnovers"} className={!defensive && !special && mode !== "turnovers" ? "active" : ""} type="button" onClick={() => onMode("team-total")}>Offense</button><button role="tab" aria-selected={defensive} className={defensive ? "active" : ""} type="button" onClick={() => onMode("team-defense")}>Defense</button><button role="tab" aria-selected={special} className={special ? "active" : ""} type="button" onClick={() => onMode("special-teams")}>Special Teams</button><button role="tab" aria-selected={mode === "turnovers"} className={mode === "turnovers" ? "active" : ""} type="button" onClick={() => onMode("team-turnovers")}>Turnovers</button></div><div className="team-stat-filters">{mode !== "turnovers" && <StatsSelect label="Statistic category" value={special ? "returning" : "total"}><option value={special ? "returning" : "total"}>{special ? "Returning" : "Total"}</option></StatsSelect>}<StatsSelect label="Season" value="season-1"><option value="season-1">Season 1 Regular Season</option></StatsSelect></div><button className="team-table-back" type="button" onClick={onBack}>← Back to stat leaders</button><div className="complete-leaders-table-scroll"><table className={`team-complete-table team-complete-table--${mode}`}><thead><tr><th colSpan={2} /><>{groups.map((group) => <th className="team-stat-group" colSpan={group.columns.length} key={group.label || "diff"}>{group.label}</th>)}</></tr><tr>{sortHeader("TEAM", "team")}{sortHeader("GP", "gp")}{groups.flatMap((group) => group.columns.map((column) => { const index = statisticIndex++; return <th key={`${group.label}-${column}-${index}`} aria-sort={sort.column === `stat-${index}` ? sort.direction === "asc" ? "ascending" : "descending" : "none"}><button className="stat-sort-button" type="button" onClick={() => changeSort(`stat-${index}`)}>{column} {sort.column === `stat-${index}` && <span aria-hidden="true">{sort.direction === "desc" ? "↓" : "↑"}</span>}</button></th>; }))}</tr></thead><tbody>{sortedRows.map((row) => <tr key={teamName(row.team)}><td><button className="team-table-name team-name-button" type="button" onClick={() => onTeam(row.team)}>{row.team.Logo && <img src={String(row.team.Logo)} alt="" />}{teamName(row.team)}</button></td><td>{row.gp}</td>{values(row).map((value, index) => <td key={index}>{Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1)}</td>)}</tr>)}</tbody></table></div></section>;
 }
 
-export function LeagueStats({ teams, games = [], onTeam }: { teams: LeagueTeam[]; games?: LeagueGame[]; onTeam: (team: LeagueTeam) => void }) {
+export function LeagueStats({ teams, games = [], onTeam, requestedPlayer = null, onPlayerClose }: { teams: LeagueTeam[]; games?: LeagueGame[]; onTeam: (team: LeagueTeam) => void; requestedPlayer?: Player | null; onPlayerClose?: () => void }) {
   const [activeView, setActiveView] = useState<StatsView>("Player");
   const [stats, setStats] = useState<PlayerStats[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
@@ -289,7 +289,7 @@ export function LeagueStats({ teams, games = [], onTeam }: { teams: LeagueTeam[]
   const [filter, setFilter] = useState("");
   const [completeSort, setCompleteSort] = useState<CompleteSort>({ column: "Yards", direction: "desc" });
   const [entrySortColumn, setEntrySortColumn] = useState("YDS");
-  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(requestedPlayer);
 
   useEffect(() => { Promise.all([getPlayerStats(), getPlayers()]).then(([statsResult, playersResult]) => { setStats(statsResult.playerStats); setPlayers(playersResult.players); }).catch((reason: unknown) => setError(reason instanceof Error ? reason.message : "Unable to load statistics")).finally(() => setLoading(false)); }, []);
 
@@ -379,9 +379,10 @@ export function LeagueStats({ teams, games = [], onTeam }: { teams: LeagueTeam[]
   const completeTitle = completeView === "tackling" ? "AFL Player Defense Stats" : isOffenseComplete ? `AFL Player ${completeView[0].toUpperCase() + completeView.slice(1)} Stats` : completeView ? "AFL Player Stat Leaders" : "AFL Stat Leaders";
 
   if (selectedPlayer) {
-    const row = stats.find((item) => normalized(item.Player) === normalized(selectedPlayer.Name));
-    const team = teamByKey.get(normalized(selectedPlayer.Team));
-    return <PlayerStatsProfile key={`${selectedPlayer.Name}-${selectedPlayer.Team}`} player={selectedPlayer} row={row} team={team} stats={stats} onBack={() => setSelectedPlayer(null)} />;
+    const profilePlayer = playerByName.get(normalized(selectedPlayer.Name)) || selectedPlayer;
+    const row = stats.find((item) => normalized(item.Player) === normalized(profilePlayer.Name));
+    const team = teamByKey.get(normalized(profilePlayer.Team));
+    return <PlayerStatsProfile key={`${profilePlayer.Name}-${profilePlayer.Team}`} player={profilePlayer} row={row} team={team} stats={stats} onBack={() => { setSelectedPlayer(null); onPlayerClose?.(); }} />;
   }
 
   return <main className="league-stats-card">

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -86,6 +86,7 @@
 .league-search__results section > button { display: flex; align-items: center; gap: 12px; width: calc(100% - 24px); margin: 0 12px; padding: 11px 4px; border: 0; border-top: 1px dotted var(--border-color); background: transparent; color: var(--text-primary); cursor: pointer; text-align: left; }
 .league-search__results section > button:hover, .league-search__results section > button:focus-visible { background: var(--surface-subtle); outline: none; }
 .league-search__results img, .league-search__player-image { width: 38px; height: 38px; object-fit: contain; border-radius: 50%; background: var(--surface-subtle); }
+.league-search__results .league-search__player-image { flex: 0 0 48px; width: 48px; height: 48px; overflow: hidden; border: 1px solid var(--border-color); border-radius: 8px; }
 .league-search__results span { display: grid; gap: 3px; }
 .league-search__results strong { font-size: .8rem; }
 .league-search__results small { color: var(--text-secondary); }


### PR DESCRIPTION
### Motivation
- Make the league search results show a player in their team jersey and make selecting a searched player navigate the UI to their player card with the offensive overview active.

### Description
- Pass a `searchablePlayers` list (players augmented with team jersey URL) into `LeagueHeader/LeagueSearch` and wire its `onPlayer` to an `openSearchedPlayer` handler so search results show player jerseys and behave like other in-app player links. (updates in `LeagueAppScreen.tsx`)
- Add a `requestedPlayer` prop to `LeagueStats` so the app can open the player profile from search and ensure the player profile closes clear this requested state; select the profile row from available players when opening the stats profile. (updates in `LeagueStats.tsx`)
- Add a small CSS rule to the search results so the player image/jersey preview is rendered at a consistent preview size and style. (update in `league.css`)

### Testing
- ✅ `npm run build` completed successfully and produced a production build. 
- ⚠️ `npm run lint` completed but reported a single non-blocking warning in `GameField.tsx`; no lint errors prevented the build. 
- ✅ Automated end-to-end verification: a headless dev instance and a Playwright script were run to exercise the search flow and capture screenshots, producing `search-preview-dark.png`, `search-preview-light.png`, and `player-offensive-overview.png`, which confirm the search preview shows the player jersey and that clicking the search result opens the player card on the Offensive/Overview tab.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a792be96fe88324a9f77b2716757d3c)