### PR TITLE
Use StatHistory + PlayerTeams for pregame season leaders (add /season-stats)

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -164,6 +164,27 @@ async function getTeamPlayers(teamAbbrev: string) {
     Stats: statsByName.get(name) ?? null,
   }));
 }
+async function getSeasonStats() {
+  const [stats, assignments] = await Promise.all([
+    readSheetObjects("StatHistory!A1:ZZ"),
+    readSheetObjects("PlayerTeams!A1:B"),
+  ]);
+  const teamByPlayer = new Map(
+    assignments
+      .map((assignment) => [
+        String(assignment.Name ?? assignment.Player ?? "").trim().toLowerCase(),
+        String(assignment.Team ?? "").trim(),
+      ] as const)
+      .filter(([name]) => name),
+  );
+
+  // StatHistory identifies a row by player, not by team. Attach the current
+  // PlayerTeams assignment so consumers can calculate team-specific leaders.
+  return stats.map((row) => {
+    const player = String(row.Player ?? row.Name ?? "").trim();
+    return { ...row, Team: teamByPlayer.get(player.toLowerCase()) ?? "" };
+  });
+}
 function normalizeSettingLabel(label: unknown) {
   return String(label || "").toLowerCase().replace(/[^a-z0-9]/g, "");
 }
@@ -453,6 +474,7 @@ async function savePlayAndGameWithRetry(data: Record<string, unknown>, gameId: s
 gameRoutes.get("/health", (_req, res) => res.json({ ok: true, app: "football-game-api", message: "API is running" }));
 gameRoutes.get("/players", async (_req, res, next) => { try { res.json({ players: await getPlayersWithTeamJerseys() }); } catch (e) { next(e); } });
 gameRoutes.get("/player-stats", async (_req, res, next) => { try { res.json({ playerStats: await readSheetObjects("PlayerStats!A1:AJ") }); } catch (e) { next(e); } });
+gameRoutes.get("/season-stats", async (_req, res, next) => { try { res.json({ seasonStats: await getSeasonStats() }); } catch (e) { next(e); } });
 gameRoutes.get("/players/:playerName/games", async (req, res, next) => {
   try {
     const [gamesSheet, historySheet, playerTeams] = await Promise.all([

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -46,6 +46,11 @@ export async function getPlayerStats(): Promise<{
 }> {
   return getJson("/player-stats", "Failed to load player stats");
 }
+export async function getSeasonStats(): Promise<{
+  seasonStats: PlayerStats[];
+}> {
+  return getJson("/season-stats", "Failed to load season statistics");
+}
 export type PlayerGame = {
   gameId: string;
   opponent: string;

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -11,7 +11,7 @@ import {
 import {
   getFrontendSettings,
   getGameState,
-  getPlayerStats,
+  getSeasonStats,
   getTeams,
   getPlayerTraits,
   getPlayHistory,
@@ -54,7 +54,7 @@ const teamValue = (team: LeagueTeam | undefined, ...keys: string[]) => {
 };
 const matchesTeam = (team: LeagueTeam, key: unknown) => {
   const wanted = normalizedTeamKey(key);
-  
+
   // Never allow a missing/blank team key to match.
   if (!wanted) return false;
 
@@ -1437,16 +1437,13 @@ function PregameMatchup({
   game,
   home,
   away,
-  players,
   stats,
 }: {
   game: LeagueGame;
   home?: LeagueTeam;
   away?: LeagueTeam;
-  players: Play[];
   stats: Record<string, string>[];
 }) {
-  const playerTeam = new Map(players.map((player) => [normalizedTeamKey(player.name ?? player.Name), player.team ?? player.Team]));
   const categories = [
     { label: "Passing", fields: ["Passing Yards", "Pass Yards", "PassYards"] },
     { label: "Rushing", fields: ["Rushing Yards", "Rush Yards", "Yards"] },
@@ -1460,15 +1457,7 @@ function PregameMatchup({
   ) =>
     stats
       .filter((row) => {
-        const playerName = normalizedTeamKey(
-          row.Player ?? row.Name,
-        );
-
-        const statTeam =
-          row.Team ||
-          playerTeam.get(playerName);
-
-        return matchesTeam(team ?? {}, statTeam);
+        return matchesTeam(team ?? {}, row.Team);
       })
       .map((row) => ({
         name: String(row.Player ?? row.Name ?? "—"),
@@ -1569,7 +1558,7 @@ export function GameCenter({
       getPlayerTraits(),
       getFrontendSettings(),
       getTeams(),
-      getPlayerStats(),
+      getSeasonStats(),
     ])
       .then(([stateRes, historyRes, playerRes, settingsRes, teamsRes, statsRes]) => {
         if (!active) return;
@@ -1578,17 +1567,13 @@ export function GameCenter({
         const loadedTeams = teamsRes.teams as LeagueTeam[];
         const normalizedGame = normalizeGame(game, stateRes.gameState);
 
-        console.log("ABOUT TO SET TEAMS", loadedTeams.length);
-
         // Set independent API-backed state immediately. If later player/fatigue
         // processing throws, the team metadata and matchup data still load.
         setTeams(loadedTeams);
-        setSeasonStats(statsRes.playerStats);
+        setSeasonStats(statsRes.seasonStats);
         setSettings(loadedSettings);
         setCurrentGame(normalizedGame);
         setHistory(historyRes.plays);
-
-        console.log("CALLED setTeams");
 
         const loadedPlayers = playerRes.players.map((player) => {
           const team = loadedTeams.find((candidate) =>
@@ -1639,7 +1624,6 @@ export function GameCenter({
         );
       })
       .catch((error: unknown) => {
-        console.error("GAME CENTER LOAD FAILED:", error);
         setLog((l) => [
           `Failed to load live game data: ${error instanceof Error ? error.message : String(error)}`,
           ...l,
@@ -1649,10 +1633,6 @@ export function GameCenter({
       active = false;
     };
   }, [game]);
-
-  useEffect(() => {
-    console.log("TEAMS STATE ACTUALLY CHANGED:", teams.length, teams);
-  }, [teams]);
 
   useEffect(() => () => {
     if (tossTimerRef.current !== null) window.clearTimeout(tossTimerRef.current);
@@ -1973,7 +1953,6 @@ export function GameCenter({
                 game={currentGame}
                 home={homeTeamDetails}
                 away={awayTeamDetails}
-                players={players}
                 stats={seasonStats}
               />
             </>


### PR DESCRIPTION
### Motivation
- Pregame team leaders were coming up blank because `StatHistory` rows do not include a team; the UI needs season stats annotated with the player’s current `PlayerTeams` assignment so leaders can be computed per team.

### Description
- Add `getSeasonStats()` in `apps/api/src/routes/gameRoutes.ts` to read `StatHistory!A1:ZZ` and `PlayerTeams!A1:B`, map player names to their current team assignment, and return rows with a `Team` field attached.
- Expose the new API at `GET /season-stats` and add a typed client wrapper `getSeasonStats()` in `apps/web/src/api/client.ts` that returns `{ seasonStats }`.
- Update `GameCenter` (`apps/web/src/components/league/GameCenter.tsx`) to call `getSeasonStats()` (instead of the previous player-stats path), wire `statsRes.seasonStats` into state, remove the now-unused `players` prop from `PregameMatchup`, and change the pregame leader filter to match `row.Team` against the loaded teams (relying on the attached `Team` value from the backend).
- Remove temporary debug logging introduced during manual changes and tidy related code paths so uniforms and leaders load independently.

### Testing
- Ran API typecheck with `npm run typecheck` in `apps/api` which completed successfully.
- Ran API unit tests with `npm test` in `apps/api` and all tests passed.
- Ran frontend lint with `npm run lint` in `apps/web` which completed successfully with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`.
- Performed frontend build by running `npm install` and `npm run build` in `apps/web`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d5cdfd9e08324b5e66bc9c08a00eb)