### PR TITLE
Fix Vite parse error by closing `getArticles` function

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -114,6 +114,7 @@ export type LeagueArticle = {
 };
 export async function getArticles(): Promise<{ articles: LeagueArticle[] }> {
   return getJson("/articles", "Failed to load league articles");
+}
 export async function getSeason(): Promise<{ week: number }> {
   return getJson("/season", "Failed to load the current season week");
 }


### PR DESCRIPTION
### Motivation
- A missing closing brace caused a TypeScript parse error (OXC/Vite: Expected `}`) that prevented the dev server and builds from parsing the API client, so the `getArticles` function needed to be properly closed.

### Description
- Inserted the missing `}` to close `getArticles` in `apps/web/src/api/client.ts`, restoring valid TypeScript structure and preventing downstream parsing issues.

### Testing
- Ran `npm ci`, `npm run build`, `npm run lint`, and `git diff --check`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d378211788324885b1f69fa8983d2)