### PR TITLE
Update run play energy and fatigue calculations

### DIFF
--- a/apps/web/src/components/league/GameControls.tsx
+++ b/apps/web/src/components/league/GameControls.tsx
@@ -8,6 +8,7 @@ import type {
 import { buildDefense } from "./formationDefense";
 import { PlayerImage } from "../players/PlayerImage";
 import { playerImageUrl } from "../players/playerImageUrls";
+import { totalEnergy } from "./gameplay/engine/fatigueEngine";
 
 const str = (v: unknown) => String(v ?? "");
 const WR_SLOTS: FormationSlot[] = ["WR1", "WR2", "WR3", "WR4"];
@@ -21,6 +22,8 @@ const PLAYER_IDENTITY_FIELDS = new Set([
   "team", "name", "position", "pos", "defpos", "image", "photo",
   "player image from ai", "translatex", "translatey", "scale", "jersey",
   "jersey image",
+  // Energy bookkeeping is represented by the ring rather than raw table cells.
+  "energy", "fatigue", "temporaryfatigue",
 ]);
 
 type Player = Record<string, unknown>;
@@ -62,14 +65,9 @@ function imgOf(p?: Player) {
 }
 
 function staminaOf(player: Player) {
-  const value = Number(
-    player.fatigue ??
-      player.Fatigue ??
-      player.stamina ??
-      player.Stamina ??
-      100,
-  );
-  return Math.min(100, Math.max(0, Number.isFinite(value) ? value : 100));
+  // The roster ring displays usable total energy, not the underlying stamina
+  // trait or either individual fatigue component.
+  return totalEnergy(player);
 }
 
 function staminaColor(stamina: number) {
@@ -187,8 +185,8 @@ function RosterDetails({ roster }: { roster: Player[] }) {
                           "--stamina-color": staminaColor(stamina),
                         } as React.CSSProperties}
                         role="img"
-                        aria-label={`${nameOf(player)} stamina: ${Math.round(stamina)}%`}
-                        title={`${Math.round(stamina)}% stamina`}
+                        aria-label={`${nameOf(player)} total energy: ${Math.round(stamina)}%`}
+                        title={`${Math.round(stamina)}% total energy`}
                       >
                         <div className="roster-player-image" aria-hidden="true">
                           <PlayerImage player={player} fallback={<span>👤</span>} />

--- a/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
@@ -1,6 +1,8 @@
 import type { EngineContext, PlayerTrait } from "./types";
 
 const STATIC_TRAITS = new Set(["size", "strength"]);
+const STARTING_ENERGY = 100;
+const STARTING_TEMPORARY_FATIGUE = 0;
 
 function number(value: unknown, fallback = 0) {
   const parsed = Number(value);
@@ -13,60 +15,84 @@ function getPlayerName(player: PlayerTrait) {
   );
 }
 
-/** Returns the points removed from skill traits at the player's current in-game stamina. */
-export function fatigueTraitPenalty(
-  player: PlayerTrait | undefined,
-  traitName: string,
-) {
-  if (!player || STATIC_TRAITS.has(traitName.replace(/\s+/g, "").toLowerCase())) {
-    return 0;
-  }
+/** Returns the energy available for display and trait calculations. */
+export function totalEnergy(player: PlayerTrait | undefined) {
+  if (!player) return STARTING_ENERGY;
 
-  // A fatigue score is added when this player first participates in a play.
-  // Players who have not participated must retain their roster trait values.
-  if (player.fatigue === undefined || player.fatigue === null) return 0;
-
-  const remainingStamina = number(player.fatigue);
-  if (remainingStamina < 0) return 8;
-  if (remainingStamina < 5) return 5;
-  if (remainingStamina < 15) return 3;
-  return 0;
+  // Temporary fatigue is kept separate from the lasting energy drain so future
+  // recovery rules can restore it without also restoring a player's energy.
+  const energy = number(player.energy ?? player.Energy, STARTING_ENERGY);
+  const temporaryFatigue = number(
+    player.temporaryFatigue ?? player.TemporaryFatigue,
+    STARTING_TEMPORARY_FATIGUE,
+  );
+  return Math.max(0, Math.min(STARTING_ENERGY, energy - temporaryFatigue));
 }
 
-/** Applies the in-game stamina penalty to a non-static trait value. */
+/** Converts total energy into the percentage retained by non-static traits. */
+export function fatigueTraitPercentage(player: PlayerTrait | undefined) {
+  const energy = totalEnergy(player);
+  const percentage =
+    0.000026666666667 * energy ** 4 -
+    0.0016 * energy ** 3 +
+    0.019333333333334 * energy ** 2 +
+    0.94 * energy +
+    75;
+
+  // The curve is intentionally bounded: fatigue can never improve a trait or
+  // reduce it below 75 percent of the player's roster value.
+  return Math.max(75, Math.min(100, percentage));
+}
+
+/** Applies the total-energy multiplier to every trait except size and strength. */
 export function applyFatigueToTrait(
   player: PlayerTrait | undefined,
   traitName: string,
   value: number,
 ) {
-  return Math.max(0, value - fatigueTraitPenalty(player, traitName));
+  const normalizedTrait = traitName.replace(/\s+/g, "").toLowerCase();
+  if (!player || STATIC_TRAITS.has(normalizedTrait)) return value;
+  return Math.max(0, value * (fatigueTraitPercentage(player) / 100));
 }
 
-export function applyFatigue(
-  ctx: EngineContext,
-  playerName: string,
-  actionType: string,
-) {
+/** Energy drained from a ball carrier, based on the player's stamina trait. */
+export function ballCarrierEnergyDrain(stamina: number) {
+  return (
+    -0.000000884897437 * stamina ** 3 +
+    0.000306287478701 * stamina ** 2 -
+    0.067104126069643 * stamina +
+    6.5
+  );
+}
+
+/** Temporary fatigue added to a ball carrier after the run is complete. */
+export function ballCarrierTemporaryFatigue(stamina: number) {
+  return (
+    -0.000000884897437 * stamina ** 3 +
+    0.000306287478701 * stamina ** 2 -
+    0.067104126069643 * stamina +
+    5.5
+  );
+}
+
+/** Applies one run's ball-carrier fatigue after the play has been resolved. */
+export function applyRunFatigue(ctx: EngineContext, playerName: string) {
   const player = ctx.players.find(
     (candidate) => getPlayerName(candidate) === playerName,
   );
   if (!player) return;
-  const drain = number(
-    (ctx.settings.drainSettings as Record<string, unknown> | undefined)?.[
-      actionType
-    ] ??
-      (ctx.settings.staminaDrains as Record<string, unknown> | undefined)?.[
-        actionType
-      ] ??
-      (ctx.settings as Record<string, unknown>)[actionType] ??
-      0,
-  );
-  const stamina = number(player.stamina ?? player.Stamina, 100);
-  const currentStamina = number(player.fatigue, stamina);
 
-  // `fatigue` is the player's remaining in-game stamina. Do not clamp it: the
-  // below-zero tier deliberately carries the largest skill penalty.
-  player.fatigue = currentStamina - drain;
+  // Stamina controls how hard the play hits the runner; every player still
+  // begins the game with the same 100 energy and zero temporary fatigue.
+  const stamina = number(player.stamina ?? player.Stamina, 100);
+  const currentEnergy = number(player.energy ?? player.Energy, STARTING_ENERGY);
+  const currentTemporaryFatigue = number(
+    player.temporaryFatigue ?? player.TemporaryFatigue,
+    STARTING_TEMPORARY_FATIGUE,
+  );
+  player.energy = currentEnergy - ballCarrierEnergyDrain(stamina);
+  player.temporaryFatigue =
+    currentTemporaryFatigue + ballCarrierTemporaryFatigue(stamina);
 }
 
 type HistoricalPlay = Record<string, unknown>;
@@ -80,26 +106,27 @@ function historicalField(play: HistoricalPlay, fieldName: string) {
   return entry?.[1];
 }
 
-/**
- * Rebuilds in-game stamina from persisted plays.
- *
- * Player fatigue is intentionally not stored with the game, so loading a game
- * must replay each recorded action using the same drain settings as a live
- * play. Resetting every player first makes this safe to call again if game data
- * is refreshed, rather than charging the history more than once.
- */
+/** Rebuilds offensive fatigue by replaying persisted run plays. */
 export function applyFatigueFromPlayHistory(
   ctx: EngineContext,
   playHistory: HistoricalPlay[],
 ) {
+  // Fatigue is derived game state rather than saved roster data. Reset first so
+  // refreshing the same history is idempotent and all players start at 100/0.
   ctx.players.forEach((player) => {
-    player.fatigue = number(player.stamina ?? player.Stamina, 100);
+    player.energy = STARTING_ENERGY;
+    player.temporaryFatigue = STARTING_TEMPORARY_FATIGUE;
   });
 
   playHistory.forEach((play) => {
     const playerName = String(historicalField(play, "player") ?? "").trim();
     const actionType = String(historicalField(play, "playtype") ?? "").trim();
-    if (playerName && actionType) applyFatigue(ctx, playerName, actionType);
+
+    // For now a run's recorded ball carrier is the only offensive participant
+    // who receives fatigue; other play types remain deliberately unaffected.
+    if (playerName && actionType.toLowerCase() === "run") {
+      applyRunFatigue(ctx, playerName);
+    }
   });
 
   return ctx.players;

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -39,7 +39,7 @@ import {
   performBruiserCheck,
   performCarryDefenderChecks,
 } from "./runEngineHelper";
-import { applyFatigue } from "./fatigueEngine";
+import { applyRunFatigue } from "./fatigueEngine";
 import {
   runPlayJSONAnimationBuilder,
   type FirstRunChallenge,
@@ -593,9 +593,9 @@ export function runPlay(
     ),
   });
 
-  // Charge the rush after resolving the play so this snap uses the stamina the
-  // runner brought into it and every subsequent snap sees the updated score.
-  applyFatigue(ctx, runnerName, "Run");
+  // Charge only the ball carrier after resolution, so this snap uses the total
+  // energy the runner brought into it and the next snap sees the new fatigue.
+  applyRunFatigue(ctx, runnerName);
 
   return playResult;
 }


### PR DESCRIPTION
### Motivation
- Update the in-game fatigue model so players begin a game with `100` energy and `0` temporary fatigue and use the requested stamina-driven drain curves for run plays.
- Ensure only offensive ball carriers are charged by run plays for now and keep static traits (`size` and `strength`) unaffected by fatigue.
- Replace the previous tiered penalty model with the requested continuous multiplier based on the player's total energy for more gradual trait scaling.

### Description
- Reworked the fatigue engine at `apps/web/src/components/league/gameplay/engine/fatigueEngine.ts` to initialize `energy`/`temporaryFatigue`, expose `totalEnergy()`, and implement `fatigueTraitPercentage()` that bounds trait multiplier between `75` and `100`.
- Implemented the requested polynomial curves as `ballCarrierEnergyDrain(stamina)` and `ballCarrierTemporaryFatigue(stamina)`, and applied them after runs via `applyRunFatigue(ctx, playerName)`; play-history replay now resets players to `100` energy / `0` temp fatigue and replays only recorded run carriers.
- Changed trait application to multiply non-static traits by the fatigue percentage in `applyFatigueToTrait()` and left `size`/`strength` unchanged, and added explanatory comments in updated code paths.
- Updated integrations: `runEngine.ts` now calls `applyRunFatigue` after a resolved run, and `GameControls.tsx` now imports `totalEnergy` to show `total energy` in the Roster Details energy ring and update accessible labels; identity field handling was extended so raw fatigue bookkeeping is not shown as a sortable column.

### Testing
- Ran `git diff --check` and confirmed no whitespace or diff issues; check passed.
- Built the web app with `npm run build` which completed successfully and produced the production bundles.
- Ran `npm run lint` which completed with no errors (one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d2b4fbe7083249343540e2e3ad2af)