### PR TITLE
Populate team statistics from PlayHistory and show full stat tables on Team page

### DIFF
--- a/apps/api/src/routes/gameRoutes.ts
+++ b/apps/api/src/routes/gameRoutes.ts
@@ -5,6 +5,7 @@ import {
   readSheetObjects,
   readSheetValues,
 } from "../services/sheets.js";
+import { aggregatePlayStats } from "../services/playStats.js";
 
 export const gameRoutes = Router();
 
@@ -135,11 +136,12 @@ async function getPlayersWithTeamJerseys() {
   }));
 }
 async function getTeamPlayers(teamAbbrev: string) {
-  const [assignments, players, playerStats, jerseys] = await Promise.all([
+  const [assignments, players, playerStats, jerseys, playHistory] = await Promise.all([
     readSheetObjects("PlayerTeams!A1:B"),
     readSheetObjects("Players!A1:AM"),
     readSheetObjects("PlayerStats!A1:AJ"),
     getTeamJerseys("Away Jersey Crop"),
+    sheetRows("PlayHistory"),
   ]);
   const teamKey = teamAbbrev.trim().toLowerCase();
   const rosterNames = new Set(
@@ -156,12 +158,13 @@ async function getTeamPlayers(teamAbbrev: string) {
     const name = String(stats.Player ?? stats.Name ?? "").trim().toLowerCase();
     if (name && rosterNames.has(name)) statsByName.set(name, stats);
   });
+  const historyStats = aggregatePlayStats(playHistory.rows.map((row) => objectFrom(playHistory.headers, row)));
 
   return [...rosterNames].map((name) => ({
     ...(playersByName.get(name) ?? { Name: assignments.find((row) => String(row.Name).trim().toLowerCase() === name)?.Name ?? name }),
     Team: teamAbbrev,
     Jersey: jerseys.get(teamKey) ?? "",
-    Stats: statsByName.get(name) ?? null,
+    Stats: { ...(statsByName.get(name) ?? {}), ...(historyStats.get(name) ?? {}) },
   }));
 }
 function normalizeSettingLabel(label: unknown) {

--- a/apps/api/src/services/playStats.test.ts
+++ b/apps/api/src/services/playStats.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { aggregatePlayStats } from "./playStats.js";
+
+test("aggregates every team-page stat family from play history", () => {
+  const stats = aggregatePlayStats([
+    { gameid: "1", playtype: "Pass", player: "Quarterback", receiver: "Receiver", yards: 24, airyards: 15, result: "Touchdown", newdown: 1, tackler: "Corner" },
+    { gameid: "1", playtype: "Pass", player: "Quarterback", receiver: "Receiver", yards: 0, result: "Incomplete" },
+    { gameid: "2", playtype: "Pass", player: "Quarterback", receiver: "Receiver", yards: 0, result: "Interception", recoveredby: "Corner" },
+    { gameid: "2", playtype: "Pass", player: "Quarterback", yards: -7, result: "Sack", tackler: "Edge" },
+    { gameid: "2", playtype: "Run", player: "Runner", yards: 12, result: "Fumble", newdown: 1, tackler: "Edge", recoveredby: "Corner", brokenTackles: 1, jukes: 2 },
+  ]);
+
+  assert.deepEqual(
+    Object.fromEntries(["Completions", "Passing Attempts", "Passing Yards", "Passing TD", "Interceptions Thrown", "Sacked", "Sack Yards Lost", "GP"].map((field) => [field, stats.get("quarterback")?.[field]])),
+    { Completions: 1, "Passing Attempts": 3, "Passing Yards": 24, "Passing TD": 1, "Interceptions Thrown": 1, Sacked: 1, "Sack Yards Lost": 7, GP: 2 },
+  );
+  assert.equal(stats.get("receiver")?.Targets, 3);
+  assert.equal(stats.get("receiver")?.["Yards After Catch"], 9);
+  assert.equal(stats.get("runner")?.Carries, 1);
+  assert.equal(stats.get("runner")?.["Rushing Fumbles Lost"], 1);
+  assert.equal(stats.get("edge")?.Tackles, 2);
+  assert.equal(stats.get("edge")?.Sacks, 1);
+  assert.equal(stats.get("corner")?.Interceptions, 1);
+  assert.equal(stats.get("corner")?.["Fumble Recoveries"], 1);
+});

--- a/apps/api/src/services/playStats.ts
+++ b/apps/api/src/services/playStats.ts
@@ -1,0 +1,113 @@
+export type PlayRow = Record<string, unknown>;
+
+const normalize = (value: unknown) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]/g, "");
+const number = (value: unknown) => Number(String(value ?? 0).replace(/,/g, "")) || 0;
+const text = (play: PlayRow, ...fields: string[]) => {
+  const wanted = new Set(fields.map(normalize));
+  const entry = Object.entries(play).find(([field]) => wanted.has(normalize(field)));
+  return String(entry?.[1] ?? "").trim();
+};
+
+type Totals = { games: Set<string>; [field: string]: number | Set<string> };
+
+/** Builds the season totals used by team pages directly from PlayHistory. */
+export function aggregatePlayStats(plays: PlayRow[]) {
+  const players = new Map<string, Totals>();
+  const get = (name: string) => {
+    const playerKey = normalize(name);
+    if (!players.has(playerKey)) players.set(playerKey, { games: new Set<string>() });
+    const totals = players.get(playerKey)!;
+    const game = text(currentPlay, "gameid", "game id");
+    if (game) totals.games.add(game);
+    return totals;
+  };
+  const value = (stats: Totals, field: string) => Number(stats[field]) || 0;
+  const add = (stats: Totals, field: string, amount = 1) => { stats[field] = value(stats, field) + amount; };
+  let currentPlay: PlayRow = {};
+
+  plays.forEach((play) => {
+    currentPlay = play;
+    const type = text(play, "playtype", "play type").toLowerCase();
+    const result = text(play, "result", "resultcategory").toLowerCase();
+    const description = text(play, "description").toLowerCase();
+    const defenseResult = text(play, "defenseresult", "defense result").toLowerCase();
+    const yards = number(text(play, "yards", "yards gained"));
+    const airYards = number(text(play, "airyards", "air yards"));
+    const actor = text(play, "player", "passer", "rusher");
+    const receiver = text(play, "receiver", "target");
+    const tackler = text(play, "tackler");
+    const recoveredBy = text(play, "recoveredby", "recovered by");
+    const isTouchdown = /touchdown|\btd\b/.test(`${result} ${description}`);
+    const isFumble = /fumble/.test(`${result} ${description} ${defenseResult}`);
+    const isSack = /sack/.test(`${result} ${description} ${defenseResult}`);
+    const isInterception = /interception/.test(`${result} ${description} ${defenseResult}`);
+    const isIncomplete = /incomplete|incompletion/.test(`${result} ${description}`);
+    const firstDown = number(text(play, "newdown", "new down")) === 1 || /first down/.test(description);
+
+    if (/run|rush/.test(type) && actor) {
+      const stats = get(actor);
+      add(stats, "Carries"); add(stats, "Rushing Yards", yards);
+      stats["Rushing Long"] = Math.max(value(stats, "Rushing Long"), yards);
+      if (isTouchdown) add(stats, "Rushing TD");
+      if (isFumble) { add(stats, "Rushing Fumbles"); if (normalize(recoveredBy) !== normalize(actor)) add(stats, "Rushing Fumbles Lost"); }
+      if (firstDown) add(stats, "Rushing First Downs");
+      if (yards < 0) add(stats, "Rush Loss");
+      [5, 10, 20, 30, 50].forEach((mark) => { if (yards >= mark) add(stats, `Rush ${mark}+`); });
+      add(stats, "Broken Tackles", number(text(play, "brokentackles", "broken tackles", "trucks")));
+      add(stats, "Jukes", number(text(play, "jukes")));
+    }
+
+    if ((/pass/.test(type) || isSack) && actor) {
+      const stats = get(actor);
+      if (isSack) { add(stats, "Sacked"); add(stats, "Sack Yards Lost", Math.abs(yards)); }
+      else {
+        add(stats, "Passing Attempts");
+        if (!isIncomplete && !isInterception) {
+          add(stats, "Completions"); add(stats, "Passing Yards", yards);
+          stats["Passing Long"] = Math.max(value(stats, "Passing Long"), yards);
+          if (isTouchdown) add(stats, "Passing TD");
+        }
+        if (isInterception) add(stats, "Interceptions Thrown");
+      }
+    }
+
+    if (/pass/.test(type) && receiver && !isSack) {
+      const stats = get(receiver);
+      add(stats, "Targets");
+      if (!isIncomplete && !isInterception) {
+        add(stats, "Receptions"); add(stats, "Receiving Yards", yards);
+        stats["Receiving Long"] = Math.max(value(stats, "Receiving Long"), yards);
+        if (yards >= 20) add(stats, "Big Receptions");
+        if (isTouchdown) add(stats, "Receiving TD");
+        if (firstDown) add(stats, "Receiving First Downs");
+        add(stats, "Yards After Catch", Math.max(0, yards - airYards));
+      }
+      if (isFumble) { add(stats, "Receiving Fumbles"); if (normalize(recoveredBy) !== normalize(receiver)) add(stats, "Receiving Fumbles Lost"); }
+    }
+
+    if (tackler && normalize(tackler) !== "na") {
+      const stats = get(tackler);
+      add(stats, "Tackles"); add(stats, "Solo Tackles");
+      if (yards < 0 || isSack || /tfl|tackle for loss/.test(defenseResult)) add(stats, "TFL");
+      if (isSack) { add(stats, "Sacks"); add(stats, "Sack Yards", Math.abs(yards)); }
+      if (isFumble) add(stats, "Forced Fumbles");
+    }
+    if (recoveredBy && isFumble) add(get(recoveredBy), "Fumble Recoveries");
+    if ((recoveredBy || tackler) && isInterception) add(get(recoveredBy || tackler), "Interceptions");
+  });
+
+  return new Map<string, Record<string, number>>([...players].map(([name, totals]) => {
+    const numericTotals = Object.fromEntries(Object.entries(totals).filter(([field]) => field !== "games")) as Record<string, number>;
+    return [name, {
+    ...numericTotals,
+    GP: totals.games.size,
+    "Completion Percentage": value(totals, "Passing Attempts") ? value(totals, "Completions") / value(totals, "Passing Attempts") * 100 : 0,
+    "Passing Average": value(totals, "Passing Attempts") ? value(totals, "Passing Yards") / value(totals, "Passing Attempts") : 0,
+    "Rushing Average": value(totals, "Carries") ? value(totals, "Rushing Yards") / value(totals, "Carries") : 0,
+    "Receiving Average": value(totals, "Receptions") ? value(totals, "Receiving Yards") / value(totals, "Receptions") : 0,
+    "Passing Yards Per Game": totals.games.size ? value(totals, "Passing Yards") / totals.games.size : 0,
+    "Rushing Yards Per Game": totals.games.size ? value(totals, "Rushing Yards") / totals.games.size : 0,
+    "Receiving Yards Per Game": totals.games.size ? value(totals, "Receiving Yards") / totals.games.size : 0,
+  }];
+  }));
+}

--- a/apps/web/src/components/league/TeamDetail.tsx
+++ b/apps/web/src/components/league/TeamDetail.tsx
@@ -27,29 +27,35 @@ const statGroups: StatGroup[] = [
     { label: "YDS", fields: ["passingyards", "passyards", "passyds"] }, { label: "AVG", fields: ["yardsperpass", "passaverage", "passavg"], decimal: true },
     { label: "YDS/G", fields: ["passingyardspergame", "passyardspergame", "passydsg"], decimal: true }, { label: "LNG", fields: ["longestpass", "passlong", "lng"] },
     { label: "TD", fields: ["passingtouchdowns", "passtds", "passtd"] }, { label: "INT", fields: ["interceptionsthrown", "passinterceptions", "passint"] },
-    { label: "SACK", fields: ["sackstaken", "passsacks"] }, { label: "RTG", fields: ["passerrating", "rating", "rtg"], decimal: true },
+    { label: "SACK", fields: ["sacked", "sackstaken", "passsacks"] }, { label: "SYL", fields: ["sackyardslost", "syl"] },
+    { label: "QBR", fields: ["qbr"], decimal: true }, { label: "RTG", fields: ["passerrating", "rating", "rtg"], decimal: true },
   ]},
   { title: "Rushing", positions: ["qb", "rb", "wr", "te"], defaultSort: "YDS", columns: [
-    { label: "GP", fields: ["games", "gp"] }, { label: "CAR", fields: ["carries", "rushingattempts", "rushattempts", "rushatt"] },
+    { label: "GP", fields: ["games", "gp"] }, { label: "ATT", fields: ["carries", "rushingattempts", "rushattempts", "rushatt"] },
     { label: "YDS", fields: ["yards", "rushingyards", "rushyards", "rushyds"] }, { label: "AVG", fields: ["rushingaverage", "rushaverage", "rushavg", "yardspercarry"], decimal: true },
-    { label: "LNG", fields: ["longestrush", "rushlong"] }, { label: "TD", fields: ["rushingtouchdowns", "rushtds", "rushtd"] },
+    { label: "LNG", fields: ["longestrush", "rushinglong", "rushlong"] }, { label: "BIG", fields: ["bigrushes", "rushbig"] }, { label: "TD", fields: ["rushingtouchdowns", "rushingtd", "rushtds", "rushtd"] },
     { label: "YDS/G", fields: ["rushingyardspergame", "rushyardspergame", "rushydsg"], decimal: true }, { label: "FUM", fields: ["fumbles", "fum"] },
-    { label: "FD", fields: ["rushingfirstdowns", "rushfirstdowns", "rushfd"] },
+    { label: "LST", fields: ["rushingfumbleslost", "fumbleslost", "fumlost"] }, { label: "FD", fields: ["rushingfirstdowns", "rushfirstdowns", "rushfd"] },
+    { label: "LOSS", fields: ["rushloss", "loss"] }, { label: "5+", fields: ["rush5+", "5+"] }, { label: "10+", fields: ["rush10+", "10+"] },
+    { label: "20+", fields: ["rush20+", "20+"] }, { label: "30+", fields: ["rush30+", "30+"] }, { label: "50+", fields: ["rush50+", "50+"] },
+    { label: "BRK TKL", fields: ["brokentackles", "brokentackle"] }, { label: "JKE", fields: ["jukes", "juke"] },
   ]},
   { title: "Receiving", positions: ["rb", "wr", "te"], defaultSort: "YDS", columns: [
     { label: "GP", fields: ["games", "gp"] }, { label: "REC", fields: ["receptions", "rec"] }, { label: "TGTS", fields: ["targets", "tgts", "tgt"] },
     { label: "YDS", fields: ["receivingyards", "recyards", "recyds"] }, { label: "AVG", fields: ["receivingaverage", "recaverage", "recavg", "yardsperreception"], decimal: true },
-    { label: "TD", fields: ["receivingtouchdowns", "rectds", "rectd"] }, { label: "LNG", fields: ["longestreception", "receivinglong", "reclong"] },
-    { label: "YDS/G", fields: ["receivingyardspergame", "recyardspergame", "recydsg"], decimal: true }, { label: "YAC", fields: ["yardsaftercatch", "yac"] },
+    { label: "TD", fields: ["receivingtouchdowns", "receivingtd", "rectds", "rectd"] }, { label: "LNG", fields: ["longestreception", "receivinglong", "reclong"] },
+    { label: "BIG", fields: ["bigreceptions", "big"] }, { label: "YDS/G", fields: ["receivingyardspergame", "recyardspergame", "recydsg"], decimal: true },
+    { label: "FUM", fields: ["receivingfumbles", "fumbles", "fum"] }, { label: "LST", fields: ["receivingfumbleslost", "fumbleslost", "fumlost"] }, { label: "YAC", fields: ["yardsaftercatch", "yac"] },
     { label: "FD", fields: ["receivingfirstdowns", "recfirstdowns", "recfd"] },
   ]},
   { title: "Defense", positions: ["dl", "dt", "de", "lb", "cb", "s", "db"], defaultSort: "TOT", columns: [
-    { label: "GP", fields: ["games", "gp"] }, { label: "SOLO", fields: ["solotackles", "solo"] }, { label: "AST", fields: ["assistedtackles", "assists", "ast"] },
-    { label: "TOT", fields: ["totaltackles", "tackles", "total", "tot"] }, { label: "SACK", fields: ["sacks", "sack"], decimal: true },
-    { label: "TFL", fields: ["tacklesforloss", "tfl"] }, { label: "PD", fields: ["passesdefended", "passdeflections", "pd"] },
-    { label: "INT", fields: ["interceptions", "defensiveinterceptions", "int"] }, { label: "YDS", fields: ["interceptionyards", "intyards", "intyds"] },
-    { label: "TD", fields: ["defensivetouchdowns", "inttouchdowns", "deftd"] }, { label: "FF", fields: ["forcedfumbles", "ff"] },
-    { label: "FR", fields: ["fumblerecoveries", "fr"] },
+    { label: "GP", fields: ["games", "gp"] }, { label: "TKL", fields: ["totaltackles", "tackles", "total", "tot", "tkl"] },
+    { label: "SACK", fields: ["sacks", "sack"] }, { label: "YDS", fields: ["sackyards", "sackyardslost", "syl"] },
+    { label: "TFL", fields: ["tacklesforloss", "tfl"] }, { label: "DEFL", fields: ["passesdefended", "passdeflections", "deflections", "defl"] },
+    { label: "INT", fields: ["interceptions", "defensiveinterceptions", "int"] }, { label: "YDS (INT)", fields: ["interceptionreturnyards", "intreturnyards", "intyds"] },
+    { label: "TD (INT)", fields: ["interceptionreturntd", "intreturntd", "inttd"] }, { label: "FF", fields: ["forcedfumbles", "ff"] },
+    { label: "FR", fields: ["fumblerecoveries", "fr"] }, { label: "FTD", fields: ["fumblereturntd", "fumtd", "ftd"] },
+    { label: "DL PLAYS", fields: ["dlplays"] }, { label: "WIN%", fields: ["dlwinpercentage", "dlwinpct"], decimal: true },
   ]},
 ];
 
@@ -59,14 +65,31 @@ function formatStat(value: number, decimal = false) {
 
 function SortableStatTable({ group, players }: { group: StatGroup; players: TeamPlayer[] }) {
   const [sort, setSort] = useState({ column: group.defaultSort, direction: "desc" as "asc" | "desc" });
-  const rows = useMemo(() => players.filter((player) => group.positions.includes(key(player.Pos ?? player.DefPos))).sort((a, b) => {
+  const rows = useMemo(() => players.filter((player) => group.positions.includes(key(group.title === "Defense" ? player.DefPos : player.Pos))).sort((a, b) => {
     const column = group.columns.find((item) => item.label === sort.column)!;
     const difference = numericStat(b.Stats, column.fields) - numericStat(a.Stats, column.fields);
     return (sort.direction === "desc" ? difference : -difference) || String(a.Name).localeCompare(String(b.Name));
   }), [group, players, sort]);
   const changeSort = (column: string) => setSort((current) => ({ column, direction: current.column === column && current.direction === "desc" ? "asc" : "desc" }));
 
-  return <section className="team-stat-group"><h3>{group.title}</h3><div className="team-stat-scroll"><table><thead><tr><th>NAME</th>{group.columns.map((column) => <th className={sort.column === column.label ? "sorted" : ""} key={column.label}><button type="button" onClick={() => changeSort(column.label)}>{column.label}<span aria-hidden="true">{sort.column === column.label ? (sort.direction === "desc" ? "▾" : "▴") : ""}</span></button></th>)}</tr></thead><tbody>{rows.map((player) => <tr key={String(player.Name)}><td><a>{player.Name}</a> <small>{player.Pos || player.DefPos}</small></td>{group.columns.map((column) => <td className={sort.column === column.label ? "sorted" : ""} key={column.label}>{formatStat(numericStat(player.Stats, column.fields), column.decimal)}</td>)}</tr>)}</tbody></table></div>{rows.length === 0 && <p className="team-stats-empty">No {group.title.toLowerCase()} players on the active roster.</p>}</section>;
+  const sumFields = (fields: string[]) => rows.reduce((sum, player) => sum + numericStat(player.Stats, fields), 0);
+  const games = Math.max(0, ...rows.map((player) => numericStat(player.Stats, ["games", "gp"])));
+  const total = (column: StatColumn) => {
+    if (column.label === "GP") return games;
+    if (column.label === "LNG") return Math.max(0, ...rows.map((player) => numericStat(player.Stats, column.fields)));
+    if (column.label === "CMP%") { const attempts = sumFields(["passattempts", "passingattempts", "att"]); return attempts ? sumFields(["completions", "cmp", "passcompletions"]) / attempts * 100 : 0; }
+    if (column.label === "AVG") {
+      const attempts = sumFields(group.title === "Passing" ? ["passattempts", "passingattempts", "att"] : group.title === "Rushing" ? ["carries", "rushingattempts", "rushattempts"] : ["receptions", "rec"]);
+      const yards = sumFields(group.title === "Passing" ? ["passingyards", "passyards"] : group.title === "Rushing" ? ["yards", "rushingyards", "rushyards"] : ["receivingyards", "recyards"]);
+      return attempts ? yards / attempts : 0;
+    }
+    if (column.label === "YDS/G") {
+      const yards = sumFields(group.title === "Passing" ? ["passingyards", "passyards"] : group.title === "Rushing" ? ["yards", "rushingyards", "rushyards"] : ["receivingyards", "recyards"]);
+      return games ? yards / games : 0;
+    }
+    return sumFields(column.fields);
+  };
+  return <section className="team-stat-group"><h3>{group.title}</h3><div className="team-stat-scroll"><table><thead><tr><th>NAME</th>{group.columns.map((column) => <th className={sort.column === column.label ? "sorted" : ""} key={column.label}><button type="button" onClick={() => changeSort(column.label)}>{column.label}<span aria-hidden="true">{sort.column === column.label ? (sort.direction === "desc" ? "▾" : "▴") : ""}</span></button></th>)}</tr></thead><tbody>{rows.map((player) => <tr key={String(player.Name)}><td><a>{player.Name}</a> <small>{group.title === "Defense" ? player.DefPos : player.Pos}</small></td>{group.columns.map((column) => <td className={sort.column === column.label ? "sorted" : ""} key={column.label}>{formatStat(numericStat(player.Stats, column.fields), column.decimal)}</td>)}</tr>)}{rows.length > 0 && <tr className="team-stat-total"><td><strong>Total</strong></td>{group.columns.map((column) => <td key={column.label}><strong>{formatStat(total(column), column.decimal)}</strong></td>)}</tr>}</tbody></table></div>{rows.length === 0 && <p className="team-stats-empty">No {group.title.toLowerCase()} players on the active roster.</p>}</section>;
 }
 function stars(player: TeamPlayer, side: "off" | "def") {
   return Number(player[side === "off" ? "Off Stars" : "Def Stars"]) || 0;


### PR DESCRIPTION
### Motivation

- The Team page stats tab was only showing a subset of stats (e.g. rushing carries and yards) and omitted defensive stats and many player stat columns; the goal is to derive complete season totals from `PlayHistory` and display the same stat columns as the main Player stats view.

### Description

- Add an aggregation service `aggregatePlayStats` in `apps/api/src/services/playStats.ts` that scans `PlayHistory` rows and builds per-player totals for passing, rushing, receiving, defensive stats, fumbles/recoveries, long plays, per-game averages, completion percentage, and other derived fields. 
- Merge play-derived totals into the team roster API by reading `PlayHistory` in `getTeamPlayers` and combining `PlayerStats` sheet values with `aggregatePlayStats` output (`apps/api/src/routes/gameRoutes.ts`).
- Expand Team page stat groups in `apps/web/src/components/league/TeamDetail.tsx` so `Passing`, `Rushing`, `Receiving`, and `Defense` include the same columns as the main Player stats tabs (many additional fields added, defensive players shown, renamed/added columns such as `ATT`, `SYL`, `BIG`, `YDS/G`, `LST`, `BRK TKL`, etc.).
- Update the shared `SortableStatTable` to: include defensive roster filtering, compute and render a team `Total` row, and calculate aggregate metrics (GP, CMP%, AVG, YDS/G, longest-play handling) from player stats.
- Add a unit test `apps/api/src/services/playStats.test.ts` that exercises representative `PlayHistory` rows and asserts aggregation covers offensive, defensive, turnover, sacks, and recovery outcomes.
- Maintained UI theming constraints (no fixed light/dark colors added) and did not alter app token usage for new/changed UI elements.

### Testing

- Ran the API unit tests: `cd apps/api && npm test` and the suite passed (4 tests, all ok). 
- Ran TypeScript checks for the API: `cd apps/api && npm run typecheck` and it completed successfully.
- Built the web app: `cd apps/web && npm run build` and the Vite build succeeded.
- Linted the web app: `cd apps/web && npm run lint` which completed; one pre-existing React Hooks warning in `GameField.tsx` remains unchanged.
- Verified no `git diff --check` issues and committed changes as `Populate team stats from play history`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8246aa519c8324870a46d395a69f1e)