### PR TITLE
Move league search control to right edge of LeagueHeader

### DIFF
--- a/apps/web/src/components/league/LeagueHeader.tsx
+++ b/apps/web/src/components/league/LeagueHeader.tsx
@@ -21,7 +21,6 @@ export function LeagueHeader({
 }) {
   return (
     <div className="league-header">
-      <LeagueSearch teams={teams} players={players} onTeam={onTeam} onPlayer={onPlayer} onArticle={(index) => { onTabChange("news"); window.setTimeout(() => document.getElementById(`article-${index}`)?.scrollIntoView({ behavior: "smooth", block: "center" }), 0); }} />
       <nav className="nav-tabs" aria-label="League tabs">
         {LEAGUE_TABS.map((tab) => (
           <button
@@ -34,6 +33,7 @@ export function LeagueHeader({
           </button>
         ))}
       </nav>
+      <LeagueSearch teams={teams} players={players} onTeam={onTeam} onPlayer={onPlayer} onArticle={(index) => { onTabChange("news"); window.setTimeout(() => document.getElementById(`article-${index}`)?.scrollIntoView({ behavior: "smooth", block: "center" }), 0); }} />
     </div>
   );
 }

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -72,7 +72,7 @@
   border-bottom: 1px solid var(--gray-light);
   scrollbar-width: none;
 }
-.league-search { position: relative; flex: 0 0 auto; align-self: stretch; display: flex; border-right: 1px solid var(--border-color); }
+.league-search { position: relative; flex: 0 0 auto; align-self: stretch; display: flex; border-left: 1px solid var(--border-color); }
 .league-search__toggle { width: 58px; border: 0; background: transparent; color: var(--text-primary); cursor: pointer; font-size: 2rem; line-height: 1; }
 .league-search__toggle:hover, .league-search__toggle:focus-visible { background: var(--surface-subtle); color: var(--control-accent); }
 .league-search__control { display: flex; align-items: center; width: min(420px, 72vw); padding: 0 12px; color: var(--text-secondary); background: var(--surface-raised); }
@@ -80,7 +80,7 @@
 .league-search__control input { min-width: 0; flex: 1; padding: 15px 10px; border: 0; outline: 0; color: var(--text-primary); background: transparent; font: inherit; }
 .league-search__control input::placeholder { color: var(--text-secondary); }
 .league-search__control button { border: 0; background: transparent; color: var(--text-secondary); cursor: pointer; font-size: 1.25rem; }
-.league-search__results { position: absolute; z-index: 150; top: 100%; left: 0; width: min(430px, 92vw); max-height: min(640px, 72vh); overflow-y: auto; border: 1px solid var(--border-color); background: var(--surface-raised); box-shadow: 0 12px 30px var(--shadow-color); }
+.league-search__results { position: absolute; z-index: 150; top: 100%; right: 0; width: min(430px, 92vw); max-height: min(640px, 72vh); overflow-y: auto; border: 1px solid var(--border-color); background: var(--surface-raised); box-shadow: 0 12px 30px var(--shadow-color); }
 .league-search__results section + section { border-top: 1px solid var(--border-color); }
 .league-search__results h3 { margin: 0; padding: 18px 16px 10px; color: var(--text-secondary); font-size: .72rem; letter-spacing: .1em; text-transform: uppercase; }
 .league-search__results section > button { display: flex; align-items: center; gap: 12px; width: calc(100% - 24px); margin: 0 12px; padding: 11px 4px; border: 0; border-top: 1px dotted var(--border-color); background: transparent; color: var(--text-primary); cursor: pointer; text-align: left; }


### PR DESCRIPTION
### Motivation

- Move the search control to the far-right edge of the league header so the tabs remain left-aligned and the search sits at the header edge while preserving existing behavior and theme-aware styling.

### Description

- Reordered the JSX in `apps/web/src/components/league/LeagueHeader.tsx` to render `LeagueSearch` after the `.nav-tabs` element so the search appears on the right.
- Adjusted `apps/web/src/components/league/league.css` to flip the search divider from `border-right` to `border-left` and right-align the results panel by changing the results positioning from `left: 0` to `right: 0`.

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and `eslint` completed with no reported errors.
- Ran `git diff --check` with no whitespace or diff-check issues reported.
- Attempted automated visual verification with Playwright, but browser download failed due to the environment CDN returning HTTP 403, so manual/browser screenshots for `data-theme="dark"` and `data-theme="light"` were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a792fb438908324b7b12186000c6f48)