### PR TITLE
Add start-game button and opening coin toss flow

### DIFF
--- a/apps/web/src/components/league/GameCenter.css
+++ b/apps/web/src/components/league/GameCenter.css
@@ -73,6 +73,22 @@
   background: var(--gray-medium);
   box-shadow: 0 8px 28px var(--shadow-color);
 }
+.pregame-start { display: flex; align-items: center; justify-content: center; gap: 18px; margin: 22px auto 0; color: var(--text-secondary); font-weight: 700; }
+.pregame-start-button, .toss-actions button { border: 1px solid var(--control-border); border-radius: 10px; background: var(--control-bg); color: var(--text-primary); padding: 11px 22px; font: inherit; font-weight: 800; cursor: pointer; box-shadow: 0 5px 16px var(--shadow-color); }
+.pregame-start-button:hover, .pregame-start-button:focus-visible, .toss-actions button:hover, .toss-actions button:focus-visible { border-color: var(--control-border-hover); background: var(--control-bg-hover); outline: 3px solid color-mix(in srgb, var(--control-accent) 28%, transparent); }
+.toss-overlay { position: fixed; inset: 0; z-index: 1000; display: grid; place-items: center; padding: 20px; background: color-mix(in srgb, var(--surface-canvas) 78%, transparent); backdrop-filter: blur(8px); }
+.toss-dialog { width: min(460px, 100%); box-sizing: border-box; padding: clamp(24px, 5vw, 42px); border: 1px solid var(--border-color); border-radius: 18px; background: var(--surface-raised); color: var(--text-primary); text-align: center; box-shadow: 0 24px 70px var(--shadow-color); }
+.toss-kicker { color: var(--text-secondary); font-size: .72rem; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; }
+.toss-dialog h2 { margin: 8px 0 20px; }
+.toss-dialog p { margin: 20px 0 0; color: var(--text-secondary); line-height: 1.5; }
+.toss-dialog strong { color: var(--text-primary); }
+.toss-coin { display: grid; width: 112px; height: 112px; margin: 0 auto; place-items: center; border: 7px double #8a6415; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #fff2a8, #d49a22 58%, #8a6415); color: #4b3508; font-family: Georgia, serif; font-size: 3.2rem; font-weight: 900; box-shadow: 0 10px 26px var(--shadow-color); }
+.toss-coin.is-flipping { animation: coin-flip 1.4s cubic-bezier(.2,.7,.3,1); }
+.toss-actions { display: flex; justify-content: center; gap: 12px; margin-top: 24px; }
+.toss-error { color: var(--accent-red) !important; font-weight: 700; }
+@keyframes coin-flip { 0% { transform: rotateY(0) translateY(0) scale(1); } 45% { transform: rotateY(900deg) translateY(-48px) scale(1.12); } 100% { transform: rotateY(1800deg) translateY(0) scale(1); } }
+@media (prefers-reduced-motion: reduce) { .toss-coin.is-flipping { animation-duration: .01ms; } }
+@media (max-width: 520px) { .pregame-start { flex-direction: column; gap: 10px; } .toss-actions { flex-direction: column; } }
 
 .pregame-heading { margin-bottom: 20px; text-align: center; }
 .pregame-heading span, .pregame-team-card header span { color: var(--text-muted); font-size: .7rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -56,6 +56,9 @@ const isPregame = (game: LeagueGame) => {
   const quarter = String(game.Qtr ?? "").trim().toUpperCase();
   return !quarter || quarter === "0" || quarter === "UNSTARTED" || quarter === "PREGAME";
 };
+type TossSide = "Heads" | "Tails";
+type TossChoice = "receive" | "kick";
+type TossPhase = "idle" | "call" | "flipping" | "decision" | "saving";
 
 type Play = Record<string, unknown>;
 type LineStatMatchup = {
@@ -1499,6 +1502,11 @@ export function GameCenter({
     id: number;
     plan: AnimationPlan;
   } | null>(null);
+  const [tossPhase, setTossPhase] = useState<TossPhase>("idle");
+  const [tossCall, setTossCall] = useState<TossSide | null>(null);
+  const [tossResult, setTossResult] = useState<TossSide | null>(null);
+  const [tossError, setTossError] = useState("");
+  const tossTimerRef = useRef<number | null>(null);
   const animationSequenceRef = useRef(0);
   const animationResolverRef = useRef<{
     id: number;
@@ -1577,6 +1585,98 @@ export function GameCenter({
       active = false;
     };
   }, [game]);
+
+  useEffect(() => () => {
+    if (tossTimerRef.current !== null) window.clearTimeout(tossTimerRef.current);
+  }, []);
+
+  const beginGame = () => {
+    if (!isPregame(currentGame)) return;
+    setCurrentGame((current) => ({ ...current, Qtr: 1, Time: 900 }));
+    setTossCall(null);
+    setTossResult(null);
+    setTossError("");
+    setTossPhase("call");
+  };
+
+  const callToss = (call: TossSide) => {
+    const result: TossSide = Math.random() < 0.5 ? "Heads" : "Tails";
+    setTossCall(call);
+    setTossResult(result);
+    setTossPhase("flipping");
+    tossTimerRef.current = window.setTimeout(() => {
+      setTossPhase("decision");
+      if (call !== result) {
+        const awayChoice: TossChoice = Math.random() < 0.8 ? "receive" : "kick";
+        tossTimerRef.current = window.setTimeout(() => {
+          tossTimerRef.current = null;
+          void finishToss(awayChoice, call, result);
+        }, 1200);
+      } else {
+        tossTimerRef.current = null;
+      }
+    }, 1400);
+  };
+
+  const finishToss = async (
+    winnerChoice: TossChoice,
+    completedCall = tossCall,
+    completedResult = tossResult,
+  ) => {
+    if (!completedCall || !completedResult) return;
+    const homeWon = completedCall === completedResult;
+    const winner = homeWon ? "Home" : "Away";
+    const receivingTeam = winnerChoice === "receive"
+      ? winner
+      : winner === "Home" ? "Away" : "Home";
+    const ballOn = receivingTeam === "Home" ? 25 : 75;
+    const startedGame: LeagueGame = {
+      ...currentGame,
+      Qtr: 1,
+      Time: 900,
+      Down: 1,
+      Distance: 10,
+      BallOn: ballOn,
+      Possession: receivingTeam,
+      DriveStart: ballOn,
+      Previous: ballOn,
+    } as LeagueGame;
+    setTossPhase("saving");
+    setTossError("");
+    try {
+      await savePlayAndGame(startedGame.GameId, {
+        game: {
+          gameId: startedGame.GameId,
+          quarter: 1,
+          time: 900,
+          down: 1,
+          distance: 10,
+          ballOn,
+          homeScore: startedGame.HomeScore,
+          awayScore: startedGame.AwayScore,
+          driveStart: ballOn,
+          previous: ballOn,
+          possession: receivingTeam,
+          homeTimeouts: 3,
+          awayTimeouts: 3,
+        },
+      });
+      setCurrentGame(startedGame);
+      previousPossessionRef.current = receivingTeam;
+      setIsGameFieldCollapsed(false);
+      setTossPhase("idle");
+      setLog((messages) => [
+        `${homeWon ? currentGame.Home : currentGame.Away} won the toss and chose to ${winnerChoice}. ${receivingTeam === "Home" ? currentGame.Home : currentGame.Away} starts at its 25-yard line.`,
+        ...messages,
+      ]);
+      onGameUpdate?.(startedGame);
+    } catch (error) {
+      setTossError(error instanceof Error ? error.message : "Failed to start the game");
+      setTossPhase("decision");
+    }
+  };
+
+  const homeWonToss = Boolean(tossCall && tossResult && tossCall === tossResult);
 
   useEffect(() => {
     if (previousPossessionRef.current === currentGame.Possession) return;
@@ -1793,13 +1893,57 @@ export function GameCenter({
             </div>
           </div>
           {isPregame(currentGame) && (
-            <PregameMatchup
-              game={currentGame}
-              home={homeTeamDetails}
-              away={awayTeamDetails}
-              players={players}
-              stats={seasonStats}
-            />
+            <>
+              <div className="pregame-start">
+                <span>Ready for kickoff?</span>
+                <button className="pregame-start-button" type="button" onClick={beginGame}>
+                  Start Game
+                </button>
+              </div>
+              <PregameMatchup
+                game={currentGame}
+                home={homeTeamDetails}
+                away={awayTeamDetails}
+                players={players}
+                stats={seasonStats}
+              />
+            </>
+          )}
+          {tossPhase !== "idle" && (
+            <div className="toss-overlay" role="dialog" aria-modal="true" aria-labelledby="toss-title">
+              <section className="toss-dialog">
+                <span className="toss-kicker">Opening coin toss</span>
+                <h2 id="toss-title">
+                  {tossPhase === "call" ? `${currentGame.Home}, make the call` :
+                    tossPhase === "flipping" ? "The coin is in the air…" :
+                      tossPhase === "saving" ? "Setting the field…" :
+                        homeWonToss ? `${currentGame.Home} won the toss!` : `${currentGame.Away} won the toss`}
+                </h2>
+                <div className={`toss-coin ${tossPhase === "flipping" ? "is-flipping" : ""}`} aria-label={tossPhase === "flipping" ? "Coin flipping" : tossResult ? `Coin landed ${tossResult}` : "Coin ready"}>
+                  <span>{tossResult ? (tossResult === "Heads" ? "H" : "T") : "★"}</span>
+                </div>
+                {tossPhase === "call" && (
+                  <div className="toss-actions">
+                    <button type="button" onClick={() => callToss("Heads")}>Heads</button>
+                    <button type="button" onClick={() => callToss("Tails")}>Tails</button>
+                  </div>
+                )}
+                {tossPhase === "flipping" && <p>You called {tossCall}. Watch the flip.</p>}
+                {tossPhase === "decision" && (
+                  <>
+                    <p>The coin landed <strong>{tossResult}</strong>. {homeWonToss ? "Choose how you want to start." : `${currentGame.Away} is making its choice…`}</p>
+                    {homeWonToss && (
+                      <div className="toss-actions">
+                        <button type="button" onClick={() => void finishToss("receive")}>Receive the ball</button>
+                        <button type="button" onClick={() => void finishToss("kick")}>Kick off</button>
+                      </div>
+                    )}
+                  </>
+                )}
+                {tossPhase === "saving" && <p>The receiving team will begin at its own 25-yard line.</p>}
+                {tossError && <p className="toss-error" role="alert">{tossError}</p>}
+              </section>
+            </div>
           )}
           <div
             className={`field-console-stage ${isGameFieldCollapsed ? "field-collapsed" : ""}`}


### PR DESCRIPTION
### Motivation

- Give coaches a simple way to start a pregame and initialize a live game clock, quarter, and kickoff sequence from the UI.
- Provide an interactive coin-toss that lets the home coach call heads/tails, shows a coin flip animation, and handles the winner's choice (receive or kick).

### Description

- Added a `Start Game` control and pregame flow in `apps/web/src/components/league/GameCenter.tsx` that sets the game to quarter 1 and `Time` to `900` seconds and moves UI out of pregame state when started.
- Implemented a coin toss dialog overlay with call, flip animation, result display, and choice UI; the away team makes an automated choice when it wins the toss.
- When the toss is resolved the code persists an initial game snapshot via `savePlayAndGame` (quarter 1, time 900, down 1 & distance 10, three timeouts each, possession set to the receiving team) and places the receiving team at its own 25-yard line (ball position set accordingly).
- Added accessible, theme-aware toss styling and reduced-motion support in `apps/web/src/components/league/GameCenter.css` and added local component state/refs to manage toss phases and timers.

### Testing

- Ran `cd apps/web && npm run build` and the web bundle was built successfully.
- Ran `cd apps/web && npm run lint` and lint completed; one pre-existing warning remained in `GameField.tsx` (no new errors).
- Ran `cd apps/api && npm test` and the API tests passed (3 tests OK).
- Ran `cd apps/api && npx tsc --noEmit` (typecheck) and it completed successfully; the API package has no `build` script so `tsc --noEmit` was used instead of `npm run build`.
- Attempted to install Playwright browsers for end-to-end screenshot testing, but browser downloads/host dependencies failed in this environment so automated browser tests/screenshots were not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d3a5d5968832484801e84aa024f19)