### PR TITLE
Keep pass setup open with persistent Done and highlight eligible runners with green selection

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -23,6 +23,7 @@
   --control-border: #4a4f58;
   --control-border-hover: #7f8792;
   --control-accent: #8fc2ff;
+  --status-success: #4ade80;
   --stat-highlight: rgba(91, 155, 213, 0.16);
   --profile-hero-bg: linear-gradient(110deg, #111419, #242930 58%, #181b20);
   --profile-hero-border: #434850;
@@ -53,6 +54,7 @@
   --control-border: #aeb8c3;
   --control-border-hover: #697786;
   --control-accent: #075eb8;
+  --status-success: #15803d;
   --stat-highlight: rgba(7, 94, 184, 0.12);
   --profile-hero-bg: linear-gradient(110deg, #ffffff, #eef2f6 58%, #e2e8ee);
   --profile-hero-border: #c9d1da;

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -2067,10 +2067,6 @@ export function GameCenter({
                   setPassSetup(false);
                   setSelectedRoutePlayer("");
                 }}
-                onPassPlay={() => {
-                  setPassSetup(false);
-                  setSelectedRoutePlayer("");
-                }}
                 onRunnerSelect={(runner) =>
                   setPlayOptions((current) => ({ ...current, runner }))
                 }

--- a/apps/web/src/components/league/GameField.css
+++ b/apps/web/src/components/league/GameField.css
@@ -833,13 +833,15 @@ textarea {
 
 .token.pass-route-eligible { cursor: pointer; }
 .token.run-player-eligible { cursor: pointer; }
-.token.run-player-eligible .player-marker {
+.token.run-player-eligible .player-aura {
   opacity: 1;
-  border-color: var(--control-accent);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--control-accent) 28%, transparent);
+  background: color-mix(in srgb, var(--control-accent) 42%, transparent);
+  box-shadow: 0 0 18px 7px color-mix(in srgb, var(--control-accent) 48%, transparent);
 }
-.token.run-player-selected .player-marker {
-  box-shadow: 0 0 0 7px color-mix(in srgb, var(--control-accent) 48%, transparent);
+.token.run-player-selected .player-aura {
+  opacity: 1;
+  background: color-mix(in srgb, var(--status-success) 58%, transparent);
+  box-shadow: 0 0 20px 9px color-mix(in srgb, var(--status-success) 62%, transparent);
 }
 .token.pass-route-assigned .player-marker { border-color: var(--control-border-hover); }
 .token.pass-route-selected .player-marker {
@@ -859,7 +861,10 @@ textarea {
 }
 
 .pass-setup-toolbar {
-  top: 12px;
+  position: fixed;
+  z-index: 410;
+  top: auto;
+  bottom: 12px;
   left: 50%;
   width: min(620px, calc(100% - 24px));
   min-height: 64px;
@@ -889,7 +894,7 @@ textarea {
   position: fixed;
   left: 50%;
   right: auto;
-  bottom: 12px;
+  bottom: 96px;
   top: auto;
   width: min(720px, calc(100% - 24px));
   min-height: 150px;

--- a/apps/web/src/components/league/GameField.tsx
+++ b/apps/web/src/components/league/GameField.tsx
@@ -455,7 +455,6 @@ export default function GameField({
   onRoutePlayerSelect,
   onPassOptionsChange,
   onPassSetupClose,
-  onPassPlay,
   onRunnerSelect,
   onRunSetupClose,
   children,
@@ -490,7 +489,6 @@ export default function GameField({
   onRoutePlayerSelect?: (player: string) => void;
   onPassOptionsChange?: (patch: { routes?: Record<string, string>; routeDepths?: Record<string, string>; reads?: Record<string, string> }) => void;
   onPassSetupClose?: () => void;
-  onPassPlay?: () => void;
   onRunnerSelect?: (player: string) => void;
   onRunSetupClose?: () => void;
   children?: ReactNode;
@@ -1556,7 +1554,6 @@ export default function GameField({
           onClick={() => {
             setSelectedPlayerMenu(null);
             setRevealedFormationSlot(null);
-            if (passSetup) onPassSetupClose?.();
             if (runSetup) onRunSetupClose?.();
           }}
         >
@@ -1768,15 +1765,14 @@ export default function GameField({
                   {(ROUTES_BY_DEPTH[routeDepths[selectedRoutePlayer]] || []).map((route) => <option key={route}>{route}</option>)}
                 </AppSelect>
               </label>
-              <button type="button" onClick={onPassSetupClose}>Done</button>
+              <button type="button" onClick={() => onRoutePlayerSelect?.("")}>Done</button>
             </div>
           )}
 
           {passSetup && (
             <div className="pass-setup-toolbar" onClick={(event) => event.stopPropagation()}>
               <div><strong>Design pass play</strong><span>Select a highlighted receiver or the QB.</span></div>
-              <button type="button" onClick={onPassSetupClose}>Cancel</button>
-              <button type="button" disabled={!routedPlayers.length} onClick={onPassPlay}>Set pass</button>
+              <button type="button" onClick={onPassSetupClose}>Done</button>
             </div>
           )}
 


### PR DESCRIPTION
### Motivation

- Prevent accidental exits from pass-play design by making the toolbar's Done action the only way to leave pass setup and keep the editor open when clicking the field or route sheet background.
- Make run-play selection clearer by visually marking all eligible ball carriers and giving the selected runner a distinct theme-aware green highlight.

### Description

- Pass setup no longer closes when clicking the field; the field click handler stops closing pass setup and individual route editors now close back to the pass setup rather than exiting it, and the pass toolbar now shows a single persistent `Done` button to finish setup (`apps/web/src/components/league/GameField.tsx`).
- The pass toolbar was moved to a fixed bottom position and layered with z-index adjustments, and the route editor sheet was shifted upward so the toolbar does not overlap it (`apps/web/src/components/league/GameField.css`).
- Run-play UI now uses the `.player-aura` element to highlight all eligible runners and applies a theme-aware green success background and glow for the selected runner, replacing the previous subtle marker treatment (`apps/web/src/components/league/GameField.css`).
- Introduced theme-specific success tokens `--status-success` for dark and light themes so the selected-runner green highlight respects the app's semantic tokens (`apps/web/src/App.css`).
- Removed the now-unused `onPassPlay` callback surface and corresponding prop usage in `GameField`/`GameCenter` to simplify flow control for pass setup (`apps/web/src/components/league/GameField.tsx`, `apps/web/src/components/league/GameCenter.tsx`).

### Testing

- Ran `npm run build` successfully (Vite build completed; chunk size warning only). 
- Ran `npm run lint` successfully with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` (no new lint errors).
- Ran `git diff --check` and repository status checks with no issues.
- Visual/browser-driven screenshot tests were not executed because no Chromium/Playwright/Puppeteer runtime was available in the environment, but the highlight uses theme variables and was validated against both `:root` theme token sets programmatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80c6a71f588324bbc9554340dae359)