### PR TITLE
Play-by-play: use stored quarter and reformat play rows in GameCenter

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -131,10 +131,17 @@ const num = (v: unknown) => Number(v) || 0;
  * legacy field names, and a new game has no first play yet. This compatibility
  * layer handles both cases instead of hard-coding one spelling everywhere.
  */
-const playField = (p: Play | null | undefined, ...keys: string[]) =>
-  keys
-    .map((k) => p?.[k])
-    .find((v) => v !== undefined && v !== null && v !== "");
+const playField = (p: Play | null | undefined, ...keys: string[]) => {
+  const populated = (value: unknown) =>
+    value !== undefined && value !== null && value !== "";
+  const directValue = keys.map((key) => p?.[key]).find(populated);
+  if (directValue !== undefined || !p) return directValue;
+
+  const normalizedKeys = new Set(keys.map(normalizedFieldKey));
+  return Object.entries(p).find(
+    ([key, value]) => normalizedKeys.has(normalizedFieldKey(key)) && populated(value),
+  )?.[1];
+};
 const logoSrc = (value: unknown) => {
   const src = str(value).trim();
   return src || undefined;
@@ -487,6 +494,23 @@ function PlayByPlayTab({
       num(playField(play, "AwayScore", "awayscore")) > num(playField(previous, "AwayScore", "awayscore"));
   });
   const formatDuration = (seconds: number) => `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+  const playResult = (play: Play) => {
+    const result = str(playField(play, "Result", "result"));
+    const type = str(playField(play, "PlayType", "playtype"));
+    const yards = num(playField(play, "Yards", "yards"));
+    return result && result !== "Normal" ? result : `${yards}-yd ${type || "Play"}`;
+  };
+  const playSpot = (play: Play) => {
+    const rawSpot = playField(play, "BallOn", "ballon");
+    if (typeof rawSpot === "string" && /[a-z]/i.test(rawSpot)) return rawSpot;
+    const yard = parseInteger(rawSpot, 50);
+    if (yard === 50) return "50";
+    const possession = str(playField(play, "Possession", "possession"));
+    const fieldSide = yard < 50
+      ? (possession === "Home" ? game.Home : game.Away)
+      : (possession === "Home" ? game.Away : game.Home);
+    return `${fieldSide} ${yard > 50 ? 100 - yard : yard}`;
+  };
   return (
     <div className="drive-log" id="playTimeline">
       <div className="play-view-tabs" role="tablist" aria-label="Play-by-play filter">
@@ -531,10 +555,7 @@ function PlayByPlayTab({
                 (playField(play, "Distance", "distance") as string | number) ??
                   10,
               );
-              const spot = formatBallOnForPoss(
-                (playField(play, "BallOn", "ballon") as string | number) ?? 50,
-                str(playField(play, "Possession", "possession")),
-              );
+              const spot = playSpot(play);
               return (
                 <div
                   className="play-row"
@@ -542,8 +563,9 @@ function PlayByPlayTab({
                     play.PlayId ?? play.playid ?? `${drive.key}-${i}`,
                   )}
                 >
-                  <div className="play-situation">
-                    {formatClock((playField(play, "Time", "time") as string | number) ?? 0)} · {formatQuarter((playField(play, "QTR", "Qtr", "quarter") as string | number) ?? 0)} · {downDist} · Ball on {spot}
+                  <strong className="play-result">{playResult(play)}</strong>
+                  <div className="play-time-quarter">
+                    {formatClock((playField(play, "Time", "time") as string | number) ?? 0)} - {formatQuarter((playField(play, "qtr", "quarter") as string | number) ?? 1)}
                   </div>
                   <div
                     className="play-desc"
@@ -551,6 +573,7 @@ function PlayByPlayTab({
                       __html: playText(play, game),
                     }}
                   />
+                  <div className="play-situation">{downDist} at {spot}</div>
                 </div>
               );
             })}

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1631,14 +1631,21 @@
   padding: 2vw 4vw;
 }
 
+.play-result,
 .play-situation {
+  display: block;
   font-weight: bold;
   color: var(--text-light);
 }
 
+.play-time-quarter {
+  margin-top: 2px;
+  color: var(--text-secondary);
+}
+
 .play-desc {
   color: var(--text-muted);
-  margin-top: 0.5vw;
+  margin: 8px 0;
 }
 
 .scoring-play-list {


### PR DESCRIPTION
### Motivation
- Fix the play-by-play UI so the quarter shown is taken from each play record (stored `QTR`/`qtr`/`quarter`) rather than showing a constant "0th", and present each play in the requested three-line format.
- Improve robustness when reading play fields by normalizing keys and falling back to matching normalized field names.
- Apply small CSS tweaks to match the layout/typography in the provided reference.

### Description
- Updated the historic-play accessor to be tolerant of different spellings and to find matching normalized keys when direct lookups fail by replacing `playField` with a normalization-aware implementation. (edited `apps/web/src/components/league/GameCenter.tsx`)
- Added `playResult` and `playSpot` helpers and changed the play row markup so each play renders as: a bold play result, a separate time/quarter line using the play's stored quarter, the HTML description, then the situation line showing `{down} at {ballon}`; this also ensures the quarter uses the stored play field names (`"qtr"`, `"quarter"`, etc.). (edited `apps/web/src/components/league/GameCenter.tsx`)
- Tweaked styles to support the new row structure by adding `.play-result`, `.play-time-quarter` and minor spacing changes for `.play-desc`. (edited `apps/web/src/components/league/league.css`)

### Testing
- Built the web app: `npm run build` in `apps/web` and the TypeScript/Vite production build completed successfully. (build succeeded)
- Linted the frontend: `npm run lint` produced one non-blocking warning (React hook dependency) but no errors. (warning)
- Ran the dev server and captured visual checks: launched the app and used a Playwright-based script to render a sample play-row and produced screenshots for both `data-theme="light"` and `data-theme="dark"` (saved to `/tmp/play-by-play-light.png` and `/tmp/play-by-play-dark.png`). (visual checks completed)
- Notes on transient tooling issues: initial attempts to run Playwright tests hit environment/dependency and CommonJS/ESM interop issues that were resolved by using a small script that imports Playwright from the local npx install and screenshots the rendered markup; the visual-check step completed and produced images.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80cf50c4f48324aaa3f7f0181e1315)