### PR TITLE
Fix touchdown drive ending yard display

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --test src/components/league/driveSummary.test.cjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -8,6 +8,7 @@ import {
   formatQuarter,
   parseInteger,
 } from "./leagueMappers";
+import { driveEndYard, driveYardsFromSpots } from "./driveSummary";
 import {
   getFrontendSettings,
   getGameState,
@@ -401,8 +402,6 @@ const playGameSeconds = (play: Play) => {
   return (quarter - 1) * 900 + (900 - clock);
 };
 
-const driveYardsFromSpots = (possession: string, start: number, end: number) =>
-  possession === "Home" ? end - start : start - end;
 /**
  * Groups raw play history into drive sections. A drive is identified by the
  * team in possession plus its starting yard line, then summarized from the last
@@ -456,9 +455,10 @@ function groupPlaysByDrive(plays: Play[], game: LeagueGame): Drive[] {
       playField(last, "AwayScore", "awayscore") ?? game.AwayScore;
     const lastType = str(playField(last, "PlayType", "playtype")).toLowerCase();
     const isKickEnding = lastType.includes("punt") || lastType.includes("kick fg") || lastType === "field goal";
-    const end = num(playField(last, ...(isKickEnding
+    const recordedEnd = num(playField(last, ...(isKickEnding
       ? ["BallOn", "ballon"]
       : ["NewBallOn", "newBallOn", "newballon"])));
+    const end = driveEndYard(drive.possession, lastResult, recordedEnd);
     drive.yards = driveYardsFromSpots(drive.possession, drive.driveStart, end);
     drive.playsCount = drive.plays.filter(isDrivePlay).length;
     const previousDrive = drives[driveIndex - 1];

--- a/apps/web/src/components/league/driveSummary.test.cjs
+++ b/apps/web/src/components/league/driveSummary.test.cjs
@@ -1,0 +1,31 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const ts = require("typescript");
+
+const source = fs.readFileSync(path.join(__dirname, "driveSummary.ts"), "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS },
+}).outputText;
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "drive-summary-"));
+const compiledPath = path.join(temporaryDirectory, "driveSummary.cjs");
+fs.writeFileSync(compiledPath, compiled);
+const { driveEndYard, driveYardsFromSpots } = require(compiledPath);
+
+test("home touchdown ignores a recorded post-score 25-yard spot", () => {
+  const end = driveEndYard("Home", "Touchdown", 25);
+  assert.equal(end, 100);
+  assert.equal(driveYardsFromSpots("Home", 25, end), 75);
+});
+
+test("away touchdown ignores a recorded post-score 25-yard spot", () => {
+  const end = driveEndYard("Away", "Touchdown", 75);
+  assert.equal(end, 0);
+  assert.equal(driveYardsFromSpots("Away", 75, end), 75);
+});
+
+test("non-touchdown drives retain their recorded ending spot", () => {
+  assert.equal(driveEndYard("Home", "Punt", 62), 62);
+});

--- a/apps/web/src/components/league/driveSummary.ts
+++ b/apps/web/src/components/league/driveSummary.ts
@@ -1,0 +1,22 @@
+export const driveYardsFromSpots = (
+  possession: string,
+  start: number,
+  end: number,
+) => possession === "Home" ? end - start : start - end;
+
+/**
+ * Returns the final field coordinate for a drive. Touchdowns always finish at
+ * the goal line, even when older play records contain the post-score kickoff
+ * spot as their NewBallOn value.
+ */
+export function driveEndYard(
+  possession: string,
+  result: string,
+  recordedEnd: number,
+) {
+  if (result.trim().toLowerCase() === "touchdown") {
+    return possession === "Home" ? 100 : 0;
+  }
+
+  return recordedEnd;
+}


### PR DESCRIPTION
### Motivation
- Drive summaries were incorrectly using post-score kickoff spots (e.g. 25) as the recorded end of scoring drives, causing drive yard totals to be underreported for touchdowns.

### Description
- Add `apps/web/src/components/league/driveSummary.ts` with `driveEndYard` and `driveYardsFromSpots` helpers to ensure touchdowns resolve to the goal line and to centralize yard arithmetic.
- Update `apps/web/src/components/league/GameCenter.tsx` to use `driveEndYard` and `driveYardsFromSpots` when computing drive end spots and yards.
- Add regression tests in `apps/web/src/components/league/driveSummary.test.cjs` that verify home and away touchdowns ignore recorded post-score 25-yard kickoff spots and a non-touchdown control case.
- Add a `test` npm script in `apps/web/package.json` to run the new regression test via `node --test`.

### Testing
- Ran `cd apps/web && npm test`, and all 3 regression tests passed (home touchdown, away touchdown, non-touchdown).
- Ran `cd apps/web && npm run build`, and TypeScript compilation plus the Vite production build completed successfully.
- Ran `cd apps/web && npm run lint`, which completed with no errors and one existing React Hooks warning in `GameField.tsx` (unchanged by this patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80d18d03f48324b5795e9051abe881)