### PR TITLE
Implement halftime possession rules (award Q3 to opening-kick opponent)

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -376,7 +376,10 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
     if (!player || (type && !["Run", "Pass"].includes(type))) return;
     const possession = str(playField(play, "Possession", "possession"));
     const driveStart = num(playField(play, "DriveStart", "drivestart"));
-    const key = `${possession}-${driveStart}`;
+    const quarter = num(playField(play, "QTR", "Qtr", "quarter"));
+    // The halftime break always terminates a drive, even when the same team
+    // later starts Q3 from a matching field position.
+    const key = `${possession}-${driveStart}-${quarter >= 3 ? "second" : "first"}`;
     if (!current || current.key !== key) {
       current = {
         key,
@@ -400,7 +403,9 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
     ).trim();
     const lastResult = str(playField(last, "Result", "result"));
     drive.result =
-      lastDescription === "Sack" &&
+      str(playField(last, "EndOfHalf", "endofhalf")) === "Yes"
+        ? "End of Half"
+        : lastDescription === "Sack" &&
       playField(last, "RecoveredBy", "recoveredby")
         ? "Fumble"
         : lastResult;
@@ -1559,6 +1564,17 @@ export function GameCenter({
           historyRes.plays,
         );
         const normalizedGame = normalizeGame(game, stateRes.gameState);
+        const firstPossession = str(
+          playField(historyRes.plays[0], "Possession", "possession"),
+        );
+        normalizedGame.OpeningPossession =
+          firstPossession === "Home" || firstPossession === "Away"
+            ? firstPossession
+            : Number(normalizedGame.Qtr) === 1 &&
+                (normalizedGame.Possession === "Home" ||
+                  normalizedGame.Possession === "Away")
+              ? normalizedGame.Possession
+              : normalizedGame.OpeningPossession;
         setCurrentGame(normalizedGame);
         setIsGameFieldCollapsed(isPregame(normalizedGame));
         setHistory(historyRes.plays);
@@ -1638,6 +1654,7 @@ export function GameCenter({
       Distance: 10,
       BallOn: ballOn,
       Possession: receivingTeam,
+      OpeningPossession: receivingTeam,
       DriveStart: ballOn,
       Previous: ballOn,
     } as LeagueGame;

--- a/apps/web/src/components/league/gameplay/engine/passEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/passEngine.ts
@@ -2,6 +2,7 @@ import type { LeagueGame } from "../../types";
 import type { EngineContext, PlayCallOptions } from "./types";
 import {
   advanceBall,
+  applyHalftimeRules,
   advanceQuarter,
   byName,
   byPosition,
@@ -98,7 +99,7 @@ export function handleSack(
       ["Safety", "Fumble", "TO on Downs"].includes(result),
     ),
   );
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     HomeScore: hs,
     AwayScore: as,
@@ -114,7 +115,7 @@ export function handleSack(
       (fumble.fumble && fumble.recoveredBy !== qbName)
         ? switchPoss(game)
         : game.Possession,
-  };
+  });
   return buildResult(
     game,
     updated,
@@ -373,7 +374,7 @@ export function passPlay(
       ].includes(result),
     ),
   );
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     HomeScore: hs,
     AwayScore: as,
@@ -384,7 +385,7 @@ export function passPlay(
     BallOn: result === "Incomplete" ? game.BallOn : next.ballOn,
     Previous: game.BallOn,
     Possession: possession,
-  };
+  });
   return buildResult(
     game,
     updated,

--- a/apps/web/src/components/league/gameplay/engine/playLogger.ts
+++ b/apps/web/src/components/league/gameplay/engine/playLogger.ts
@@ -66,6 +66,7 @@ export function logPlayToDB(
   historyLength: number,
   extra: Record<string, unknown> = {},
 ) {
+  const updatedState = game as unknown as Record<string, unknown>;
   const normalized = determinePlayOutcome(
     result,
     playtype,
@@ -101,7 +102,12 @@ export function logPlayToDB(
     airyards: extra.airyards ?? (playtype === "Pass" ? yards : 0),
     newdown: game.Down,
     newdist: game.Distance,
-    newballon: game.BallOn,
+    // Preserve where the final play actually ended; the live game state has
+    // already moved the ball to the receiving team's 25 for the third quarter.
+    newballon: updatedState.EndOfHalf
+      ? updatedState.HalfEndBallOn
+      : game.BallOn,
+    endofhalf: updatedState.EndOfHalf ? "Yes" : "",
     drivestart:
       (prev as unknown as Record<string, unknown>).DriveStart ?? prev.BallOn,
     homescore: game.HomeScore,

--- a/apps/web/src/components/league/gameplay/engine/runEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/runEngine.ts
@@ -3,6 +3,7 @@ import type { EngineContext, PlayCallOptions } from "./types";
 import { buildResult } from "./playLogger";
 import {
   advanceBall,
+  applyHalftimeRules,
   advanceQuarter,
   byName,
   clockRunoff,
@@ -510,7 +511,7 @@ export function runPlay(
       ["Touchdown", "Safety", "TO on Downs", "Fumble"].includes(result),
     ),
   ); // TRAIT USED: Speed
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     HomeScore: hs,
     AwayScore: as,
@@ -526,7 +527,7 @@ export function runPlay(
         : ((game as unknown as Record<string, unknown>).DriveStart ??
           game.BallOn),
     Possession: possession,
-  };
+  });
 
   const successfulTrucks = runState.log.filter((entry) =>
     /\btrucks\b/i.test(entry),

--- a/apps/web/src/components/league/gameplay/engine/specialTeamsEngine.ts
+++ b/apps/web/src/components/league/gameplay/engine/specialTeamsEngine.ts
@@ -1,6 +1,6 @@
 import type { LeagueGame } from "../../types";
 import type { EngineContext, PlayCallOptions } from "./types";
-import { advanceQuarter, kickoffSpot, n, randomInt, switchPoss } from "./utils";
+import { advanceQuarter, applyHalftimeRules, kickoffSpot, n, randomInt, switchPoss } from "./utils";
 import { buildResult } from "./playLogger";
 
 export function punt(game: LeagueGame, ctx: EngineContext) {
@@ -16,7 +16,7 @@ export function punt(game: LeagueGame, ctx: EngineContext) {
   );
   const possession = switchPoss(game);
   const clock = advanceQuarter(game, randomInt(5, 8));
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     Qtr: clock.qtr,
     Time: clock.time,
@@ -26,7 +26,7 @@ export function punt(game: LeagueGame, ctx: EngineContext) {
     Previous: game.BallOn,
     DriveStart: ball,
     Possession: possession,
-  };
+  });
   return buildResult(
     game,
     updated,
@@ -56,7 +56,7 @@ export function kickFG(game: LeagueGame, ctx: EngineContext) {
   const possession = switchPoss(game);
   const clock = advanceQuarter(game, randomInt(3, 8));
   const spot = kickoffSpot(possession);
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     HomeScore: hs,
     AwayScore: as,
@@ -69,7 +69,7 @@ export function kickFG(game: LeagueGame, ctx: EngineContext) {
     DriveStart: spot,
     Possession: possession,
     pendingFGTeam: undefined,
-  };
+  });
   return buildResult(
     game,
     updated,
@@ -95,7 +95,7 @@ export function goForTwo(game: LeagueGame, ctx: EngineContext) {
   }
   const possession = switchPoss(game);
   const spot = kickoffSpot(possession);
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     HomeScore: hs,
     AwayScore: as,
@@ -104,7 +104,7 @@ export function goForTwo(game: LeagueGame, ctx: EngineContext) {
     BallOn: spot,
     DriveStart: spot,
     Possession: possession,
-  };
+  });
   return buildResult(
     game,
     updated,
@@ -137,13 +137,13 @@ export function handleTimeout(game: LeagueGame, ctx: EngineContext) {
 }
 export function spikeBall(game: LeagueGame, ctx: EngineContext) {
   const clock = advanceQuarter(game, 1);
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     Qtr: clock.qtr,
     Time: clock.time,
     Down: Math.min(4, n(game.Down) + 1),
     Distance: game.Distance,
-  };
+  });
   return buildResult(
     game,
     updated,
@@ -165,13 +165,13 @@ export function kneel(
   const clock = advanceQuarter(game, 40);
   const ball =
     game.Possession === "Home" ? n(game.BallOn) - 1 : n(game.BallOn) + 1;
-  const updated = {
+  const updated = applyHalftimeRules(game, {
     ...game,
     Qtr: clock.qtr,
     Time: clock.time,
     Down: Math.min(4, n(game.Down) + 1),
     BallOn: ball,
-  };
+  });
   return buildResult(
     game,
     updated,

--- a/apps/web/src/components/league/gameplay/engine/utils.ts
+++ b/apps/web/src/components/league/gameplay/engine/utils.ts
@@ -81,6 +81,40 @@ export function advanceQuarter(game: LeagueGame, secondsUsed: number) {
   } else if (left === 0 && Number(game.Qtr) >= 4) qtr = "FINAL";
   return { qtr, time };
 }
+
+/**
+ * Ends the first-half drive and awards the second-half opening possession to
+ * the team that kicked off to begin the game. This is intentionally applied
+ * after the play outcome so a score/turnover on the final play is still
+ * recorded before the halftime reset wins.
+ */
+export function applyHalftimeRules<T extends LeagueGame>(
+  previous: LeagueGame,
+  updated: T,
+): T {
+  if (Number(previous.Qtr) !== 2 || Number(updated.Qtr) !== 3) return updated;
+
+  const openingPossession = previous.OpeningPossession;
+  if (openingPossession !== "Home" && openingPossession !== "Away") {
+    return updated;
+  }
+
+  const possession = openingPossession === "Home" ? "Away" : "Home";
+  const ballOn = kickoffSpot(possession);
+  return {
+    ...updated,
+    EndOfHalf: true,
+    HalfEndBallOn: updated.BallOn,
+    Possession: possession,
+    BallOn: ballOn,
+    Previous: ballOn,
+    DriveStart: ballOn,
+    Down: 1,
+    Distance: 10,
+    HomeTimeouts: 3,
+    AwayTimeouts: 3,
+  };
+}
 export function clockRunoff(
   mode: ClockMode = "Normal",
   base = randomInt(4, 12),

--- a/apps/web/src/components/league/types.ts
+++ b/apps/web/src/components/league/types.ts
@@ -13,6 +13,8 @@ export type LeagueGame = {
   Distance: string | number;
   BallOn: string | number;
   Possession: "Home" | "Away" | string;
+  /** Team that received the opening kickoff; the other team receives in Q3. */
+  OpeningPossession?: "Home" | "Away" | string;
   Week?: string | number;
   "Kickoff Time"?: string;
   Date?: string;


### PR DESCRIPTION
### Motivation

- Enforce that the team which received the opening kickoff must be on defense to start Q3 and that the drive in progress at the end of Q2 terminates at halftime.  
- Ensure the team that kicked off (and played defense first) receives the ball at its own 25-yard line to start the third quarter.

### Description

- Add `OpeningPossession` to the `LeagueGame` shape and record it from the toss flow or reconstruct it from play history when loading saved games in `GameCenter.tsx`.  
- Introduce a centralized `applyHalftimeRules` function in `gameplay/engine/utils.ts` that detects the Q2->Q3 transition and resets possession, ball spot, series, and timeouts to start Q3 with the correct team at its 25.  
- Apply `applyHalftimeRules` to run, pass, and special-teams flows (`runEngine.ts`, `passEngine.ts`, `specialTeamsEngine.ts`) so the halftime transition is applied consistently after a play outcome.  
- Preserve the final play's actual ending field position in the play history and mark the play/drive as `End of Half`, and split drives across the half in the play-by-play grouping logic (`playLogger.ts`, `GameCenter.tsx`).

### Testing

- Ran `npm install` which completed successfully.  
- Built the frontend with `npm run build` (TypeScript + Vite) and the build succeeded.  
- Ran `npm run lint` and lint completed with no errors; a pre-existing React Hooks warning remained but did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d445ed5b88324a34e744682304695)