### PR TITLE
Default league views to current week

### DIFF
--- a/apps/web/src/components/league/GamesBanner.tsx
+++ b/apps/web/src/components/league/GamesBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AppSelect } from "../ui/AppSelect";
 import type { LeagueGame } from "./types";
 import { formatBallOnForPoss, formatClock, formatDownDistance } from "./leagueMappers";
@@ -10,12 +10,18 @@ const gameWeek = (game: LeagueGame, index: number) =>
 
 type GamesBannerProps = {
   games: LeagueGame[];
+  currentWeek: number | null;
   onHome: () => void;
   onSelectGame: (game: LeagueGame) => void;
 };
 
-export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
-  const [week, setWeek] = useState(1);
+export function GamesBanner({ games, currentWeek, onHome, onSelectGame }: GamesBannerProps) {
+  const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
+  const week = selectedWeek ?? currentWeek ?? 1;
+  const weeks = useMemo(() => {
+    const gameWeeks = games.map(gameWeek).filter(Number.isFinite);
+    return [...new Set([...WEEKS, ...gameWeeks, ...(currentWeek === null ? [] : [currentWeek])])].sort((a, b) => a - b);
+  }, [currentWeek, games]);
   const weekGames = games.filter((game, index) => gameWeek(game, index) === week);
 
   return (
@@ -30,8 +36,8 @@ export function GamesBanner({ games, onHome, onSelectGame }: GamesBannerProps) {
       </button>
       <label className="games-banner__picker">
         <span>Week</span>
-        <AppSelect containerClassName="app-select--compact" value={week} onChange={(event) => setWeek(Number(event.target.value))}>
-          {WEEKS.map((item) => <option key={item} value={item}>Week {item}</option>)}
+        <AppSelect containerClassName="app-select--compact" value={week} onChange={(event) => setSelectedWeek(Number(event.target.value))}>
+          {weeks.map((item) => <option key={item} value={item}>Week {item}</option>)}
         </AppSelect>
       </label>
       <div className="games-banner__rail">

--- a/apps/web/src/components/league/LeagueAppScreen.tsx
+++ b/apps/web/src/components/league/LeagueAppScreen.tsx
@@ -160,6 +160,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
       <section className="league-app">
         <GamesBanner
           games={games}
+          currentWeek={seasonWeek}
           onHome={returnToLeagueHome}
           onSelectGame={openGame}
         />
@@ -171,6 +172,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
       <section className="league-app">
         <GamesBanner
           games={games}
+          currentWeek={seasonWeek}
           onHome={returnToLeagueHome}
           onSelectGame={openGame}
         />
@@ -236,6 +238,7 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
           )}
           <GamesBanner
             games={games}
+            currentWeek={seasonWeek}
             onHome={returnToLeagueHome}
             onSelectGame={openGame}
           />
@@ -255,12 +258,12 @@ export function LeagueAppScreen({ onBack }: LeagueAppScreenProps) {
                   </section>
                 )}
                 {advanceWeekError && <p className="advance-week__error" role="alert">{advanceWeekError}</p>}
-                <LeagueSchedule games={games} onSelectGame={openGame} />
+                <LeagueSchedule games={games} currentWeek={seasonWeek} onSelectGame={openGame} />
               </div>
             )}
             {activeTab === "schedules" && (
               <div className="league-tab-content active">
-                <LeagueSchedules games={games} teams={teams} onSelectGame={openGame} onSelectTeam={setSelectedTeam} />
+                <LeagueSchedules games={games} teams={teams} currentWeek={seasonWeek} onSelectGame={openGame} onSelectTeam={setSelectedTeam} />
               </div>
             )}
             {activeTab === "standings" && (

--- a/apps/web/src/components/league/LeagueSchedule.tsx
+++ b/apps/web/src/components/league/LeagueSchedule.tsx
@@ -19,13 +19,15 @@ function kickoffParts(game: LeagueGame) {
   };
 }
 
-export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; onSelectGame: (game: LeagueGame) => void }) {
-  const [activeWeek, setActiveWeek] = useState(1);
+export function LeagueSchedule({ games, currentWeek, onSelectGame }: { games: LeagueGame[]; currentWeek: number | null; onSelectGame: (game: LeagueGame) => void }) {
+  const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
+  const activeWeek = selectedWeek ?? currentWeek ?? 1;
   const weekGames = useMemo(
     () => games.filter((game, index) => gameWeek(game, index) === activeWeek),
     [activeWeek, games],
   );
   const finalGames = weekGames.filter((game) => String(game.Qtr).toUpperCase() === "FINAL").length;
+
   const weekLabel = (week: number) => {
     const game = games.find((item, index) => gameWeek(item, index) === week);
     if (!game) return `WEEK ${week}`;
@@ -43,7 +45,7 @@ export function LeagueSchedule({ games, onSelectGame }: { games: LeagueGame[]; o
       </header>
       <nav className="week-tabs" aria-label="Scoreboard weeks">
         {WEEKS.map((week) => (
-          <button key={week} type="button" className={activeWeek === week ? "active" : ""} onClick={() => setActiveWeek(week)}>
+          <button key={week} type="button" className={activeWeek === week ? "active" : ""} onClick={() => setSelectedWeek(week)}>
             <span>WEEK {week}</span><small>{weekLabel(week)}</small>
           </button>
         ))}

--- a/apps/web/src/components/league/LeagueSchedules.tsx
+++ b/apps/web/src/components/league/LeagueSchedules.tsx
@@ -38,11 +38,13 @@ function dayKey(game: LeagueGame) {
 export function LeagueSchedules({
   games,
   teams,
+  currentWeek,
   onSelectGame,
   onSelectTeam,
 }: {
   games: LeagueGame[];
   teams: LeagueTeam[];
+  currentWeek: number | null;
   onSelectGame: (game: LeagueGame) => void;
   onSelectTeam?: (team: LeagueTeam) => void;
 }) {
@@ -61,8 +63,8 @@ export function LeagueSchedules({
     });
     return [...labels].sort((a, b) => a[1].localeCompare(b[1]));
   }, [games, teams]);
-  const weeks = useMemo(() => [...new Set(games.map(getWeek))].sort((a, b) => a - b), [games]);
-  const displayedWeek = activeWeek ?? weeks[0];
+  const weeks = useMemo(() => [...new Set([...games.map(getWeek), ...(currentWeek === null ? [] : [currentWeek])])].sort((a, b) => a - b), [currentWeek, games]);
+  const displayedWeek = activeWeek ?? currentWeek ?? weeks[0];
 
   const visibleGames = useMemo(() => games.filter((game, index) =>
     getWeek(game, index) === displayedWeek


### PR DESCRIPTION
### Motivation
- Ensure the Scores tab, Schedules tab, and top game carousel show the current season week by default so users land on the active week when opening league screens.
- Preserve existing manual week selection while including dynamically-discovered weeks and the backend-provided season week in the week picker.

### Description
- Pass the current season week from the league screen into the carousel and tab components by adding a `currentWeek`/`currentWeek: number | null` prop to `GamesBanner`, `LeagueSchedule`, and `LeagueSchedules`. 
- Update `GamesBanner` to include `currentWeek` in its computed week list and to default to the backend-provided week while keeping a local `selectedWeek` override when the user chooses a different week. 
- Update `LeagueSchedule` and `LeagueSchedules` to derive their displayed week from a `selectedWeek` override or the `currentWeek` fallback so tabs default to the current week without forcing user selection. 
- Replace the previous effect-based state sync (which triggered lint errors) with a `selectedWeek ?? currentWeek ?? default` pattern to avoid synchronous `setState` in effects and preserve manual selection.
- Files changed: `apps/web/src/components/league/GamesBanner.tsx`, `LeagueSchedule.tsx`, `LeagueSchedules.tsx`, and `LeagueAppScreen.tsx`.

### Testing
- Built the web app with `npm run build` and the production bundle completed successfully. 
- Ran lint with `npm run lint` and it completed with a pre-existing `react-hooks/exhaustive-deps` warning in `apps/web/src/components/league/GameField.tsx` but no new errors from these changes. 
- Ran repository checks (`git diff --check`) and local validations which returned no new issues related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d34e848a883248b6b4dae6e1486b4)