### PR TITLE
Improve Gamecenter play-by-play drive views

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -375,7 +375,27 @@ type Drive = {
   awayScore: unknown;
   yards: number;
   playsCount: number;
+  duration: number;
 };
+
+const isDrivePlay = (play: Play) => {
+  const type = str(playField(play, "PlayType", "playtype")).toLowerCase();
+  const result = str(playField(play, "Result", "result")).toLowerCase();
+  return !type.includes("punt") && !type.includes("kick fg") &&
+    type !== "field goal" && result !== "timeout";
+};
+
+const playGameSeconds = (play: Play) => {
+  const quarter = Math.max(1, parseInteger(playField(play, "QTR", "Qtr", "quarter"), 1));
+  const rawClock = playField(play, "Time", "time");
+  const clock = typeof rawClock === "string" && rawClock.includes(":")
+    ? rawClock.split(":").reduce((minutes, value) => minutes * 60 + num(value), 0)
+    : num(rawClock);
+  return (quarter - 1) * 900 + (900 - clock);
+};
+
+const driveYardsFromSpots = (possession: string, start: number, end: number) =>
+  possession === "Home" ? end - start : start - end;
 /**
  * Groups raw play history into drive sections. A drive is identified by the
  * team in possession plus its starting yard line, then summarized from the last
@@ -386,18 +406,16 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
   const drives: Drive[] = [];
   let current: Drive | null = null;
   plays.forEach((play) => {
-    const player = playField(play, "Player", "Passer", "player");
-    const type = str(playField(play, "PlayType", "playtype"));
-    if (!player || (type && !["Run", "Pass"].includes(type))) return;
     const possession = str(playField(play, "Possession", "possession"));
+    if (!possession) return;
     const driveStart = num(playField(play, "DriveStart", "drivestart"));
     const quarter = num(playField(play, "QTR", "Qtr", "quarter"));
     // The halftime break always terminates a drive, even when the same team
     // later starts Q3 from a matching field position.
-    const key = `${possession}-${driveStart}-${quarter >= 3 ? "second" : "first"}`;
-    if (!current || current.key !== key) {
+    const half = quarter >= 3 ? "second" : "first";
+    if (!current || current.possession !== possession || !current.key.endsWith(half) || (driveStart && current.driveStart !== driveStart)) {
       current = {
-        key,
+        key: `${drives.length}-${possession}-${driveStart}-${half}`,
         possession,
         driveStart,
         plays: [],
@@ -406,12 +424,13 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
         awayScore: game.AwayScore,
         yards: 0,
         playsCount: 0,
+        duration: 0,
       };
       drives.push(current);
     }
     current.plays.push(play);
   });
-  drives.forEach((drive) => {
+  drives.forEach((drive, driveIndex) => {
     const last = drive.plays[drive.plays.length - 1];
     const lastDescription = str(
       playField(last, "Description", "description"),
@@ -428,13 +447,24 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
       playField(last, "HomeScore", "homescore") ?? game.HomeScore;
     drive.awayScore =
       playField(last, "AwayScore", "awayscore") ?? game.AwayScore;
-    const end = num(playField(last, "NewBallOn", "newBallOn", "newballon"));
-    drive.yards =
-      drive.possession === "Home"
-        ? end - drive.driveStart
-        : drive.driveStart - end;
-    drive.playsCount = drive.plays.length;
+    const lastType = str(playField(last, "PlayType", "playtype")).toLowerCase();
+    const isKickEnding = lastType.includes("punt") || lastType.includes("kick fg") || lastType === "field goal";
+    const end = num(playField(last, ...(isKickEnding
+      ? ["BallOn", "ballon"]
+      : ["NewBallOn", "newBallOn", "newballon"])));
+    drive.yards = driveYardsFromSpots(drive.possession, drive.driveStart, end);
+    drive.playsCount = drive.plays.filter(isDrivePlay).length;
+    const previousDrive = drives[driveIndex - 1];
+    const firstQuarter = Math.max(1, parseInteger(playField(drive.plays[0], "QTR", "Qtr", "quarter"), 1));
+    const driveStartedAt = previousDrive
+      ? playGameSeconds(previousDrive.plays[previousDrive.plays.length - 1])
+      : (firstQuarter - 1) * 900;
+    drive.duration = Math.max(0, playGameSeconds(last) - driveStartedAt);
   });
+  const finalState = String(game.Qtr ?? "").toUpperCase();
+  if (drives.length && finalState !== "FINAL" && finalState !== "F") {
+    drives[drives.length - 1].result = "Current Drive";
+  }
   return drives;
 }
 /**
@@ -449,10 +479,22 @@ function PlayByPlayTab({
   game: LeagueGame;
   history: Play[];
 }) {
+  const [view, setView] = useState<"all" | "scoring">("all");
+  const drives = groupPlaysByDrive(history, game);
+  const chronologicalScoring = history.filter((play, index) => {
+    const previous = history[index - 1];
+    return num(playField(play, "HomeScore", "homescore")) > num(playField(previous, "HomeScore", "homescore")) ||
+      num(playField(play, "AwayScore", "awayscore")) > num(playField(previous, "AwayScore", "awayscore"));
+  });
+  const formatDuration = (seconds: number) => `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
   return (
     <div className="drive-log" id="playTimeline">
-      {groupPlaysByDrive(history, game).map((drive) => (
-        <details className="drive-section" key={drive.key} open>
+      <div className="play-view-tabs" role="tablist" aria-label="Play-by-play filter">
+        <button type="button" role="tab" aria-selected={view === "all"} onClick={() => setView("all")}>All Plays</button>
+        <button type="button" role="tab" aria-selected={view === "scoring"} onClick={() => setView("scoring")}>Scoring Plays</button>
+      </div>
+      {view === "all" && [...drives].reverse().map((drive, driveIndex) => (
+        <details className="drive-section" key={drive.key} open={driveIndex === 0}>
           <summary className="drive-header">
             <span className="drive-toggle" aria-hidden="true">
               ^
@@ -464,7 +506,7 @@ function PlayByPlayTab({
             <span className="drive-overview">
               <span className="drive-result">{drive.result}</span>
               <span className="drive-summary">
-                {drive.playsCount} Plays, {drive.yards} Yards
+                {drive.playsCount} plays, {drive.yards} yards, {formatDuration(drive.duration)}
               </span>
             </span>
             <span className="drive-score">
@@ -483,7 +525,7 @@ function PlayByPlayTab({
             </span>
           </summary>
           <div className="drive-plays">
-            {drive.plays.map((play, i) => {
+            {[...drive.plays].reverse().map((play, i) => {
               const downDist = formatDownDistance(
                 (playField(play, "Down", "down") as string | number) ?? 1,
                 (playField(play, "Distance", "distance") as string | number) ??
@@ -501,12 +543,12 @@ function PlayByPlayTab({
                   )}
                 >
                   <div className="play-situation">
-                    {downDist} at {spot}
+                    {formatClock((playField(play, "Time", "time") as string | number) ?? 0)} · {formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? 0)} · {downDist} · Ball on {spot}
                   </div>
                   <div
                     className="play-desc"
                     dangerouslySetInnerHTML={{
-                      __html: `(${formatClock((playField(play, "Time", "time") as string | number) ?? "0:00")} - ${formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? game.Qtr)}) ${playText(play, game)}`,
+                      __html: playText(play, game),
                     }}
                   />
                 </div>
@@ -515,6 +557,18 @@ function PlayByPlayTab({
           </div>
         </details>
       ))}
+      {view === "scoring" && <div className="scoring-play-list">
+        {[...chronologicalScoring].reverse().map((play, index) => {
+          const drive = drives.find((candidate) => candidate.plays.includes(play));
+          const possession = str(playField(play, "Possession", "possession"));
+          return <article className="scoring-play-card" key={String(play.PlayId ?? play.playid ?? index)}>
+            <TeamLogo className="drive-logo" src={possession === "Home" ? game.HomeLogo : game.AwayLogo} />
+            <div><strong>{str(playField(play, "Result", "result")) || "Score"}</strong><span>{formatClock((playField(play, "Time", "time") as string | number) ?? 0)} · {formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? 0)}</span><p dangerouslySetInnerHTML={{ __html: playText(play, game) }} /><small>{drive ? `${drive.playsCount} plays, ${drive.yards} yards, ${formatDuration(drive.duration)}` : "Scoring play"}</small></div>
+            <div className="scoring-score"><b>{String(playField(play, "HomeScore", "homescore") ?? 0)}</b><b>{String(playField(play, "AwayScore", "awayscore") ?? 0)}</b><span>{game.Home}</span><span>{game.Away}</span></div>
+          </article>;
+        })}
+        {!chronologicalScoring.length && <p className="empty-play-message">No scoring plays yet.</p>}
+      </div>}
     </div>
   );
 }
@@ -1884,16 +1938,15 @@ export function GameCenter({
     else if (label === "Spike") void persist(spikeBall(currentGame, ctx));
     else if (label === "Kneel") void persist(kneel(currentGame, ctx, options));
   };
-  const drivePlays = history.filter(
-    (p) =>
-      str(playField(p, "Possession", "possession")) === currentGame.Possession,
-  ).length;
-  const driveYards =
-    currentGame.Possession === "Home"
-      ? num(currentGame.BallOn) -
-        num((currentGame as unknown as Play).DriveStart)
-      : num((currentGame as unknown as Play).DriveStart) -
-        num(currentGame.BallOn);
+  const currentDrive = groupPlaysByDrive(history, currentGame).at(-1);
+  const drivePlays = currentDrive?.possession === currentGame.Possession
+    ? currentDrive.playsCount
+    : 0;
+  const driveYards = driveYardsFromSpots(
+    currentGame.Possession,
+    num((currentGame as unknown as Play).DriveStart),
+    num(currentGame.BallOn),
+  );
   const lastPlay = history.length ? playText(history[history.length - 1]) : "";
   return (
     <div id="gameUI">

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1517,8 +1517,40 @@
   width: 100%;
 }
 
+.play-view-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+  margin: 16px;
+  padding: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--surface-subtle);
+}
+
+.play-view-tabs button {
+  min-height: 38px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.play-view-tabs button[aria-selected="true"] {
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: 0 3px 12px var(--shadow-color);
+}
+
+.play-view-tabs button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--control-accent) 30%, transparent);
+}
+
 .drive-section {
-  border-bottom: 1px solid var(--gray-light);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .drive-section > summary {
@@ -1541,7 +1573,7 @@
 
 .drive-toggle {
   grid-row: span 2;
-  color: #4169e1;
+  color: var(--control-accent);
   cursor: pointer;
   text-align: center;
   font-size: 8vw;
@@ -1595,7 +1627,7 @@
 }
 
 .play-row {
-  border-top: 1px solid var(--gray-light);
+  border-top: 1px solid var(--border-color);
   padding: 2vw 4vw;
 }
 
@@ -1607,6 +1639,42 @@
 .play-desc {
   color: var(--text-muted);
   margin-top: 0.5vw;
+}
+
+.scoring-play-list {
+  display: grid;
+  gap: 12px;
+  padding: 0 16px 16px;
+}
+
+.scoring-play-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: start;
+  padding: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: 0 3px 12px var(--shadow-color);
+}
+
+.scoring-play-card > div:nth-child(2) { display: grid; gap: 4px; }
+.scoring-play-card span,
+.scoring-play-card small { color: var(--text-secondary); }
+.scoring-play-card p { margin: 4px 0; color: var(--text-secondary); }
+.scoring-score { display: grid; grid-template-columns: repeat(2, auto); gap: 4px 12px; text-align: center; }
+.scoring-score b { font-size: 1.1rem; }
+.scoring-score span { font-size: .72rem; }
+.empty-play-message { color: var(--text-secondary); text-align: center; }
+
+@media (min-width: 700px) {
+  .drive-header { padding: 16px 24px; grid-template-columns: 44px 64px minmax(0, 1fr) 150px; }
+  .drive-toggle { font-size: 2rem; }
+  .drive-logo { width: 44px; height: 44px; }
+  .drive-result, .drive-summary, .drive-score .team-name, .drive-score .score-value { font-size: .9rem; }
+  .play-row { padding: 16px 28px; }
 }
 
 /* Box score and team stats tabs ported from the Apps Script game view */


### PR DESCRIPTION
### Motivation
- Make the Play-by-Play UI match the requested behavior: provide `All Plays` and `Scoring Plays` views and show drives in collapsible, newest-first order with only the current drive expanded.
- Ensure each archived play row shows the play’s persisted clock, quarter, down, distance, ball spot, and possession rather than the live game snapshot (so plays retain their original timing/quarter).
- Correct drive calculations so yardage and play counts are derived from drive start/end spots and exclude punts/field goals from the drive play count while still showing them in the drive detail.

### Description
- Added `All Plays` and `Scoring Plays` tabs to the Play-by-Play view and a small tab control UI in `PlayByPlayTab` to switch between them.
- Implemented `groupPlaysByDrive` to group history into drive objects keyed by possession/drive start/half, compute drive yards via `driveYardsFromSpots`, compute elapsed drive `duration`, and count drive plays using `isDrivePlay` which excludes punts/field goals/timeouts.
- Rendered drives newest-first with only the current/latest drive expanded, reversed drive play order so first play is at the bottom and last play at the top, and changed play rows to use persisted `Time/QTR/Down/Distance/BallOn` fields (via `playField`) and `playText` for descriptions.
- Updated the Gamecast drive summary calculations to reuse the new drive grouping (`groupPlaysByDrive`) and `driveYardsFromSpots` so current-drive plays and yard totals are accurate.
- Added scoring-play cards that show the play time, quarter, description, score after the play, drive length/play count, and drive duration, and added theme-aware styling in `league.css` using the app’s semantic tokens (no fixed light/dark colors introduced).

### Testing
- Ran `npm run build` successfully (Vite build completed).
- Ran `npm run lint` which completed; lint surfaced one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` but no new errors.
- Ran `git diff --check` and `git status` to validate the working tree; changes were committed as "Update gamecenter play-by-play drives".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80cb7638188324b3a89ba7c7e348b4)