### PR TITLE
Update box score presentation: logos, team totals and restyle

### DIFF
--- a/apps/web/src/components/league/GameCenter.tsx
+++ b/apps/web/src/components/league/GameCenter.tsx
@@ -755,16 +755,21 @@ function parseTimeSeconds(v: unknown) {
  */
 function TeamTable({
   title,
+  logo,
   columns,
   rows,
 }: {
   title: string;
+  logo?: unknown;
   columns: string[];
   rows: (string | number)[][];
 }) {
   return (
     <div className="stats-group">
-      <div className="stats-title">{title}</div>
+      <div className="stats-title">
+        <TeamLogo src={logo} className="stats-title-logo" />
+        <span>{title}</span>
+      </div>
       <table className="stats-table">
         <thead>
           <tr>
@@ -808,10 +813,20 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
   const [subtab, setSubtab] = useState<"Home" | "Overview" | "Away">("Home");
   const stats = useMemo(() => calcStats(history), [history]);
   const passRows = (team: string, condensed = false) =>
-    stats.pass
+    (() => {
+      const rows = stats.pass
       .filter((p) => p.team === team)
-      .sort((a, b) => b.yards - a.yards)
-      .map((p) =>
+      .sort((a, b) => b.yards - a.yards);
+      const total = rows.reduce((sum, player) => ({
+        completions: sum.completions + (player.completions || 0),
+        attempts: sum.attempts + (player.attempts || 0),
+        yards: sum.yards + player.yards,
+        tds: sum.tds + (player.tds || 0),
+        ints: sum.ints + (player.ints || 0),
+        sacks: sum.sacks + (player.sacks || 0),
+        sackYds: sum.sackYds + (player.sackYds || 0),
+      }), { completions: 0, attempts: 0, yards: 0, tds: 0, ints: 0, sacks: 0, sackYds: 0 });
+      const output: (string | number)[][] = rows.map((p) =>
         condensed
           ? [
               p.playername,
@@ -832,6 +847,11 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
               "0.0",
             ],
       );
+      if (rows.length) output.push(condensed
+        ? ["TEAM", `${total.completions}/${total.attempts}`, total.yards, total.tds, total.ints, `${total.sacks}-${Math.abs(total.sackYds)}`]
+        : ["TEAM", `${total.completions}/${total.attempts}`, total.yards, avg(total.yards, total.completions), total.tds, total.ints, `${total.sacks}-${Math.abs(total.sackYds)}`, "0.0"]);
+      return output;
+    })();
   const rushRows = (team: string, condensed = false) => {
     const rows = stats.rush
       .filter((p) => p.team === team)
@@ -932,15 +952,15 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
       );
     return out;
   };
-  const defRows = (team: string) =>
-    stats.def
+  const defRows = (team: string) => {
+    const rows = stats.def
       .filter((p) => p.team === team)
       .sort(
         (a, b) =>
           (b.tackles || 0) - (a.tackles || 0) ||
           (b.dLineWins || 0) - (a.dLineWins || 0),
       )
-      .map((p) => [
+    const output: (string | number)[][] = rows.map((p) => [
         p.playername,
         p.tackles || 0,
         p.tfl || 0,
@@ -950,8 +970,11 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
         p.sacks || 0,
         p.fr || 0,
         p.ints || 0,
-        p.deflections || 0,
-      ]);
+      p.deflections || 0,
+    ]);
+    if (rows.length) output.push(["TEAM", ...(["tackles", "tfl", "ff", "dLineWins", "dLineLosses", "sacks", "fr", "ints", "deflections"] as const).map((field) => rows.reduce((sum, player) => sum + (player[field] || 0), 0))]);
+    return output;
+  };
   const offballRows = (team: string) => {
     const rows = stats.offball
       .filter((p) => p.team === team)
@@ -983,15 +1006,18 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
     return output;
   };
   const teamName = (t: string) => (t === "Home" ? game.Home : game.Away);
+  const teamLogo = (t: string) => (t === "Home" ? game.HomeLogo : game.AwayLogo);
   const renderTeam = (team: string) => (
     <>
       <TeamTable
         title={`${teamName(team)} Passing`}
+        logo={teamLogo(team)}
         columns={["Player", "C/ATT", "YDS", "AVG", "TD", "INT", "SACKS", "RTG"]}
         rows={passRows(team)}
       />
       <TeamTable
         title={`${teamName(team)} Rushing`}
+        logo={teamLogo(team)}
         columns={[
           "Player",
           "CAR",
@@ -1007,11 +1033,13 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
       />
       <TeamTable
         title={`${teamName(team)} Receiving`}
+        logo={teamLogo(team)}
         columns={["Player", "REC", "YDS", "AVG", "TD", "LONG", "TGTS"]}
         rows={recRows(team)}
       />
       <TeamTable
         title={`${teamName(team)} Defensive`}
+        logo={teamLogo(team)}
         columns={[
           "Player",
           "TKL",
@@ -1028,6 +1056,7 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
       />
       <TeamTable
         title={`${teamName(team)} Offensive Line`}
+        logo={teamLogo(team)}
         columns={["Player", "OL W", "OL L", "LEAD", "WIN %"]}
         rows={offballRows(team)}
       />
@@ -1043,7 +1072,8 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
             type="button"
             onClick={() => setSubtab(t)}
           >
-            {t === "Home" ? game.Home : t === "Away" ? game.Away : t}
+            {t !== "Overview" && <TeamLogo src={teamLogo(t)} className="boxscore-pill-logo" />}
+            <span>{t === "Home" ? game.Home : t === "Away" ? game.Away : t}</span>
           </button>
         ))}
       </div>
@@ -1058,6 +1088,7 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
                   {kind === "Passing" && (
                     <TeamTable
                       title={`${teamName(team)} Passing`}
+                      logo={teamLogo(team)}
                       columns={["Player", "C/ATT", "YDS", "TD", "INT", "SACKS"]}
                       rows={passRows(team, true)}
                     />
@@ -1065,6 +1096,7 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
                   {kind === "Rushing" && (
                     <TeamTable
                       title={`${teamName(team)} Rushing`}
+                      logo={teamLogo(team)}
                       columns={["Player", "CAR", "YDS", "TD", "LONG"]}
                       rows={rushRows(team, true)}
                     />
@@ -1072,6 +1104,7 @@ function BoxScoreTab({ game, history }: { game: LeagueGame; history: Play[] }) {
                   {kind === "Receiving" && (
                     <TeamTable
                       title={`${teamName(team)} Receiving`}
+                      logo={teamLogo(team)}
                       columns={["Player", "REC", "YDS", "TD", "LONG"]}
                       rows={recRows(team, true)}
                     />

--- a/apps/web/src/components/league/league.css
+++ b/apps/web/src/components/league/league.css
@@ -1688,66 +1688,83 @@
 
 /* Box score and team stats tabs ported from the Apps Script game view */
 .boxscore-card {
+  box-sizing: border-box;
   width: min(100%, 1500px);
-  margin: 5vw auto;
-  padding: clamp(16px, 3vw, 40px);
-  background: var(--gray-medium);
-  border-radius: 8px;
-  box-shadow: 0 0 12px #0006;
+  margin: clamp(16px, 2vw, 28px) auto;
+  padding: clamp(14px, 1.5vw, 22px);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 4px 16px var(--shadow-color);
   overflow-x: auto;
 }
 .boxscore-pill-container {
   display: flex;
-  background: var(--gray-light);
-  border-radius: 20px;
-  padding: clamp(4px, 1vw, 12px);
-  gap: clamp(4px, 1vw, 12px);
-  margin-bottom: clamp(18px, 4vw, 56px);
+  background: var(--surface-subtle);
+  border-radius: 999px;
+  padding: 0;
+  margin-bottom: 24px;
 }
 .boxscore-pill {
   flex: 1;
-  padding: clamp(10px, 2vw, 24px) clamp(12px, 3vw, 36px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 8px 14px;
   background: transparent;
   border: none;
   cursor: pointer;
   font-weight: 700;
-  border-radius: 16px;
-  color: var(--text-light);
-  font-size: clamp(13px, 2vw, 24px);
+  border-radius: 999px;
+  color: var(--text-primary);
+  font-size: .85rem;
 }
 .boxscore-pill.active {
-  background: var(--accent-red);
-  color: var(--gray-dark);
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: 0 2px 9px var(--shadow-color);
 }
+.boxscore-pill:focus-visible { outline: 3px solid color-mix(in srgb, var(--control-accent) 35%, transparent); outline-offset: 1px; }
+.boxscore-pill-logo { width: 20px; height: 20px; object-fit: contain; }
 .stats-group {
-  margin-bottom: clamp(24px, 5vw, 72px);
+  margin-bottom: 18px;
 }
 .stats-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
   font-weight: 700;
-  margin: clamp(12px, 2vw, 28px) 0;
-  font-size: clamp(16px, 2.5vw, 28px);
+  margin: 0;
+  padding: 9px 2px 7px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: .9rem;
 }
+.stats-title-logo { width: 20px; height: 20px; object-fit: contain; }
 .stats-table {
   width: 100%;
   border-collapse: collapse;
 }
 .stats-table th,
 .stats-table td {
-  padding: clamp(8px, 1.5vw, 20px);
-  text-align: center;
-  font-size: clamp(12px, 1.8vw, 20px);
+  padding: 7px 8px;
+  text-align: right;
+  font-size: .78rem;
+  white-space: nowrap;
 }
+.stats-table th:first-child,
+.stats-table td:first-child { text-align: left; border-right: 1px solid var(--border-color); }
 .stats-table th {
-  background: var(--gray-light);
-  border-bottom: 2px solid var(--accent-red);
-  color: var(--text-light);
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-weight: 500;
 }
-.stats-table tr:nth-child(even) {
-  background: var(--gray-dark);
-}
-.stats-table tr:nth-child(odd) {
-  background: var(--gray-medium);
-}
+.stats-table tbody tr { border-bottom: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent); }
+.stats-table tbody tr:nth-child(even) { background: var(--surface-subtle); }
+.stats-table tbody tr:nth-child(odd) { background: var(--surface-raised); }
 .stats-table .team-row td {
   font-weight: 700;
 }
@@ -1757,12 +1774,12 @@
 }
 .overview-section {
   display: grid;
-  gap: clamp(18px, 4vw, 56px);
+  gap: 4px;
 }
 .stats-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(16px, 3vw, 48px);
+  gap: 26px;
 }
 .team-table {
   min-width: 0;
@@ -1811,6 +1828,8 @@
   .team-stats-card {
     margin-inline: 0;
   }
+  .boxscore-pill { padding-inline: 8px; }
+  .boxscore-pill-logo { display: none; }
 }
 
 .play-caller {


### PR DESCRIPTION
### Motivation

- Refresh the box score UI to match the compact reference layout while preserving existing columns and sections. 
- Surface team identity (logos) in the pill tabs and each stat section and add team aggregate rows for clearer totals.

### Description

- Restyled the box score container, pill navigation, and tables to use the app's semantic design tokens and a compact card layout by updating `apps/web/src/components/league/league.css`.
- Added team logos into the box score pill tabs and each `TeamTable` heading via the existing `TeamLogo` component and a `logo` prop on `TeamTable` in `apps/web/src/components/league/GameCenter.tsx`.
- Added aggregate `TEAM` rows to passing and defensive tables (and preserved existing rushing/receiving totals) by computing totals in the per-section row builders (`passRows`, `defRows`) and appending a highlighted team row.
- Kept all existing columns, condensed/full views, overview layout, and the shared `TeamTable` renderer while making table rows alternate and improving spacing and focus states.

### Testing

- Ran `npm run build` and production bundle succeeded (build completed; a non-blocking large-chunk warning was reported). 
- Ran `npm run lint` which completed successfully with a single pre-existing `react-hooks/exhaustive-deps` warning in `GameField.tsx` and no errors.
- Ran `npm test` and unit tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a80d39eb1f08324950fd41ef4ae969e)