### PR TITLE
Fix loading games without play history

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -128,11 +128,13 @@ const num = (v: unknown) => Number(v) || 0;
 /**
  * Reads the first populated value from a play record using several possible
  * key names. Play history can contain backend-style PascalCase, lower-case, or
- * legacy field names, so the UI uses this small compatibility layer instead of
- * hard-coding one spelling everywhere.
+ * legacy field names, and a new game has no first play yet. This compatibility
+ * layer handles both cases instead of hard-coding one spelling everywhere.
  */
-const playField = (p: Play, ...keys: string[]) =>
-  keys.map((k) => p[k]).find((v) => v !== undefined && v !== null && v !== "");
+const playField = (p: Play | null | undefined, ...keys: string[]) =>
+  keys
+    .map((k) => p?.[k])
+    .find((v) => v !== undefined && v !== null && v !== "");
 const logoSrc = (value: unknown) => {
   const src = str(value).trim();
   return src || undefined;


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when opening a newly-started game that has a valid `Possession` on the game row but no play-history rows, where the UI attempted to read fields from `historyRes.plays[0]` and crashed because it was `undefined`.

### Description
- Update the play-field helper so it accepts a missing play record (`Play | null | undefined`) and uses optional chaining (`p?.[k]`) to safely read keys, and clarify the comment to note that new games may have no first play.

### Testing
- Ran `git diff --check`, `npm run lint` (completed with one pre-existing React hooks warning), and `npm run build` (TypeScript + Vite build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7e462d06b88324b0ab105cbc6f55db)