### PR TITLE
Add season week advancement

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -18,6 +18,30 @@ async function sheetRows(name: string) {
   if (!rows.length) throw new Error(`Sheet '${name}' not found or empty.`);
   return { headers: rows[0].map(String), rows: rows.slice(1) };
 }
+async function getSeasonWeek() {
+  const { headers, rows } = await sheetRows("Season");
+  const variableIndex = headers.findIndex((header) => normHeader(header) === "variable");
+  const valueIndex = headers.findIndex((header) => normHeader(header) === "value");
+  const weekRow = rows.find((row) => normHeader(cell(row, variableIndex)) === "week");
+  const week = Number(cell(weekRow ?? [], valueIndex));
+  if (variableIndex === -1 || valueIndex === -1 || !weekRow || !Number.isInteger(week) || week < 1) {
+    throw new Error("Season sheet must contain a positive numeric Week variable.");
+  }
+  return { week, rowNumber: rows.indexOf(weekRow) + 2, valueColumn: valueIndex };
+}
+async function advanceSeasonWeek() {
+  const season = await getSeasonWeek();
+  const { headers, rows } = await sheetRows("Games");
+  const weekIndex = headers.findIndex((header) => normHeader(header) === "week");
+  const quarterIndex = headers.findIndex((header) => ["qtr", "quarter"].includes(normHeader(header)));
+  const currentGames = rows.filter((row) => Number(cell(row, weekIndex)) === season.week);
+  if (!currentGames.length || currentGames.some((row) => String(cell(row, quarterIndex)).trim().toUpperCase() !== "FINAL")) {
+    throw new Error(`Week ${season.week} cannot advance until all of its games are final.`);
+  }
+  const column = String.fromCharCode(65 + season.valueColumn);
+  await batchUpdateSheetValues([{ range: `Season!${column}${season.rowNumber}`, values: [[season.week + 1]] }]);
+  return season.week + 1;
+}
 function objectFrom(headers: string[], row: Row) {
   const obj: Record<string, unknown> = {};
   headers.forEach((h, i) => (obj[h] = row[i] ?? ""));
@@ -515,6 +539,8 @@ gameRoutes.get("/teams", async (_req, res, next) => { try { res.json({ teams: aw
 gameRoutes.get("/standings", async (_req, res, next) => { try { res.json({ standings: await getStandingsFromSheet() }); } catch (e) { next(e); } });
 gameRoutes.get("/teams/:team/players", async (req, res, next) => { try { res.json({ players: await getTeamPlayers(req.params.team) }); } catch (e) { next(e); } });
 gameRoutes.get("/games", async (_req, res, next) => { try { res.json({ games: await getGamesList() }); } catch (e) { next(e); } });
+gameRoutes.get("/season", async (_req, res, next) => { try { res.json({ week: (await getSeasonWeek()).week }); } catch (e) { next(e); } });
+gameRoutes.post("/season/advance", async (_req, res, next) => { try { res.json({ ok: true, week: await advanceSeasonWeek() }); } catch (e) { next(e); } });
 gameRoutes.get("/games/:gameId/state", async (req, res, next) => { try { res.json({ gameState: await getGameState(req.params.gameId) }); } catch (e) { next(e); } });
 gameRoutes.get("/games/:gameId/play-history", async (req, res, next) => { try { res.json({ plays: await getPlayHistory(req.params.gameId) }); } catch (e) { next(e); } });
 gameRoutes.get("/frontend-settings", async (_req, res, next) => { try { res.json(await getFrontendSettingsFromSheet()); } catch (e) { next(e); } });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -99,6 +99,12 @@ export async function getGamesList(): Promise<{
 }> {
   return getJson("/games", "Failed to load games from backend API");
 }
+export async function getSeason(): Promise<{ week: number }> {
+  return getJson("/season", "Failed to load the current season week");
+}
+export async function advanceSeason(): Promise<{ ok: boolean; week: number }> {
+  return postJson("/season/advance", {}, "Failed to advance the season week");
+}
 export async function getGameState(
   gameId: string | number,
 ): Promise<{ gameState: Record<string, unknown> | null }> {

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getGames, getPlayers, getStandings, getTeams } from "../../api/client";
+import { advanceSeason, getGames, getPlayers, getSeason, getStandings, getTeams } from "../../api/client";
 import type { Player } from "../players/types";
 import type { LeagueGame, LeagueTab, LeagueTeam } from "./types";
 import { mockGames, mockTeams } from "./leagueMockData";
@@ -24,6 +24,9 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
   const [teams, setTeams] = useState<LeagueTeam[]>(mockTeams);
   const [standings, setStandings] = useState<LeagueTeam[]>(mockTeams);
   const [players, setPlayers] = useState<Player[]>([]);
+  const [seasonWeek, setSeasonWeek] = useState<number | null>(null);
+  const [isAdvancingWeek, setIsAdvancingWeek] = useState(false);
+  const [advanceWeekError, setAdvanceWeekError] = useState("");
   const [searchedPlayer, setSearchedPlayer] = useState<Player | null>(null);
   const [selectedGame, setSelectedGame] = useState<LeagueGame | null>(null);
   const [selectedTeam, setSelectedTeam] = useState<LeagueTeam | null>(null);
@@ -37,9 +40,9 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
         ...game,
       })));
     });
-  useEffect(() => {
-    Promise.all([getGames(), getStandings(), getTeams(), getPlayers()])
-      .then(([gamesResponse, standingsResponse, teamsResponse, playersResponse]) => {
+  const refreshLeagueData = () =>
+    Promise.all([getGames(), getStandings(), getTeams(), getPlayers(), getSeason()])
+      .then(([gamesResponse, standingsResponse, teamsResponse, playersResponse, seasonResponse]) => {
         const sheetTeams = teamsResponse.teams as LeagueTeam[];
         setTeams(sheetTeams);
         setGames(normalizeGames(gamesResponse.games, sheetTeams));
@@ -50,13 +53,32 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
           ),
         );
         setPlayers(playersResponse.players);
-      })
+        setSeasonWeek(seasonResponse.week);
+      });
+
+  useEffect(() => {
+    refreshLeagueData()
       .catch(() => {
         setGames(normalizeGames(mockGames, mockTeams));
         setTeams(mockTeams);
         setStandings(mockTeams);
-      });
+      })
   }, []);
+
+  const currentWeekGames = seasonWeek === null ? [] : games.filter((game) => Number(game.Week) === seasonWeek);
+  const canAdvanceWeek = currentWeekGames.length > 0 && currentWeekGames.every((game) => String(game.Qtr).trim().toUpperCase() === "FINAL");
+  const handleAdvanceWeek = async () => {
+    setIsAdvancingWeek(true);
+    setAdvanceWeekError("");
+    try {
+      await advanceSeason();
+      await refreshLeagueData();
+    } catch (error) {
+      setAdvanceWeekError(error instanceof Error ? error.message : "Failed to advance the season week");
+    } finally {
+      setIsAdvancingWeek(false);
+    }
+  };
 
   useEffect(() => {
     return () => {
@@ -226,6 +248,13 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
             )}
             {activeTab === "scores" && (
               <div className="league-tab-content active">
+                {canAdvanceWeek && (
+                  <section className="advance-week" aria-labelledby="advance-week-title">
+                    <div><span>WEEK {seasonWeek} COMPLETE</span><h2 id="advance-week-title">Ready for the next week?</h2></div>
+                    <button type="button" onClick={handleAdvanceWeek} disabled={isAdvancingWeek}>{isAdvancingWeek ? "Advancing…" : "Advance Week"}</button>
+                  </section>
+                )}
+                {advanceWeekError && <p className="advance-week__error" role="alert">{advanceWeekError}</p>}
                 <LeagueSchedule games={games} onSelectGame={openGame} />
               </div>
             )}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -129,6 +129,27 @@
   color: var(--text-muted);
   font-size: clamp(16px, 4vw, 24px);
 }
+.advance-week {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 24px 2.5vw 0;
+  padding: 20px 24px;
+  color: var(--text-primary);
+  border: 1px solid var(--control-border);
+  border-radius: 12px;
+  background: var(--surface-raised);
+  box-shadow: 0 4px 12px var(--shadow-color);
+}
+.advance-week span { color: var(--control-accent); font-size: .72rem; font-weight: 800; letter-spacing: .1em; }
+.advance-week h2 { margin: 5px 0 0; font-size: 1.25rem; }
+.advance-week button { padding: 12px 20px; color: var(--text-primary); border: 1px solid var(--control-border); border-radius: 9px; background: var(--control-bg); box-shadow: 0 3px 10px var(--shadow-color); font: inherit; font-weight: 800; cursor: pointer; }
+.advance-week button:hover, .advance-week button:focus-visible { border-color: var(--control-border-hover); background: var(--control-bg-hover); outline: none; }
+.advance-week button:focus-visible { box-shadow: 0 0 0 3px color-mix(in srgb, var(--control-accent) 30%, transparent); }
+.advance-week button:disabled { cursor: wait; opacity: .65; }
+.advance-week__error { margin: 12px 2.5vw 0; color: var(--text-primary); }
+@media (max-width: 600px) { .advance-week { align-items: stretch; flex-direction: column; } }
 .news-feed {
   display: grid;
   gap: 3vw;


### PR DESCRIPTION
### Motivation

- Provide an "advance week" mechanic that increments the Season sheet Week variable and refreshes frontend data when a week is complete. 
- Ensure the action is only available once all games in the current week are finished to prevent premature progression.

### Description

- Backend: added `getSeasonWeek` and `advanceSeasonWeek` helpers that validate the Season sheet and require every game in the current week to be `FINAL` before writing the incremented week, and exposed `/season` and `/season/advance` endpoints. 【F:apps/api/src/routes/gameRoutes.ts†L21-L43】【F:apps/api/src/routes/gameRoutes.ts†L541-L543】
- Client: added `getSeason` and `advanceSeason` methods to the web API client to call the new endpoints. 【F:apps/web/src/api/client.ts†L102-L107】
- UI: updated `LeagueAppScreen` to load the current season week, show an "Advance Week" clear action on the league home when every game for the active week is `FINAL`, and call the advance API then repull games/standings/teams/players/season data. 【F:apps/web/src/components/league/LeagueAppScreen.tsx†L43-L57】【F:apps/web/src/components/league/LeagueAppScreen.tsx†L249-L258】
- Styling: added responsive, theme-aware `.advance-week` styles that use the app's semantic tokens and work in both dark and light themes. 【F:apps/web/src/components/league/league.css†L132-L152】

### Testing

- Ran API unit tests with `npm test` in `apps/api` and they passed. 
- Ran type checking `npm run typecheck` and the web build `npm run build` which both succeeded. 
- Ran frontend lint `npm run lint` which completed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`. 
- Visually checked the new Advance Week UI in both dark and light themes using headless screenshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d32a897ec83248c154ad40914c7d3)