### PR TITLE
Add temporary fatigue recovery for bench players and opponent drives

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -306,6 +306,7 @@ function playValueForHeader(play: Record<string, unknown>, header: string) {
     brokentackles: ["brokenTackles", "brokentackles"],
     stopreason: ["stopReason", "stopreason"],
     runlog: ["runLog", "runlog"],
+    fatiguerecovery: ["fatigueRecovery", "fatiguerecovery"],
   };
 
   for (const key of aliases[normalized] ?? [normalized]) {

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -33,7 +33,10 @@ import {
   runPlay,
   spikeBall,
 } from "./gameplay/gameEngine";
-import { applyFatigueFromPlayHistory } from "./gameplay/engine/fatigueEngine";
+import {
+  applyFatigueFromPlayHistory,
+  applyFatigueRecovery,
+} from "./gameplay/engine/fatigueEngine";
 import type {
   FormationSlot,
   FrontendSettings,
@@ -1599,6 +1602,31 @@ export function GameCenter({
     if (playInFlightRef.current) return;
     playInFlightRef.current = true;
     const previousGame = currentGame;
+    const fatigueSnapshot = players.map((player) => ({
+      player,
+      energy: player.energy,
+      temporaryFatigue: player.temporaryFatigue,
+    }));
+    const offenseIsHome = currentGame.Possession === "Home";
+    const offenseTeam = offenseIsHome ? currentGame.Home : currentGame.Away;
+    const defenseTeam = offenseIsHome ? currentGame.Away : currentGame.Home;
+    const possessionChanged = result.game.Possession !== currentGame.Possession;
+    const trailingDrivePlays = [...history]
+      .reverse()
+      .findIndex(
+        (play) =>
+          str(playField(play, "Possession", "possession")) !==
+          currentGame.Possession,
+      );
+    const priorDrivePlays =
+      trailingDrivePlays === -1 ? history.length : trailingDrivePlays;
+    const fatigueRecovery = applyFatigueRecovery(ctx, {
+      offenseTeam: String(offenseTeam ?? ""),
+      defenseTeam: String(defenseTeam ?? ""),
+      offensivePlayers: Object.values(playOptions.formation ?? {}),
+      opponentDrivePlays: possessionChanged ? priorDrivePlays + 1 : 0,
+    });
+    Object.assign(result.play, { fatigueRecovery });
     setIsSavingPlay(true);
     const gamePayload = {
       gameId: result.game.GameId,
@@ -1648,6 +1676,10 @@ export function GameCenter({
         routeDepths: {},
       }));
     } catch (error) {
+      fatigueSnapshot.forEach(({ player, energy, temporaryFatigue }) => {
+        player.energy = energy;
+        player.temporaryFatigue = temporaryFatigue;
+      });
       setCurrentGame(previousGame);
       setLog((l) => [
         `Save failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/fatigueEngine.ts
@@ -97,6 +97,91 @@ export function applyRunFatigue(ctx: EngineContext, playerName: string) {
 
 type HistoricalPlay = Record<string, unknown>;
 
+export type FatigueRecovery = {
+  player: string;
+  amount: number;
+  reason: "bench" | "opponent-drive";
+};
+
+function randomBetween(min: number, max: number, random: () => number) {
+  return min + random() * (max - min);
+}
+
+function playerTeam(player: PlayerTrait) {
+  return String(player.team ?? player.Team ?? "").trim().toLowerCase();
+}
+
+function recoverTemporaryFatigue(player: PlayerTrait, amount: number) {
+  const current = number(
+    player.temporaryFatigue ?? player.TemporaryFatigue,
+    STARTING_TEMPORARY_FATIGUE,
+  );
+  player.temporaryFatigue = Math.max(0, current - Math.max(0, amount));
+}
+
+/**
+ * Applies recovery earned during a completed offensive snap. Exact rolls are
+ * returned so they can be saved with the play and replayed after a refresh.
+ */
+export function applyFatigueRecovery(
+  ctx: EngineContext,
+  options: {
+    offenseTeam: string;
+    defenseTeam: string;
+    offensivePlayers: string[];
+    opponentDrivePlays?: number;
+    random?: () => number;
+  },
+) {
+  const random = options.random ?? Math.random;
+  const offenseTeam = options.offenseTeam.trim().toLowerCase();
+  const defenseTeam = options.defenseTeam.trim().toLowerCase();
+  const onField = new Set(options.offensivePlayers.filter(Boolean));
+  const recovery: FatigueRecovery[] = [];
+
+  // An absent formation does not prove that everybody was on the bench (for
+  // example, special-teams calls do not currently carry an offensive lineup).
+  if (onField.size) {
+    ctx.players.forEach((player) => {
+      const name = getPlayerName(player);
+      if (playerTeam(player) !== offenseTeam || onField.has(name)) return;
+      const amount = randomBetween(0.75, 1.75, random);
+      recoverTemporaryFatigue(player, amount);
+      recovery.push({ player: name, amount, reason: "bench" });
+    });
+  }
+
+  const drivePlays = Math.max(0, options.opponentDrivePlays ?? 0);
+  if (drivePlays) {
+    ctx.players.forEach((player) => {
+      if (playerTeam(player) !== defenseTeam) return;
+      const amount =
+        randomBetween(3, 6, random) +
+        randomBetween(0.75, 1.5, random) * drivePlays;
+      recoverTemporaryFatigue(player, amount);
+      recovery.push({
+        player: getPlayerName(player),
+        amount,
+        reason: "opponent-drive",
+      });
+    });
+  }
+
+  return recovery;
+}
+
+function savedRecovery(play: HistoricalPlay): FatigueRecovery[] {
+  const value = historicalField(play, "fatigueRecovery");
+  if (Array.isArray(value)) return value as FatigueRecovery[];
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as FatigueRecovery[]) : [];
+  } catch {
+    return [];
+  }
+}
+
 function historicalField(play: HistoricalPlay, fieldName: string) {
   const normalizedFieldName = fieldName.replace(/[^a-z0-9]/gi, "").toLowerCase();
   const entry = Object.entries(play).find(
@@ -127,6 +212,13 @@ export function applyFatigueFromPlayHistory(
     if (playerName && actionType.toLowerCase() === "run") {
       applyRunFatigue(ctx, playerName);
     }
+
+    savedRecovery(play).forEach(({ player: recoveredPlayer, amount }) => {
+      const player = ctx.players.find(
+        (candidate) => getPlayerName(candidate) === recoveredPlayer,
+      );
+      if (player) recoverTemporaryFatigue(player, number(amount));
+    });
   });
 
   return ctx.players;


### PR DESCRIPTION
### Motivation

- Implement temporary fatigue recovery rules so bench players and defenders regain temporary fatigue after snaps and opponent drives per the new fatigue model.
- Persist exact recovery rolls with each play so rebuilding fatigue from history is deterministic and refresh-safe.
- Ensure recovery only reduces `temporaryFatigue` (never restores lasting `energy`) and can be rolled back if saving a play fails.

### Description

- Added `applyFatigueRecovery` (and helpers `randomBetween`, `recoverTemporaryFatigue`, `playerTeam`) to `apps/web/src/components/league/gameplay/engine/fatigueEngine.ts` to apply randomized recovery: `0.75–1.75` for bench players and `3–6 + (0.75–1.5 * opponentDrivePlays)` for defenders, returning per-player `FatigueRecovery` records.\
- Added `savedRecovery` and replay logic in `applyFatigueFromPlayHistory` so stored `fatigueRecovery` entries are applied when rebuilding fatigue from play history.\
- Updated `GameCenter.tsx` to compute drive length and offensive/defensive teams, call `applyFatigueRecovery` before persisting a play, attach `fatigueRecovery` to the saved `play`, and snapshot/restore player fatigue on save failure.\
- Extended API header mapping in `apps/api/src/routes/gameRoutes.ts` to include `fatigueRecovery` so serialized recovery records round-trip through the backend.

### Testing

- Built the web app with `npm run build` (success).\
- Ran lint with `npm run lint` (success; one pre-existing React Hooks warning in `GameField.tsx`).\
- Ran backend tests with `npm test` (all tests passed).\
- Ran typecheck with `npm run typecheck` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d2fc92ee8832481bb9318132c4ae0)