### PR TITLE
Document web dependency install and add league news (react-markdown)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,5 +1,21 @@
 # React + TypeScript + Vite
 
+## Local development
+
+Install the web app's locked dependencies before starting Vite, and repeat this
+step after pulling a change to `package.json` or `package-lock.json`:
+
+```sh
+cd apps/web
+npm ci
+npm run dev
+```
+
+If Vite reports that it cannot resolve an installed package (for example,
+`react-markdown`), stop the development server, run `npm ci` from `apps/web`,
+and then restart the server. This refreshes `node_modules` from the committed
+lockfile instead of leaving Vite to use a stale installation.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:


### PR DESCRIPTION
### Motivation

- Ensure contributors install the web app's locked dependencies before running Vite so Vite can resolve packages declared in the lockfile. 
- Surface published league articles in the UI using the committed article model and markdown rendering so editors can author rich article content.

### Description

- Add local development instructions to `apps/web/README.md` that recommend running `npm ci` in `apps/web` before starting Vite and document the fix for Vite resolution errors like `react-markdown`.
- Add `react-markdown` to `apps/web/package.json` and update the lockfile to pin the dependency. 
- Replace the placeholder secondary headlines with a `LeagueNews` implementation in `apps/web/src/components/league/LeagueNews.tsx` that fetches articles via `getArticles`, renders a feature and headline list, shows a detailed `ArticleView`, renders article markdown with `ReactMarkdown`, exposes an `articleExcerpt` helper, and handles load failures and empty states. 
- Minor JSX/markup tidy in the news UI and accompanying CSS changes referenced by the commit.

### Testing

- Ran `cd apps/web && npm ci` which completed successfully. 
- Ran `cd apps/web && npm run build` which produced a successful production build and emitted chunk-size warnings only. 
- Ran `cd apps/web && npm run lint` which completed with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d38876d3c832493b1997e24586877)