### PR TITLE
Fix scoring drive yard totals

### DIFF
--- a/apps/web/src/components/league/gameplay/engine/playLogger.ts
+++ b/apps/web/src/components/league/gameplay/engine/playLogger.ts
@@ -76,6 +76,19 @@ export function logPlayToDB(
     String(extra.recoveredby ?? ""),
     prev.Down,
   );
+  // Scoring plays reset the live game state to the opponent's kickoff spot.
+  // Keep the play's actual ending spot in history so drive summaries measure
+  // to the goal line instead of accidentally measuring to that reset spot.
+  const scoringEndBallOn =
+    normalized.outcome === "Touchdown"
+      ? prev.Possession === "Home"
+        ? 100
+        : 0
+      : normalized.outcome === "Safety"
+        ? prev.Possession === "Home"
+          ? 0
+          : 100
+        : undefined;
   const playid = `${prev.GameId}-${Date.now()}-${historyLength + 1}`;
   return {
     gameid: prev.GameId,
@@ -104,9 +117,9 @@ export function logPlayToDB(
     newdist: game.Distance,
     // Preserve where the final play actually ended; the live game state has
     // already moved the ball to the receiving team's 25 for the third quarter.
-    newballon: updatedState.EndOfHalf
-      ? updatedState.HalfEndBallOn
-      : game.BallOn,
+    newballon:
+      scoringEndBallOn ??
+      (updatedState.EndOfHalf ? updatedState.HalfEndBallOn : game.BallOn),
     endofhalf: updatedState.EndOfHalf ? "Yes" : "",
     drivestart:
       (prev as unknown as Record<string, unknown>).DriveStart ?? prev.BallOn,


### PR DESCRIPTION
### Motivation
- Scoring plays were recorded using the post-score kickoff reset position instead of the actual end-of-play spot, causing drive yard summaries to be incorrect (for example, a 75-yard drive displaying as 50). 

### Description
- Compute a `scoringEndBallOn` for `Touchdown` and `Safety` outcomes in `apps/web/src/components/league/gameplay/engine/playLogger.ts`. 
- Use `scoringEndBallOn` when populating `newballon` in `logPlayToDB` so the play history preserves the true goal-line ending spot while retaining the existing halftime `EndOfHalf` behavior. 
- The change only affects play history logging and does not modify any UI elements.

### Testing
- Ran `npm ci`, which completed successfully. 
- Ran `npm run build`, which completed successfully (build produced a chunk-size warning but succeeded). 
- Ran `npm run lint`, which completed successfully with one pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx`. 
- Ran `git diff --check` with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80cdba99f0832481acb6a0b7d7ed21)