### PR TITLE
Remove 10-team limit in `getTeamsFromSheet`

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -94,7 +94,9 @@ async function getGameState(gameId: string) {
 }
 async function getTeamsFromSheet() {
   const { headers, rows } = await sheetRows("Teams");
-  return rows.filter((r) => r?.[0] !== "" && r?.[0] != null).slice(0, 10).map((r) => objectFrom(headers, r));
+  return rows
+    .filter((r) => r?.[0] !== "" && r?.[0] != null)
+    .map((r) => objectFrom(headers, r));
 }
 async function getStandingsFromSheet() {
   const standings = await readSheetObjects("standings!A1:Z");


### PR DESCRIPTION
### Motivation
- Allow loading all teams from the `Teams` sheet instead of truncating the results to the first 10 rows.

### Description
- Updated `getTeamsFromSheet` to remove the `.slice(0, 10)` truncation and map all filtered rows to objects, and reformatted the return for readability.

### Testing
- Ran `yarn test` and `yarn build` in CI; automated tests and type checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d5523c2708324a0091363a3dab163)